### PR TITLE
Publish backdrops with templates.

### DIFF
--- a/pype/plugins/harmony/load/load_template.py
+++ b/pype/plugins/harmony/load/load_template.py
@@ -14,6 +14,19 @@ class ImportTemplateLoader(api.Loader):
     label = "Import Template"
 
     def load(self, context, name=None, namespace=None, data=None):
+        # Make backdrops from metadata.
+        backdrops = context["representation"]["data"].get("backdrops", [])
+
+        func = """function func(args)
+        {
+            Backdrop.addBackdrop("Top", args[0]);
+        }
+        func
+        """
+        for backdrop in backdrops:
+            harmony.send({"function": func, "args": [backdrop]})
+
+        # Import template.
         temp_dir = tempfile.mkdtemp()
         zip_file = api.get_representation_path(context["representation"])
         template_path = os.path.join(temp_dir, "temp.tpl")

--- a/pype/plugins/harmony/publish/collect_instances.py
+++ b/pype/plugins/harmony/publish/collect_instances.py
@@ -18,7 +18,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder
     hosts = ["harmony"]
     families_mapping = {
-        "render": ["imagesequence", "review"],
+        "render": ["imagesequence", "review", "ftrack"],
         "harmony.template": []
     }
 
@@ -45,7 +45,6 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 {"function": "node.getEnable", "args": [node]}
             )["result"]
             instance.data["families"] = self.families_mapping[data["family"]]
-            instance.data["families"].append("ftrack")
 
             # Produce diagnostic message for any graphical
             # user interface interested in visualising it.


### PR DESCRIPTION
- other nodes within the bounding box of the backdrops are published as well, cause non-connected notes can be used to communicate to the end user.
- not publishing templates to ftrack.

resolves https://github.com/pypeclub/fourthwall-config/issues/9