### PR TITLE
Bugfix/publish buttons collecting fix

### DIFF
--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -793,14 +793,14 @@ class Window(QtWidgets.QDialog):
 
     def on_was_stopped(self):
         errored = self.controller.errored
-        if self.controller.collected:
+        if self.controller.collect_state == 0:
+            self.footer_button_play.setEnabled(False)
+            self.footer_button_validate.setEnabled(False)
+        else:
             self.footer_button_play.setEnabled(not errored)
             self.footer_button_validate.setEnabled(
                 not errored and not self.controller.validated
             )
-        else:
-            self.footer_button_play.setEnabled(False)
-            self.footer_button_validate.setEnabled(False)
         self.footer_button_play.setFocus()
 
         self.footer_button_reset.setEnabled(True)

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -762,8 +762,8 @@ class Window(QtWidgets.QDialog):
             )
 
     def on_was_stopped(self):
+        errored = self.controller.errored
         if self.controller.collected:
-            errored = self.controller.errored
             self.footer_button_play.setEnabled(not errored)
             self.footer_button_validate.setEnabled(
                 not errored and not self.controller.validated

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -754,6 +754,8 @@ class Window(QtWidgets.QDialog):
         self.on_tab_changed(self.state["current_page"])
         self.update_compatibility()
 
+        self.button_suspend_logs.setEnabled(False)
+
         self.footer_button_validate.setEnabled(False)
         self.footer_button_reset.setEnabled(False)
         self.footer_button_stop.setEnabled(True)

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -726,14 +726,12 @@ class Window(QtWidgets.QDialog):
         self.on_tab_changed(self.state["current_page"])
         self.update_compatibility()
 
-        self.footer_button_validate.setEnabled(True)
-        self.footer_button_reset.setEnabled(True)
-        self.footer_button_stop.setEnabled(False)
-        self.footer_button_play.setEnabled(True)
-        self.footer_button_play.setFocus()
+        self.footer_button_validate.setEnabled(False)
+        self.footer_button_reset.setEnabled(False)
+        self.footer_button_stop.setEnabled(True)
+        self.footer_button_play.setEnabled(False)
 
     def on_passed_group(self, order):
-
         for group_item in self.instance_model.group_items.values():
             if self.overview_instance_view.isExpanded(group_item.index()):
                 continue
@@ -764,11 +762,17 @@ class Window(QtWidgets.QDialog):
             )
 
     def on_was_stopped(self):
-        errored = self.controller.errored
-        self.footer_button_play.setEnabled(not errored)
-        self.footer_button_validate.setEnabled(
-            not errored and not self.controller.validated
-        )
+        if self.controller.collected:
+            errored = self.controller.errored
+            self.footer_button_play.setEnabled(not errored)
+            self.footer_button_validate.setEnabled(
+                not errored and not self.controller.validated
+            )
+        else:
+            self.footer_button_play.setEnabled(False)
+            self.footer_button_validate.setEnabled(False)
+        self.footer_button_play.setFocus()
+
         self.footer_button_reset.setEnabled(True)
         self.footer_button_stop.setEnabled(False)
         if errored:


### PR DESCRIPTION
Issue:
During collecting are available Play, Validate and reset buttons which may crash GUI sequences.

Solution:
Buttons are disabled on reset and are getting available only after collection. Only refresh button is available if stop button is clicked during collecting.