### PR TITLE
Hotfix/extract review type conversions

### DIFF
--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -610,8 +610,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
         # NOTE Skipped using instance's resolution
         full_input_path_single_file = temp_data["full_input_path_single_file"]
         input_data = pype.lib.ffprobe_streams(full_input_path_single_file)[0]
-        input_width = input_data["width"]
-        input_height = input_data["height"]
+        input_width = int(input_data["width"])
+        input_height = int(input_data["height"])
 
         self.log.debug("pixel_aspect: `{}`".format(pixel_aspect))
         self.log.debug("input_width: `{}`".format(input_width))

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -631,6 +631,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
             output_width = input_width
             output_height = input_height
 
+        output_width = int(output_width)
+        output_height = int(output_height)
+
         self.log.debug(
             "Output resolution is {}x{}".format(output_width, output_height)
         )


### PR DESCRIPTION
Issue:
Input resolution values are kept in string so if resolution is not in preset extractor will crash due to unsupported operation between string and integer.

Input resolution values are converted to integer.