### PR TITLE
PYPE-743: fixing yeti cache version updates

### DIFF
--- a/pype/plugins/maya/load/load_yeti_cache.py
+++ b/pype/plugins/maya/load/load_yeti_cache.py
@@ -105,7 +105,6 @@ class YetiCacheLoader(api.Loader):
         io.install()
         namespace = container["namespace"]
         container_node = container["objectName"]
-        # import web_pdb; web_pdb.set_trace()
 
         fur_settings = io.find_one(
             {"parent": representation["parent"], "name": "fursettings"}
@@ -120,8 +119,6 @@ class YetiCacheLoader(api.Loader):
         settings_fname = api.get_representation_path(fur_settings)
         path = api.get_representation_path(representation)
         # Get all node data
-        # fname, ext = os.path.splitext(path)
-        # settings_fname = "{}.fursettings".format(fname)
         with open(settings_fname, "r") as fp:
             settings = json.load(fp)
 
@@ -213,7 +210,6 @@ class YetiCacheLoader(api.Loader):
                     yeti_node = yeti_nodes[0]
 
                     for attr, value in data["attrs"].items():
-                        # import web_pdb; web_pdb.set_trace()
                         # handle empty attribute strings. Those are reported
                         # as None, so their type is NoneType and this is not
                         # supported on attributes in Maya. We change it to

--- a/pype/plugins/maya/publish/collect_yeti_cache.py
+++ b/pype/plugins/maya/publish/collect_yeti_cache.py
@@ -49,6 +49,10 @@ class CollectYetiCache(pyblish.api.InstancePlugin):
             attr_data = {}
             for attr in SETTINGS:
                 current = cmds.getAttr("%s.%s" % (shape, attr))
+                # change None to empty string as Maya doesn't support
+                # NoneType in attributes
+                if current is None:
+                    current = ""
                 attr_data[attr] = current
 
             # Get transform data


### PR DESCRIPTION
**Yeti Cache loader** was handling paths to _cache_ and _fursettings_ file manually, guessing location of one from other. Yeti cache files and fursettings are now two representations of one version.

This PR is taking paths from avalon now so version updates (and switching works).