### PR TITLE
Maya - Look: Skip invalid connections

### DIFF
--- a/pype/plugins/maya/publish/collect_look.py
+++ b/pype/plugins/maya/publish/collect_look.py
@@ -277,7 +277,13 @@ class CollectLook(pyblish.api.InstancePlugin):
         if looksets:
             for look in looksets:
                 for at in shaderAttrs:
-                    con = cmds.listConnections("{}.{}".format(look, at))
+                    try:
+                        con = cmds.listConnections("{}.{}".format(look, at))
+                    except ValueError:
+                        # skip attributes that are invalid in current
+                        # context. For example in the case where
+                        # Arnold is not enabled.
+                        continue
                     if con:
                         materials.extend(con)
 


### PR DESCRIPTION
## Problem

When Arnold is not enabled in Maya, collect look will fail because of missing connection it is looking for (like `aiShader*` stuff).

## Fix
This fix force collector to skip silently those invalid connections.