### PR TITLE
ignore case in scene version parsing

### DIFF
--- a/pype/lib.py
+++ b/pype/lib.py
@@ -458,7 +458,7 @@ def get_version_from_path(file):
         v: version number in string ('001')
 
     """
-    pattern = re.compile(r"[\._]v([0-9]+)")
+    pattern = re.compile(r"[\._]v([0-9]+)", re.IGNORECASE)
     try:
         return pattern.findall(file)[0]
     except IndexError:


### PR DESCRIPTION
## Problem

If scene name is named with capital `V` in version string, `collect_scene_version.py` will fail. We should allow both cases in scene version string.

## Solution

Switch regex searching for scene version to ignore case mode.