### PR TITLE
Feature/pype 785 osx compatibility

### DIFF
--- a/pype/ftrack/lib/ftrack_app_handler.py
+++ b/pype/ftrack/lib/ftrack_app_handler.py
@@ -259,7 +259,8 @@ class AppAction(BaseAction):
                 executable=execfile, args=[], environment=env
             )
 
-        elif sys.platform.startswith("linux") or sys.platform.startswith("darwin"):
+        elif (sys.platform.startswith("linux")
+                or sys.platform.startswith("darwin")):
             execfile = os.path.join(path.strip('"'), self.executable)
             if not os.path.isfile(execfile):
                 msg = "Launcher doesn't exist - {}".format(execfile)

--- a/pype/ftrack/lib/ftrack_app_handler.py
+++ b/pype/ftrack/lib/ftrack_app_handler.py
@@ -259,7 +259,7 @@ class AppAction(BaseAction):
                 executable=execfile, args=[], environment=env
             )
 
-        elif sys.platform.startswith("linux"):
+        elif sys.platform.startswith("linux") or sys.platform.startswith("darwin"):
             execfile = os.path.join(path.strip('"'), self.executable)
             if not os.path.isfile(execfile):
                 msg = "Launcher doesn't exist - {}".format(execfile)
@@ -303,7 +303,7 @@ class AppAction(BaseAction):
                     )
                 }
 
-            popen = avalonlib.launch(
+            popen = avalon.lib.launch(  # noqa: F841
                 "/usr/bin/env", args=["bash", execfile], environment=env
             )
 


### PR DESCRIPTION
## Basic macOS compatibility

This PR adds pype basic compatibility.

### Aditional dependecies:

It needs **Xcode Command Line Tools** installed (they are including git, gcc, etc.). Pype is trying to install them by itself but needs to be online.


| ❗ Tested on macOS 10.15.3 Catalina |
| --- |

Needs corresponding PR in **pype-setup** and **pype-config**
Depends on pypeclub/pype-setup#22
Depends on pypeclub/pype-config#24

### Know problems

- Tray menu is rendered twice over itself. Native style seems to be overlaid by Qt styled menu.
- Hosts and their plugins are not tested at all.

