### PR TITLE
fixed missing import for previous PR

### DIFF
--- a/pype/plugins/maya/publish/collect_scene.py
+++ b/pype/plugins/maya/publish/collect_scene.py
@@ -1,7 +1,7 @@
 import pyblish.api
 import avalon.api
 import os
-from pype.maya import lib
+from pype.maya import cmds
 
 
 class CollectMayaScene(pyblish.api.ContextPlugin):


### PR DESCRIPTION
Previous PR was based on different code and is now missing maya.cmds as import. This is fixing it. Needs to be merged to develop too.