### PR TITLE
hotfix/master integrate fixes

### DIFF
--- a/pype/plugins/global/publish/integrate_master_version.py
+++ b/pype/plugins/global/publish/integrate_master_version.py
@@ -111,13 +111,13 @@ class IntegrateMasterVersion(pyblish.api.InstancePlugin):
 
         all_copied_files = []
         transfers = instance.data.get("transfers", list())
-        for dst in transfers.values():
+        for _src, dst in transfers:
             dst = os.path.normpath(dst)
             if dst not in all_copied_files:
                 all_copied_files.append(dst)
 
         hardlinks = instance.data.get("hardlinks", list())
-        for dst in hardlinks.values():
+        for _src, dst in hardlinks:
             dst = os.path.normpath(dst)
             if dst not in all_copied_files:
                 all_copied_files.append(dst)

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -329,8 +329,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     test_dest_files.append(
                         os.path.normpath(template_filled)
                     )
-                # Store used frame value to template data
-                template_data["frame"] = repre_context["frame"]
 
                 self.log.debug(
                     "test_dest_files: {}".format(str(test_dest_files)))
@@ -387,6 +385,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     if not dst_start_frame:
                         dst_start_frame = dst_padding
 
+                # Store used frame value to template data
+                template_data["frame"] = dst_start_frame
                 dst = "{0}{1}{2}".format(
                     dst_head,
                     dst_start_frame,

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -89,6 +89,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         "project", "asset", "task", "subset", "version", "representation",
         "family", "hierarchy", "task", "username"
     ]
+    default_template_name = "publish"
 
     def process(self, instance):
 
@@ -261,7 +262,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         # Each should be a single representation (as such, a single extension)
         representations = []
         destination_list = []
-        template_name = 'publish'
+
         if 'transfers' not in instance.data:
             instance.data['transfers'] = []
 
@@ -288,8 +289,10 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             files = repre['files']
             if repre.get('stagingDir'):
                 stagingdir = repre['stagingDir']
-            if repre.get('anatomy_template'):
-                template_name = repre['anatomy_template']
+
+            template_name = (
+                repre.get('anatomy_template') or self.default_template_name
+            )
             if repre.get("outputName"):
                 template_data["output"] = repre['outputName']
 

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -326,6 +326,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     test_dest_files.append(
                         os.path.normpath(template_filled)
                     )
+                # Store used frame value to template data
+                template_data["frame"] = repre_context["frame"]
 
                 self.log.debug(
                     "test_dest_files: {}".format(str(test_dest_files)))


### PR DESCRIPTION
- fixed invalid iterations in integrate master version
- `template_data` stores used `frame` value for master version
- `template_name` is not overriden during representation loop