### PR TITLE
hotfix/review extractors

### DIFF
--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -58,7 +58,7 @@ class ExtractBurnin(pype.api.Extractor):
         if "representations" not in instance.data:
             raise RuntimeError("Burnin needs already created mov to work on.")
 
-        if self.profiles is None:
+        if self.use_legacy_code(instance):
             return self.legacy_process(instance)
         self.main_process(instance)
 
@@ -70,6 +70,12 @@ class ExtractBurnin(pype.api.Extractor):
                 instance.data["representations"].remove(repre)
 
         self.log.debug(instance.data["representations"])
+
+    def use_legacy_code(self, instance):
+        presets = instance.context.data.get("presets")
+        if presets is None and self.profiles is None:
+            return True
+        return "burnins" in (presets.get("tools") or {})
 
     def main_process(self, instance):
         # TODO get these data from context


### PR DESCRIPTION
Issue:
ExtractBurnin have legacy code, but using it is based on detection of `profiles` variable which is set always because of default presets.

Solved:
Legacy detection is based on existence of `presets["tools"]["burnins"]` key.