### PR TITLE
Feature/PYPE-733 intent store label value

### DIFF
--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -127,7 +127,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
             # Add custom attributes for AssetVersion
             assetversion_cust_attrs = {}
-            intent_val = instance.context.data.get("intent")
+            intent_val = instance.context.data.get("intent", {}).get("value")
             if intent_val:
                 assetversion_cust_attrs["intent"] = intent_val
 

--- a/pype/plugins/ftrack/publish/integrate_ftrack_note.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_note.py
@@ -71,18 +71,19 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         session = instance.context.data["ftrackSession"]
 
         intent_val = instance.context.data.get("intent", {}).get("value")
-        intent_label = None
+        intent_label = instance.context.data.get("intent", {}).get("label")
+        final_label = None
         if intent_val:
-            intent_label = self.get_intent_label(session, intent_val)
-            if intent_label is None:
-                intent_label = intent_val
+            final_label = self.get_intent_label(session, intent_val)
+            if final_label is None:
+                final_label = intent_label
 
         # if intent label is set then format comment
         # - it is possible that intent_label is equal to "" (empty string)
-        if intent_label:
-            msg = "Intent label is to `{}`.".format(intent_label)
+        if final_label:
+            msg = "Intent label is set to `{}`.".format(final_label)
             comment = self.note_with_intent_template.format(**{
-                "intent": intent_val,
+                "intent": final_label,
                 "comment": comment
             })
 
@@ -90,7 +91,7 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
             msg = (
                 "Intent is set to `{}` and was not added"
                 " to comment because label is set to `{}`."
-            ).format(intent_val, intent_label)
+            ).format(intent_val, final_label)
 
         else:
             msg = "Intent is not set."

--- a/pype/plugins/ftrack/publish/integrate_ftrack_note.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_note.py
@@ -40,7 +40,8 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
         if not config:
             return
 
-        items = config.get("data")
+        configuration = json.loads(config)
+        items = configuration.get("data")
         if not items:
             return
 

--- a/pype/plugins/global/publish/collect_anatomy.py
+++ b/pype/plugins/global/publish/collect_anatomy.py
@@ -6,10 +6,6 @@ Requires:
     username -> collect_pype_user *(pyblish.api.CollectorOrder + 0.001)
     datetimeData -> collect_datetime_data *(pyblish.api.CollectorOrder)
 
-Optional:
-    comment -> collect_comment *(pyblish.api.CollectorOrder)
-    intent -> collected in pyblish-lite
-
 Provides:
     context -> anatomy (pypeapp.Anatomy)
     context -> anatomyData

--- a/pype/plugins/global/publish/collect_rendered_files.py
+++ b/pype/plugins/global/publish/collect_rendered_files.py
@@ -35,7 +35,7 @@ class CollectRenderedFiles(pyblish.api.ContextPlugin):
     def _process_path(self, data):
         # validate basic necessary data
         data_err = "invalid json file - missing data"
-        required = ["asset", "user", "intent", "comment",
+        required = ["asset", "user", "comment",
                     "job", "instances", "session", "version"]
         assert all(elem in data.keys() for elem in required), data_err
 

--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -51,9 +51,12 @@ class ExtractBurnin(pype.api.Extractor):
             "frame_end": frame_end_handle,
             "duration": duration,
             "version": int(version),
-            "comment": instance.context.data.get("comment", ""),
-            "intent": instance.context.data.get("intent", {}).get("label", "")
+            "comment": instance.context.data.get("comment", "")
         })
+
+        intent = instance.context.data.get("intent", {}).get("label")
+        if intent:
+            prep_data["intent"] = intent
 
         # get anatomy project
         anatomy = instance.context.data['anatomy']

--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -52,7 +52,7 @@ class ExtractBurnin(pype.api.Extractor):
             "duration": duration,
             "version": int(version),
             "comment": instance.context.data.get("comment", ""),
-            "intent": instance.context.data.get("intent", "")
+            "intent": instance.context.data.get("intent", {}).get("label", "")
         })
 
         # get anatomy project

--- a/pype/plugins/nuke/publish/extract_slate_frame.py
+++ b/pype/plugins/nuke/publish/extract_slate_frame.py
@@ -157,7 +157,7 @@ class ExtractSlateFrame(pype.api.Extractor):
             return
 
         comment = instance.context.data.get("comment")
-        intent = instance.context.data.get("intent", {}).get("value")
+        intent = instance.context.data.get("intent", {}).get("value", "")
 
         try:
             node["f_submission_note"].setValue(comment)

--- a/pype/plugins/nuke/publish/extract_slate_frame.py
+++ b/pype/plugins/nuke/publish/extract_slate_frame.py
@@ -157,7 +157,7 @@ class ExtractSlateFrame(pype.api.Extractor):
             return
 
         comment = instance.context.data.get("comment")
-        intent = instance.context.data.get("intent")
+        intent = instance.context.data.get("intent", {}).get("value")
 
         try:
             node["f_submission_note"].setValue(comment)


### PR DESCRIPTION
- plugins expect that intent is stored as dictionary with `label` and `value`
- intent should not be required key for all plugins now
- ftrack note use label of intent from custom attribute