### PR TITLE
bugfix/ftrack future warning

### DIFF
--- a/pype/plugins/ftrack/publish/collect_ftrack_api.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_api.py
@@ -22,7 +22,7 @@ class CollectFtrackApi(pyblish.api.ContextPlugin):
         ftrack_log.setLevel(logging.WARNING)
 
         # Collect session
-        session = ftrack_api.Session()
+        session = ftrack_api.Session(auto_connect_event_hub=True)
         self.log.debug("Ftrack user: \"{0}\"".format(session.api_user))
         context.data["ftrackSession"] = session
 


### PR DESCRIPTION
Issue:
New version of python-ftrack-api has set `auto_connect_event_hub` to `False` which will cause issues if won't be handled.

Solution:
Ftrack session created during publishing has set `auto_connect_event_hub` to True on session initialization.