### PR TITLE
premiere workfile root per task (multi-root)

### DIFF
--- a/pype/hooks/premiere/prelaunch.py
+++ b/pype/hooks/premiere/prelaunch.py
@@ -42,7 +42,10 @@ class PremierePrelaunch(PypeHook):
         # if anatomy template should have different root for particular task
         # just add for example > work[conforming]:
         workfile_search_key = f"work[{task.lower()}]"
-        workfile_key = anatomy_filled.get(workfile_search_key, "work")
+        workfile_key = anatomy_filled.get(
+            workfile_search_key,
+            anatomy_filled.get("work")
+        )
         workdir = env["AVALON_WORKDIR"] = workfile_key["folder"]
 
         # create workdir if doesn't exist
@@ -91,7 +94,7 @@ class PremierePrelaunch(PypeHook):
         ).format(asset_name, project_name)
 
         project_name = project_entity["name"]
-        self.project_code = project_entity["data"]["code"]
+        self.project_code = project_entity["data"].get("code")
 
         self.log.info(
             "Anatomy object collected for project \"{}\".".format(project_name)
@@ -106,7 +109,7 @@ class PremierePrelaunch(PypeHook):
             "root": root_path,
             "project": {
                 "name": project_name,
-                "code": project_entity["data"].get("code")
+                "code": self.project_code
             },
             "asset": asset_entity["name"],
             "hierarchy": hierarchy.replace("\\", "/"),

--- a/pype/hooks/premiere/prelaunch.py
+++ b/pype/hooks/premiere/prelaunch.py
@@ -1,7 +1,8 @@
 import os
 import traceback
+from avalon import api, io, lib
 from pype.lib import PypeHook
-from pype.api import Logger
+from pype.api import Logger, Anatomy
 from pype.hosts.premiere import lib as prlib
 
 
@@ -12,6 +13,7 @@ class PremierePrelaunch(PypeHook):
     path to the project by environment variable to Premiere launcher
     shell script.
     """
+    project_code = None
 
     def __init__(self, logger=None):
         if not logger:
@@ -26,6 +28,30 @@ class PremierePrelaunch(PypeHook):
         if not env:
             env = os.environ
 
+        # initialize
+        self._S = api.Session
+
+        # get context variables
+        self._S["AVALON_PROJECT"] = env["AVALON_PROJECT"]
+        self._S["AVALON_ASSET"] = env["AVALON_ASSET"]
+        task = self._S["AVALON_TASK"] = env["AVALON_TASK"]
+
+        # get workfile path
+        anatomy_filled = self.get_anatomy_filled()
+
+        # if anatomy template should have different root for particular task
+        # just add for example > work[conforming]:
+        workfile_search_key = f"work[{task.lower()}]"
+        workfile_key = anatomy_filled.get(workfile_search_key, "work")
+        workdir = env["AVALON_WORKDIR"] = workfile_key["folder"]
+
+        # create workdir if doesn't exist
+        os.makedirs(workdir, exist_ok=True)
+        self.log.info(f"Work dir is: `{workdir}`")
+
+        # adding project code to env
+        env["AVALON_PROJECT_CODE"] = self.project_code
+
         try:
             __import__("pype.hosts.premiere")
             __import__("pyblish")
@@ -36,7 +62,68 @@ class PremierePrelaunch(PypeHook):
 
         else:
             # Premiere Setup integration
-            # importlib.reload(prlib)
             prlib.setup(env)
 
         return True
+
+    def get_anatomy_filled(self):
+        root_path = api.registered_root()
+        project_name = self._S["AVALON_PROJECT"]
+        asset_name = self._S["AVALON_ASSET"]
+
+        io.install()
+        project_entity = io.find_one({
+            "type": "project",
+            "name": project_name
+        })
+        assert project_entity, (
+            "Project '{0}' was not found."
+        ).format(project_name)
+        self.log.debug("Collected Project \"{}\"".format(project_entity))
+
+        asset_entity = io.find_one({
+            "type": "asset",
+            "name": asset_name,
+            "parent": project_entity["_id"]
+        })
+        assert asset_entity, (
+            "No asset found by the name '{0}' in project '{1}'"
+        ).format(asset_name, project_name)
+
+        project_name = project_entity["name"]
+        self.project_code = project_entity["data"]["code"]
+
+        self.log.info(
+            "Anatomy object collected for project \"{}\".".format(project_name)
+        )
+
+        hierarchy_items = asset_entity["data"]["parents"]
+        hierarchy = ""
+        if hierarchy_items:
+            hierarchy = os.path.join(*hierarchy_items)
+
+        template_data = {
+            "root": root_path,
+            "project": {
+                "name": project_name,
+                "code": project_entity["data"].get("code")
+            },
+            "asset": asset_entity["name"],
+            "hierarchy": hierarchy.replace("\\", "/"),
+            "task": self._S["AVALON_TASK"],
+            "ext": "ppro",
+            "version": 1,
+            "username": os.getenv("PYPE_USERNAME", "").strip()
+        }
+
+        avalon_app_name = os.environ.get("AVALON_APP_NAME")
+        if avalon_app_name:
+            application_def = lib.get_application(avalon_app_name)
+            app_dir = application_def.get("application_dir")
+            if app_dir:
+                template_data["app"] = app_dir
+
+        anatomy = Anatomy(project_name)
+        anatomy_filled = anatomy.format_all(template_data).get_solved()
+
+        return anatomy_filled

--- a/pype/hosts/premiere/__init__.py
+++ b/pype/hosts/premiere/__init__.py
@@ -1,4 +1,3 @@
-import os
 from avalon import api as avalon
 from pyblish import api as pyblish
 from pype.api import Logger

--- a/pype/hosts/premiere/extensions/com.pype/jsx/batchRenamer.jsx
+++ b/pype/hosts/premiere/extensions/com.pype/jsx/batchRenamer.jsx
@@ -61,15 +61,12 @@ var BatchRenamer = {
     var seq = app.project.activeSequence;
     var metadata = $.pype.getSequencePypeMetadata(seq, true);
 
-    var startCount = 10;
-    var stepCount = 10;
     var padding = 3;
     var newItems = {};
+    var projectCode = data.projectCode
     var episode = data.ep;
     var episodeSuf = data.epSuffix;
     var shotPref = 'sh';
-    var count = 0;
-    var seqCheck = '';
 
     for (var c = 0; c < selected.length; c++) {
       // fill in hierarchy if set
@@ -79,15 +76,7 @@ var BatchRenamer = {
       var sequenceName = name.slice(0, 5);
       var shotNum = Number(name.slice((name.length - 3), name.length));
 
-      // if (sequenceName !== seqCheck) {
-      //   seqCheck = sequenceName;
-      //   count = 0;
-      // };
-      //
-      // var seqCount = (count * stepCount) + startCount;
-      // count += 1;
-
-      var newName = episode + sequenceName + shotPref + (shotNum).pad(padding);
+      var newName = projectCode + episode + sequenceName + shotPref + (shotNum).pad(padding);
       $.pype.log(newName);
       selected[c].clip.name = newName;
 

--- a/pype/hosts/premiere/ppro/index.html
+++ b/pype/hosts/premiere/ppro/index.html
@@ -39,14 +39,16 @@ var ENV;
         <div class="input-group input-group-sm mb-1">
 
           <div class="input-group-prepend">
-            <span class="input-group-text" id="basic-addon6">Rename targeted text layers<br />
-              converts sc010sh020
-              <br />to lbb201sc010sh020<br />and creates ftrack metadata</span>
+            <span class="input-group-text" id="basic-addon6">
+              Rename targeted text layers<br />
+              converts `sc010sh020`<br />
+              to `proj01ep01sc01sh01`<br />
+              and creates ftrack metadata</span>
             <div class="input-group-text">
-              <input type="text" name="episode" placeholder="lbb2" aria-label="episode" aria-describedby="basic-addon5" value="" style="width:75px;">
+              <input type="text" name="episode" placeholder="ep01" aria-label="episode" aria-describedby="basic-addon5" value="" style="width:75px;">
             </div>
             <div class="input-group-text">
-              <input type="text" name="ep_suffix" placeholder="nameofepisode" aria-label="Name of episode" aria-describedby="basic-addon5" value="">
+              <input type="text" name="ep_suffix" placeholder="longerEpisodeName" aria-label="Name of episode" aria-describedby="basic-addon5" value="">
             </div>
           </div>
           <div class="input-group-append">

--- a/pype/hosts/premiere/ppro/js/pype.js
+++ b/pype/hosts/premiere/ppro/js/pype.js
@@ -65,6 +65,7 @@ class Pype {
         let data = {};
         data.ep = $('input[name=episode]', $renameId).val();
         data.epSuffix = $('input[name=ep_suffix]', $renameId).val();
+        data.projectCode = this.env.AVALON_PROJECT_CODE;
 
         if (!data.ep) {
           this.csi.evalScript('$.pype.alert_message("' + 'Need to fill episode code' + '")');


### PR DESCRIPTION
- client request for workfiles to be having own anatomy template defined per task
- change of renaming tool look and behavior

To test this PR just add:
```
work[conforming]:
  folder: "{root[production]}/{project[name]}/{hierarchy}/{asset}/work/{task}"
  file: "{project[code]}_{asset}_{task}_{@version}<_{comment}>.{ext}"
  path: "{@folder}/{@file}"
```
into `pype-config/anatomy/default.yaml` (notice task name key work also root[production]).