### PR TITLE
feature/stop in middle of instance loop

### DIFF
--- a/pype/tools/pyblish_pype/control.py
+++ b/pype/tools/pyblish_pype/control.py
@@ -302,6 +302,11 @@ class Controller(QtCore.QObject):
                             "%s was inactive, skipping.." % instance
                         )
                         continue
+                    # Stop if was stopped
+                    if self.stopped:
+                        self.stopped = False
+                        yield IterationBreak("Stopped")
+
                     yield (plugin, instance)
             else:
                 families = util.collect_families_from_instances(


### PR DESCRIPTION
Issue:
It is not possible to stop publishing in middle of instance plugin. (issue when there is more than 10 instances)

Solved:
Check for `stopped` inside instance loop.