### PR TITLE
preserve mb file type during publish

### DIFF
--- a/pype/plugins/maya/publish/collect_scene.py
+++ b/pype/plugins/maya/publish/collect_scene.py
@@ -1,5 +1,3 @@
-from maya import cmds
-
 import pyblish.api
 import avalon.api
 import os
@@ -42,8 +40,8 @@ class CollectMayaScene(pyblish.api.ContextPlugin):
         })
 
         data['representations'] = [{
-            'name': 'ma',
-            'ext': 'ma',
+            'name': ext.lstrip("."),
+            'ext': ext.lstrip("."),
             'files': file,
             "stagingDir": folder,
         }]


### PR DESCRIPTION
## Problem:

If workfile was published Pype didn't check for its type. It forcefully published it as maya ASCII file (ma). This resulted in published file with wrong extension and maya unable to open it.

## Solution:

This PR is changing it so we set scene type by the current one