### PR TITLE
Warn users about no nodes selected.

### DIFF
--- a/pype/plugins/nuke/create/create_write_prerender.py
+++ b/pype/plugins/nuke/create/create_write_prerender.py
@@ -48,6 +48,14 @@ class CreateWritePrerender(plugin.PypeCreator):
                 self.log.error(msg)
                 nuke.message(msg)
 
+            if len(nodes) == 0:
+                msg = (
+                    "No nodes selected. Please select a single node to connect"
+                    " to or tick off `Use selection`"
+                )
+                self.log.error(msg)
+                nuke.message(msg)
+
             selected_node = nodes[0]
             inputs = [selected_node]
             outputs = selected_node.dependent()

--- a/pype/plugins/nuke/create/create_write_render.py
+++ b/pype/plugins/nuke/create/create_write_render.py
@@ -49,6 +49,14 @@ class CreateWriteRender(plugin.PypeCreator):
                 self.log.error(msg)
                 nuke.message(msg)
 
+            if len(nodes) == 0:
+                msg = (
+                    "No nodes selected. Please select a single node to connect"
+                    " to or tick off `Use selection`"
+                )
+                self.log.error(msg)
+                nuke.message(msg)
+
             selected_node = nodes[0]
             inputs = [selected_node]
             outputs = selected_node.dependent()


### PR DESCRIPTION
No nodes selected case was not handled so users get a cryptic error message:
```
Traceback (most recent call last):
  File "K:\pype-setup\repos\avalon-core\avalon\pipeline.py", line 994, in create
    instance = plugin.process()
  File "<string>", line 52, in process
IndexError: list index out of range
Traceback (most recent call last):
  File "K:\pype-setup\repos\avalon-core\avalon\tools\creator\app.py", line 493, in on_create
    options={"useSelection": use_selection})
  File "K:\pype-setup\repos\avalon-core\avalon\pipeline.py", line 1000, in create
    assert plugins, "No Creator plug-ins were run, this is a bug"
AssertionError: No Creator plug-ins were run, this is a bug
```

Now users get an error message box with:
```
No nodes selected. Please select a single node to connect to or tick off `Use selection`
```