### PR TITLE
Bugfix/266 toggle instance in pyblish pype crashes

### DIFF
--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -415,9 +415,9 @@ class Window(QtWidgets.QDialog):
             QtCore.Qt.DirectConnection
         )
 
-        artist_view.toggled.connect(self.on_item_toggled)
-        overview_instance_view.toggled.connect(self.on_item_toggled)
-        overview_plugin_view.toggled.connect(self.on_item_toggled)
+        artist_view.toggled.connect(self.on_instance_toggle)
+        overview_instance_view.toggled.connect(self.on_instance_toggle)
+        overview_plugin_view.toggled.connect(self.on_plugin_toggle)
 
         footer_button_stop.clicked.connect(self.on_stop_clicked)
         footer_button_reset.clicked.connect(self.on_reset_clicked)
@@ -537,7 +537,7 @@ class Window(QtWidgets.QDialog):
         ):
             instance_item.setData(enable_value, Roles.IsEnabledRole)
 
-    def on_item_toggled(self, index, state=None):
+    def on_instance_toggle(self, index, state=None):
         """An item is requesting to be toggled"""
         if not index.data(Roles.IsOptionalRole):
             return self.info("This item is mandatory")
@@ -548,7 +548,27 @@ class Window(QtWidgets.QDialog):
         if state is None:
             state = not index.data(QtCore.Qt.CheckStateRole)
 
-        index.model().setData(index, state, QtCore.Qt.CheckStateRole)
+        instance_id = index.data(Roles.ObjectIdRole)
+        instanceitem = self.instance_model.instance_items[instance_id]
+        instanceitem.setData(state, QtCore.Qt.CheckStateRole)
+
+        self.update_compatibility()
+
+    def on_plugin_toggle(self, index, state=None):
+        """An item is requesting to be toggled"""
+        if not index.data(Roles.IsOptionalRole):
+            return self.info("This item is mandatory")
+
+        if self.controller.collect_state != 1:
+            return self.info("Cannot toggle")
+
+        if state is None:
+            state = not index.data(QtCore.Qt.CheckStateRole)
+
+        plugin_id = index.data(Roles.ObjectIdRole)
+        plugin_item = self.plugin_model.plugin_items[plugin_id]
+        plugin_item.setData(state, QtCore.Qt.CheckStateRole)
+
         self.update_compatibility()
 
     def on_tab_changed(self, target):


### PR DESCRIPTION
Issue:
`setData` method called in model cause `TypeError: invalid result from InstanceItem.setData()`

Solution:
Toggle setData method happens on item not on model.

Resolves: https://github.com/pypeclub/pype/issues/266