### PR TITLE
feature/ftrack parent thumbnails

### DIFF
--- a/pype/ftrack/events/event_thumbnail_updates.py
+++ b/pype/ftrack/events/event_thumbnail_updates.py
@@ -2,57 +2,42 @@ from pype.ftrack import BaseEvent
 
 
 class ThumbnailEvents(BaseEvent):
-
     def launch(self, session, event):
-        '''just a testing event'''
+        """Updates thumbnails of entities from new AssetVersion."""
 
-        # self.log.info(event)
-        # start of event procedure ----------------------------------
-        for entity in event['data'].get('entities', []):
+        for entity in event["data"].get("entities", []):
+            if (
+                entity["action"] == "remove"
+                or entity["entityType"].lower() != "assetversion"
+                or "thumbid" not in (entity.get("keys") or [])
+            ):
+                continue
 
             # update created task thumbnail with first parent thumbnail
-            if entity['entityType'] == 'task' and entity['action'] == 'add':
+            version = session.get("AssetVersion", entity["entityId"])
+            if not version:
+                continue
 
-                task = session.get('TypedContext', entity['entityId'])
-                parent = task['parent']
+            thumbnail = version.get("thumbnail")
+            if not thumbnail:
+                continue
 
-                if parent.get('thumbnail') and not task.get('thumbnail'):
-                    task['thumbnail'] = parent['thumbnail']
-                    self.log.info('>>> Updated thumbnail on [ %s/%s ]'.format(
-                        parent['name'], task['name']
-                    ))
+            parent = version["asset"]["parent"]
+            task = version["task"]
+            parent["thumbnail_id"] = version["thumbnail_id"]
+            if parent.entity_type.lower() == "project":
+                name = parent["full_name"]
+            else:
+                name = parent["name"]
 
-            # Update task thumbnail from published version
-            # if (entity['entityType'] == 'assetversion' and
-            #         entity['action'] == 'encoded'):
-            elif (
-                entity['entityType'] == 'assetversion' and
-                entity['action'] != 'remove' and
-                'thumbid' in (entity.get('keys') or [])
-            ):
+            task_msg = ""
+            if task:
+                task["thumbnail_id"] = version["thumbnail_id"]
+                task_msg = " and task [ {} ]".format(task["name"])
 
-                version = session.get('AssetVersion', entity['entityId'])
-                if not version:
-                    continue
-
-                thumbnail = version.get('thumbnail')
-                if not thumbnail:
-                    continue
-
-                parent = version['asset']['parent']
-                task = version['task']
-                parent['thumbnail_id'] = version['thumbnail_id']
-                if parent.entity_type.lower() == "project":
-                    name = parent["full_name"]
-                else:
-                    name = parent["name"]
-                msg = '>>> Updating thumbnail for shot [ {} ]'.format(name)
-
-                if task:
-                    task['thumbnail_id'] = version['thumbnail_id']
-                    msg += " and task [ {} ]".format(task["name"])
-
-                self.log.info(msg)
+            self.log.info(">>> Updating thumbnail for shot [ {} ]{}".format(
+                name, task_msg
+            ))
 
             try:
                 session.commit()
@@ -61,5 +46,4 @@ class ThumbnailEvents(BaseEvent):
 
 
 def register(session, plugins_presets):
-    '''Register plugin. Called when used as an plugin.'''
     ThumbnailEvents(session, plugins_presets).register()


### PR DESCRIPTION
Issue:
ThumbnailEvents handler now set, to created entity, thumbnail of it's parent. But parent's thumbnail at the time of creation may be default ftrack thumbnail. That cause strange behavior when publishing from nukestudio or premiere is happening. First are created entities and set their thumbnails, then are created new asset versions which are not connected to task but only it's parent. In that case tasks have different thumbnail than it's parent entity.

Solution:
Handler is skipping setting thumbnail if hierarchical entities at all. Ftrack provides populating thumbnails function which do what we need to do. 
![image](https://user-images.githubusercontent.com/43494761/81196213-0d20cb80-8fbf-11ea-8e96-2e05bd700ea3.png)
