### PR TITLE
Integrate: handle errors during file copy

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -5,6 +5,7 @@ import sys
 import copy
 import clique
 import errno
+import six
 
 from pymongo import DeleteOne, InsertOne
 import pyblish.api
@@ -569,7 +570,12 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         # copy file with speedcopy and check if size of files are simetrical
         while True:
-            copyfile(src, dst)
+            try:
+                copyfile(src, dst)
+            except OSError as e:
+                self.log.critical("Cannot copy {} to {}".format(src, dst))
+                self.log.critical(e)
+                six.reraise(*sys.exc_info())
             if str(getsize(src)) in str(getsize(dst)):
                 break
 


### PR DESCRIPTION
## Problem

During copy phase we are not properly handling cases when copying fails. Thus we only get system error after unsuccessful publish fails and that doesn't include information about files.

## Solution

This PR is catching **OSError** and is outputting to log more stuff.