### PR TITLE
passing PYPE_PYTHON_EXE to farm jobs

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -225,6 +225,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         environment = job["Props"].get("Env", {})
         environment["PYPE_METADATA_FILE"] = metadata_path
         environment["AVALON_PROJECT"] = io.Session["AVALON_PROJECT"]
+        environment["PYPE_LOG_NO_COLORS"] = "1"
+        try:
+            environment["PYPE_PYTHON_EXE"] = os.environ["PYPE_PYTHON_EXE"]
+        except KeyError:
+            # PYPE_PYTHON_EXE not set
+            pass
         i = 0
         for index, key in enumerate(environment):
             if key.upper() in self.enviro_filter:


### PR DESCRIPTION
This is passig `PYPE_PYTHON_EXE` environment variable to farm jobs (if set). Also setting `PYPE_LOG_NO_COLORS` for farm job as output coloring doesn't make much sense in deadline/muster logs.

Depends on pypeclub/pype-setup#19