### PR TITLE
nuke family `render2d` if published from imgsequence

### DIFF
--- a/pype/plugins/nuke/publish/collect_writes.py
+++ b/pype/plugins/nuke/publish/collect_writes.py
@@ -115,7 +115,7 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
 
         # Add version data to instance
         version_data = {
-            "colorspace":  node["colorspace"].value(),
+            "colorspace": node["colorspace"].value(),
         }
 
         instance.data["family"] = "write"
@@ -149,6 +149,11 @@ class CollectNukeWrites(pyblish.api.InstancePlugin):
             "deadlineChunkSize": deadlineChunkSize,
             "deadlinePriority": deadlinePriority
         })
+
+        if "render" in families:
+            instance.data["family"] = "render2d"
+            if "render" not in families:
+                instance.data["families"].insert(0, "render")
 
         if "prerender" in families:
             instance.data.update({


### PR DESCRIPTION
At the moment when we are publishing from render.local and render.farm the published main family is render2d but if we are rendering from already rendered frames the main published family is write. This will fix it to render2d for better consistency.