### PR TITLE
Fix render collection

### DIFF
--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -157,6 +157,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
             attachTo = []
             if sets:
                 for s in sets:
+                    if "family" not in cmds.listAttr(s):
+                        continue
+
                     attachTo.append(
                         {
                             "version": None,  # we need integrator for that


### PR DESCRIPTION
When objects attached to the render layers do not have family the collection would error out.

This happened for me when having a material override in a render layer.