### PR TITLE
Optional script validation

### DIFF
--- a/pype/plugins/nuke/publish/validate_script.py
+++ b/pype/plugins/nuke/publish/validate_script.py
@@ -11,6 +11,7 @@ class ValidateScript(pyblish.api.InstancePlugin):
     families = ["workfile"]
     label = "Check script settings"
     hosts = ["nuke"]
+    optional = True
 
     def process(self, instance):
         ctx_data = instance.context.data


### PR DESCRIPTION
In a pinch users need to be able to ignore the script validation to get a shot out.