### PR TITLE
feature/Blender handling collections in rig and layout assets

### DIFF
--- a/pype/plugins/blender/create/create_layout.py
+++ b/pype/plugins/blender/create/create_layout.py
@@ -34,19 +34,7 @@ class CreateLayout(Creator):
         objects_to_link = set()
 
         if (self.options or {}).get("useSelection"):
-
             for obj in lib.get_selection():
-
-                objects_to_link.add(obj)
-
-                if obj.type == 'ARMATURE':
-
-                    for subobj in obj.children:
-
-                        objects_to_link.add(subobj)
-
-        for obj in objects_to_link:
-
-            collection.objects.link(obj)
+                collection.children.link(obj.users_collection[0])
 
         return collection

--- a/pype/plugins/blender/create/create_rig.py
+++ b/pype/plugins/blender/create/create_rig.py
@@ -31,22 +31,11 @@ class CreateRig(Creator):
         # This links automatically the children meshes if they were not
         # selected, and doesn't link them twice if they, insted,
         # were manually selected by the user.
-        objects_to_link = set()
 
         if (self.options or {}).get("useSelection"):
-
             for obj in lib.get_selection():
-
-                objects_to_link.add(obj)
-
-                if obj.type == 'ARMATURE':
-
-                    for subobj in obj.children:
-
-                        objects_to_link.add(subobj)
-
-        for obj in objects_to_link:
-
-            collection.objects.link(obj)
+                for child in obj.users_collection[0].children:
+                    collection.children.link(child)
+                collection.objects.link(obj)
 
         return collection

--- a/pype/plugins/blender/load/load_animation.py
+++ b/pype/plugins/blender/load/load_animation.py
@@ -29,7 +29,6 @@ class BlendAnimationLoader(pype.hosts.blender.plugin.AssetLoader):
     icon = "code-fork"
     color = "orange"
 
-    @staticmethod
     def _remove(self, objects, lib_container):
 
         for obj in objects:
@@ -41,7 +40,6 @@ class BlendAnimationLoader(pype.hosts.blender.plugin.AssetLoader):
 
         bpy.data.collections.remove(bpy.data.collections[lib_container])
 
-    @staticmethod
     def _process(self, libpath, lib_container, container_name):
 
         relative = bpy.context.preferences.filepaths.use_relative_paths
@@ -131,7 +129,7 @@ class BlendAnimationLoader(pype.hosts.blender.plugin.AssetLoader):
         container_metadata["lib_container"] = lib_container
 
         objects_list = self._process(
-            self, libpath, lib_container, container_name)
+            libpath, lib_container, container_name)
 
         # Save the list of objects in the metadata container
         container_metadata["objects"] = objects_list
@@ -205,14 +203,10 @@ class BlendAnimationLoader(pype.hosts.blender.plugin.AssetLoader):
         objects = collection_metadata["objects"]
         lib_container = collection_metadata["lib_container"]
 
-        # Get the armature of the rig
-        armatures = [obj for obj in objects if obj.type == 'ARMATURE']
-        assert(len(armatures) == 1)
-
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         objects_list = self._process(
-            self, str(libpath), lib_container, collection.name)
+            str(libpath), lib_container, collection.name)
 
         # Save the list of objects in the metadata container
         collection_metadata["objects"] = objects_list
@@ -249,7 +243,7 @@ class BlendAnimationLoader(pype.hosts.blender.plugin.AssetLoader):
         objects = collection_metadata["objects"]
         lib_container = collection_metadata["lib_container"]
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         bpy.data.collections.remove(collection)
 

--- a/pype/plugins/blender/load/load_layout.py
+++ b/pype/plugins/blender/load/load_layout.py
@@ -29,7 +29,6 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
     icon = "code-fork"
     color = "orange"
 
-    @staticmethod
     def _remove(self, objects, lib_container):
 
         for obj in objects:
@@ -46,7 +45,6 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
 
         bpy.data.collections.remove(bpy.data.collections[lib_container])
 
-    @staticmethod
     def _process(self, libpath, lib_container, container_name, actions):
 
         relative = bpy.context.preferences.filepaths.use_relative_paths
@@ -136,7 +134,7 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
         container_metadata["lib_container"] = lib_container
 
         objects_list = self._process(
-            self, libpath, lib_container, container_name, {})
+            libpath, lib_container, container_name, {})
 
         # Save the list of objects in the metadata container
         container_metadata["objects"] = objects_list
@@ -218,10 +216,10 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
 
                 actions[obj.name] = obj.animation_data.action
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         objects_list = self._process(
-            self, str(libpath), lib_container, collection.name, actions)
+            str(libpath), lib_container, collection.name, actions)
 
         # Save the list of objects in the metadata container
         collection_metadata["objects"] = objects_list
@@ -258,7 +256,7 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
         objects = collection_metadata["objects"]
         lib_container = collection_metadata["lib_container"]
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         bpy.data.collections.remove(collection)
 

--- a/pype/plugins/blender/load/load_layout.py
+++ b/pype/plugins/blender/load/load_layout.py
@@ -66,6 +66,7 @@ class BlendLayoutLoader(pype.hosts.blender.plugin.AssetLoader):
 
         for element_container in layout_container.children:
             element_container.make_local()
+            meshes.extend([obj for obj in element_container.objects if obj.type == 'MESH'])
             armatures.extend([obj for obj in element_container.objects if obj.type == 'ARMATURE'])
             for child in element_container.children:
                 child.make_local()

--- a/pype/plugins/blender/load/load_model.py
+++ b/pype/plugins/blender/load/load_model.py
@@ -30,7 +30,6 @@ class BlendModelLoader(pype.hosts.blender.plugin.AssetLoader):
     icon = "code-fork"
     color = "orange"
 
-    @staticmethod
     def _remove(self, objects, lib_container):
 
         for obj in objects:
@@ -39,7 +38,6 @@ class BlendModelLoader(pype.hosts.blender.plugin.AssetLoader):
 
         bpy.data.collections.remove(bpy.data.collections[lib_container])
 
-    @staticmethod
     def _process(self, libpath, lib_container, container_name):
 
         relative = bpy.context.preferences.filepaths.use_relative_paths
@@ -118,7 +116,7 @@ class BlendModelLoader(pype.hosts.blender.plugin.AssetLoader):
         container_metadata["lib_container"] = lib_container
 
         objects_list = self._process(
-            self, libpath, lib_container, container_name)
+            libpath, lib_container, container_name)
 
         # Save the list of objects in the metadata container
         container_metadata["objects"] = objects_list
@@ -189,10 +187,10 @@ class BlendModelLoader(pype.hosts.blender.plugin.AssetLoader):
             logger.info("Library already loaded, not updating...")
             return
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         objects_list = self._process(
-            self, str(libpath), lib_container, collection.name)
+            str(libpath), lib_container, collection.name)
 
         # Save the list of objects in the metadata container
         collection_metadata["objects"] = objects_list
@@ -226,7 +224,7 @@ class BlendModelLoader(pype.hosts.blender.plugin.AssetLoader):
         objects = collection_metadata["objects"]
         lib_container = collection_metadata["lib_container"]
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         bpy.data.collections.remove(collection)
 

--- a/pype/plugins/blender/load/load_rig.py
+++ b/pype/plugins/blender/load/load_rig.py
@@ -30,7 +30,6 @@ class BlendRigLoader(pype.hosts.blender.plugin.AssetLoader):
     icon = "code-fork"
     color = "orange"
 
-    @staticmethod
     def _remove(self, objects, lib_container):
 
         for obj in objects:
@@ -45,7 +44,6 @@ class BlendRigLoader(pype.hosts.blender.plugin.AssetLoader):
 
         bpy.data.collections.remove(bpy.data.collections[lib_container])
 
-    @staticmethod
     def _process(self, libpath, lib_container, container_name, action):
 
         relative = bpy.context.preferences.filepaths.use_relative_paths
@@ -131,7 +129,7 @@ class BlendRigLoader(pype.hosts.blender.plugin.AssetLoader):
         container_metadata["lib_container"] = lib_container
 
         objects_list = self._process(
-            self, libpath, lib_container, container_name, None)
+            libpath, lib_container, container_name, None)
 
         # Save the list of objects in the metadata container
         container_metadata["objects"] = objects_list
@@ -210,10 +208,10 @@ class BlendRigLoader(pype.hosts.blender.plugin.AssetLoader):
 
         action = armatures[0].animation_data.action
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         objects_list = self._process(
-            self, str(libpath), lib_container, collection.name, action)
+            str(libpath), lib_container, collection.name, action)
 
         # Save the list of objects in the metadata container
         collection_metadata["objects"] = objects_list
@@ -250,7 +248,7 @@ class BlendRigLoader(pype.hosts.blender.plugin.AssetLoader):
         objects = collection_metadata["objects"]
         lib_container = collection_metadata["lib_container"]
 
-        self._remove(self, objects, lib_container)
+        self._remove(objects, lib_container)
 
         bpy.data.collections.remove(collection)
 


### PR DESCRIPTION
I've changed the behaviour of Blender with rig and layout assets.

The new rig:
![Annotation 2020-06-09 114101](https://user-images.githubusercontent.com/1087869/84256637-1811d300-ab0c-11ea-8e7d-e046f7b36e2e.png)
and the new layout:
![Annotation 2020-06-10 111952](https://user-images.githubusercontent.com/1087869/84256804-54453380-ab0c-11ea-80e7-ca1967014650.png)

In comparison, the old rig:
![Annotation 2020-06-09 114115](https://user-images.githubusercontent.com/1087869/84256658-1ea04a80-ab0c-11ea-8554-53d9d4d8a29c.png)
and the old layout
![Annotation 2020-06-10 112827](https://user-images.githubusercontent.com/1087869/84257637-8d31d800-ab0d-11ea-92c5-9c00d60015d6.png)

While the old version was more streamlined, it was difficult to navigate the outliner:
![Annotation 2020-06-09 114121](https://user-images.githubusercontent.com/1087869/84256666-1fd17780-ab0c-11ea-9754-788b05a90fa0.png)
And for a weird Blender behaviour, hiding the children object moved the meshes in the rig's collection:
![Annotation 2020-06-09 114126](https://user-images.githubusercontent.com/1087869/84256674-2233d180-ab0c-11ea-8d10-ebca7946180f.png)
![Annotation 2020-06-09 114133](https://user-images.githubusercontent.com/1087869/84256677-2364fe80-ab0c-11ea-9f76-bbf468f268b3.png)

The new version keeps the collections as created by the artists. We find that is way easier to navigate the outliner in this way.