### PR TITLE
fixed condition for multipartExr

### DIFF
--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -68,7 +68,7 @@ class ExtractBurnin(pype.api.Extractor):
         for i, repre in enumerate(instance.data["representations"]):
             self.log.debug("__ i: `{}`, repre: `{}`".format(i, repre))
 
-            if "multipartExr" in repre.get("tags", []):
+            if instance.data.get("multipartExr") is True:
                 # ffmpeg doesn't support multipart exrs
                 continue
 

--- a/pype/plugins/global/publish/extract_jpeg.py
+++ b/pype/plugins/global/publish/extract_jpeg.py
@@ -36,7 +36,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             if not isinstance(repre['files'], list):
                 continue
 
-            if "multipartExr" in tags:
+            if instance.data.get("multipartExr") is True:
                 # ffmpeg doesn't support multipart exrs
                 continue
 

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -63,7 +63,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
             tags = repre.get("tags", [])
 
-            if "multipartExr" in tags:
+            if inst_data.get("multipartExr") is True:
                 # ffmpeg doesn't support multipart exrs
                 continue
 


### PR DESCRIPTION
## Problem
ffpmeg is not supporting multipart exrs therefor we introduced `multipartExr` property to pass that information down the line so extractor avoid running ffmpeg against those data.

Unfortunately those extractors were looking for it in wrong place - in tags on representation, but should look instead at instance data.

This bug resulted in inability to publish renders with multipart exrs as ffmpeg always crashed.