### PR TITLE
Feature/maya deadline plugin

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -14,7 +14,10 @@ import pyblish.api
 
 def _get_script():
     """Get path to the image sequence script."""
-    from pathlib import Path
+    try:
+        from pathlib import Path
+    except ImportError:
+        from pathlib2 import Path
 
     try:
         from pype.scripts import publish_filesequence
@@ -26,6 +29,7 @@ def _get_script():
         module_path = module_path[: -len(".pyc")] + ".py"
 
     path = Path(os.path.normpath(module_path)).resolve(strict=True)
+    assert path is not None, ("Cannot determine path")
 
     return str(path)
 
@@ -840,7 +844,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
         # add audio to metadata file if available
         audio_file = context.data.get("audioFile")
-        if os.path.isfile(audio_file):
+        if audio_file and os.path.isfile(audio_file):
             publish_job.update({"audio": audio_file})
 
         # pass Ftrack credentials in case of Muster

--- a/pype/plugins/maya/create/create_render.py
+++ b/pype/plugins/maya/create/create_render.py
@@ -179,7 +179,7 @@ class CreateRender(avalon.maya.Creator):
         self.data["framesPerTask"] = 1
         self.data["whitelist"] = False
         self.data["machineList"] = ""
-        self.data["useMayaBatch"] = True
+        self.data["useMayaBatch"] = False
         self.data["vrayScene"] = False
         # Disable for now as this feature is not working yet
         # self.data["assScene"] = False

--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -332,9 +332,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
         options["extendFrames"] = extend_frames
         options["overrideExistingFrame"] = override_frames
 
-        maya_render_plugin = "MayaBatch"
-        if not attributes.get("useMayaBatch", True):
-            maya_render_plugin = "MayaCmd"
+        maya_render_plugin = "MayaPype"
+        if attributes.get("useMayaBatch", True):
+            maya_render_plugin = "MayaBatch"
 
         options["mayaRenderPlugin"] = maya_render_plugin
 

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -41,7 +41,7 @@ payload_skeleton = {
         "BatchName": None,  # Top-level group name
         "Name": None,  # Job name, as seen in Monitor
         "UserName": None,
-        "Plugin": "MayaBatch",
+        "Plugin": "MayaPype",
         "Frames": "{start}-{end}x{step}",
         "Comment": None,
     },
@@ -274,7 +274,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             step=int(self._instance.data["byFrameStep"]))
 
         payload_skeleton["JobInfo"]["Plugin"] = self._instance.data.get(
-            "mayaRenderPlugin", "MayaBatch")
+            "mayaRenderPlugin", "MayaPype")
 
         payload_skeleton["JobInfo"]["BatchName"] = filename
         # Job name, as seen in Monitor
@@ -311,12 +311,14 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
             "AVALON_TASK",
             "PYPE_USERNAME",
             "PYPE_DEV",
-            "PYPE_LOG_NO_COLORS"
+            "PYPE_LOG_NO_COLORS",
+            "PYPE_SETUP_PATH"
         ]
 
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)
         environment["PYPE_LOG_NO_COLORS"] = "1"
+        environment["PYPE_MAYA_VERSION"] = cmds.about(v=True)
         payload_skeleton["JobInfo"].update({
             "EnvironmentKeyValue%d" % index: "{key}={value}".format(
                 key=key,
@@ -428,7 +430,8 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
                 int(self._instance.data["frameStartHandle"]),
                 int(self._instance.data["frameEndHandle"])),
 
-            "Plugin": "MayaBatch",
+            "Plugin": self._instance.data.get(
+                "mayaRenderPlugin", "MayaPype"),
             "FramesPerTask": self._instance.data.get("framesPerTask", 1)
         }
 


### PR DESCRIPTION
## Maya Pype Deadline plugin

This plugin should be used by Maya jobs submitted from Pype to Deadline as it runs Maya through Pype, setting all needed environments. It is more safe to use our own plugin then hijacking `MayaBatch` plugin as that can break not-pype stuff easily.

This use by default `MayaPype` plugin with option to switch to default `MayaBatch` using option on *Render* instance.

## Installation

To install it just copy content of `/vendor/deadline` to your Deadline Repository and set correct path to `launchers/maya_render.bat/.sh` in plugin Options.

This also resolves some bugs, see below.

Resolves #281 
Resolves #282 

🏴 this is interdependent with pypeclub/pype-setup#38
|---|