### PR TITLE
Deadline wait for scene file to sync.

### DIFF
--- a/pype/plugins/fusion/publish/submit_deadline.py
+++ b/pype/plugins/fusion/publish/submit_deadline.py
@@ -68,6 +68,9 @@ class FusionSubmitDeadline(pyblish.api.InstancePlugin):
                 # Top-level group name
                 "BatchName": filename,
 
+                # Asset dependency to wait for at least the scene file to sync.
+                "AssetDependency0": filepath,
+
                 # Job name, as seen in Monitor
                 "Name": filename,
 

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -226,6 +226,9 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                 # Top-level group name
                 "BatchName": filename,
 
+                # Asset dependency to wait for at least the scene file to sync.
+                "AssetDependency0": filepath,
+
                 # Job name, as seen in Monitor
                 "Name": jobname,
 

--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -128,6 +128,9 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                 # Top-level group name
                 "BatchName": script_name,
 
+                # Asset dependency to wait for at least the scene file to sync.
+                "AssetDependency0": script_path,
+
                 # Job name, as seen in Monitor
                 "Name": jobname,
 


### PR DESCRIPTION
When working remotely the submission to Deadline is immediate but the files might not have synced between sites.
We add just the scene file for now, but later might wanna add other file dependencies.