### PR TITLE
add timeout on request to deadline

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -262,7 +262,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         # self.log.info(json.dumps(payload, indent=4, sort_keys=True))
 
         url = "{}/api/jobs".format(self.DEADLINE_REST_URL)
-        response = requests.post(url, json=payload)
+        response = requests.post(url, json=payload, timeout=10)
         if not response.ok:
             raise Exception(response.text)
 

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -352,6 +352,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         """
         if 'verify' not in kwargs:
             kwargs['verify'] = False if os.getenv("PYPE_DONT_VERIFY_SSL", True) else True  # noqa
+        # add 10sec timeout before bailing out
+        kwargs['timeout'] = 10
         return requests.post(*args, **kwargs)
 
     def _requests_get(self, *args, **kwargs):
@@ -366,4 +368,6 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         """
         if 'verify' not in kwargs:
             kwargs['verify'] = False if os.getenv("PYPE_DONT_VERIFY_SSL", True) else True  # noqa
+        # add 10sec timeout before bailing out
+        kwargs['timeout'] = 10
         return requests.get(*args, **kwargs)

--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -251,7 +251,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         self.expected_files(instance, render_path)
         self.log.debug("__ expectedFiles: `{}`".format(
             instance.data["expectedFiles"]))
-        response = requests.post(self.deadline_url, json=payload)
+        response = requests.post(self.deadline_url, json=payload, timeout=10)
 
         if not response.ok:
             raise Exception(response.text)


### PR DESCRIPTION
## Problem

When deadline web service is not working properly, connection can take forever - deadline will not terminate connection with status code. This will block whole publishing process and freeze host completely (as requests is blocking operation)

## Solution

Add `timeout` to request. Set to 10sec as this seems like reasonable value.