### PR TITLE
PYPE-753 maya extract review refactor

### DIFF
--- a/pype/plugins/maya/publish/extract_playblast.py
+++ b/pype/plugins/maya/publish/extract_playblast.py
@@ -58,9 +58,9 @@ class ExtractPlayblast(pype.api.Extractor):
         preset['compression'] = "png"
         preset['start_frame'] = start
         preset['end_frame'] = end
-        preset['camera_options'] = {
-            "depthOfField": cmds.getAttr("{0}.depthOfField".format(camera)),
-        }
+        camera_option = preset.get("camera_option", {})
+        camera_option["depthOfField"] = cmds.getAttr(
+            "{0}.depthOfField".format(camera))
 
         stagingdir = self.staging_dir(instance)
         filename = "{0}".format(instance.name)


### PR DESCRIPTION
#### Changes:

* Changed misleading name to `extract_playblast`
* fps is taken from instance or context
* Camera options are taken now from capture preset
* rendering is forced to png instead of jpg

:warning: **requires PR**: pype-config now includes values previously hardcoded in plugin
