### PR TITLE
Update validate_rig_output_ids.py

### DIFF
--- a/pype/plugins/maya/publish/validate_rig_output_ids.py
+++ b/pype/plugins/maya/publish/validate_rig_output_ids.py
@@ -38,7 +38,8 @@ class ValidateRigOutputIds(pyblish.api.InstancePlugin):
         if compute:
             out_set = next(x for x in instance if x.endswith("out_SET"))
             instance_nodes = pc.sets(out_set, query=True)
-            instance_nodes.extend([x.getShape() for x in instance_nodes if x.getShape()])
+            instance_nodes.extend(
+                [x.getShape() for x in instance_nodes if x.getShape()])
 
             scene_nodes = pc.ls(type="transform") + pc.ls(type="mesh")
             scene_nodes = set(scene_nodes) - set(instance_nodes)

--- a/pype/plugins/maya/publish/validate_rig_output_ids.py
+++ b/pype/plugins/maya/publish/validate_rig_output_ids.py
@@ -38,7 +38,7 @@ class ValidateRigOutputIds(pyblish.api.InstancePlugin):
         if compute:
             out_set = next(x for x in instance if x.endswith("out_SET"))
             instance_nodes = pc.sets(out_set, query=True)
-            instance_nodes.extend([x.getShape() for x in instance_nodes])
+            instance_nodes.extend([x.getShape() for x in instance_nodes if x.getShape()])
 
             scene_nodes = pc.ls(type="transform") + pc.ls(type="mesh")
             scene_nodes = set(scene_nodes) - set(instance_nodes)


### PR DESCRIPTION
Allowing different types of objects in `out_SET` of rig is not working because we are running `getShape()` function on them explicitly. This will return *None* for objects where shape is not defined, failing later in code. This is checking for this cases.