### PR TITLE
Feature/291 expose warnings to user in pyblish pype

### DIFF
--- a/pype/tools/pyblish_pype/model.py
+++ b/pype/tools/pyblish_pype/model.py
@@ -490,12 +490,8 @@ class PluginModel(QtGui.QStandardItemModel):
         new_records = result.get("records") or []
         if not has_warning:
             for record in new_records:
-                if not hasattr(record, "levelname"):
-                    continue
-
-                if str(record.levelname).lower() in [
-                    "warning", "critical", "error"
-                ]:
+                level_no = record.get("levelno")
+                if level_no and level_no >= 30:
                     new_flag_states[PluginStates.HasWarning] = True
                     break
 
@@ -789,12 +785,8 @@ class InstanceModel(QtGui.QStandardItemModel):
         new_records = result.get("records") or []
         if not has_warning:
             for record in new_records:
-                if not hasattr(record, "levelname"):
-                    continue
-
-                if str(record.levelname).lower() in [
-                    "warning", "critical", "error"
-                ]:
+                level_no = record.get("levelno")
+                if level_no and level_no >= 30:
                     new_flag_states[InstanceStates.HasWarning] = True
                     break
 

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -984,22 +984,8 @@ class Window(QtWidgets.QDialog):
             self._suspend_logs
         )
 
-        error = result.get("error")
-        if error:
-            records = result.get("records") or []
+        if "error" in result:
             action_state |= PluginActionStates.HasFailed
-            fname, line_no, func, exc = error.traceback
-
-            records.append({
-                "label": str(error),
-                "type": "error",
-                "filename": str(fname),
-                "lineno": str(line_no),
-                "func": str(func),
-                "traceback": error.formatted_traceback
-            })
-
-            result["records"] = records
 
         plugin_item.setData(action_state, Roles.PluginActionProgressRole)
 

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -989,9 +989,14 @@ class Window(QtWidgets.QDialog):
 
         plugin_item.setData(action_state, Roles.PluginActionProgressRole)
 
-        self.plugin_model.update_with_result(result)
-        self.instance_model.update_with_result(result)
         self.terminal_model.update_with_result(result)
+        plugin_item = self.plugin_model.update_with_result(result)
+        instance_item = self.instance_model.update_with_result(result)
+
+        if self.perspective_widget.isVisible():
+            self.perspective_widget.update_context(
+                plugin_item, instance_item
+            )
 
     def closeEvent(self, event):
         """Perform post-flight checks before closing


### PR DESCRIPTION
Issue:
Color visualization of warnings stopped to work because records in update result are already prepared for terminal model.

Changes:
- Access to logs in plugin and instance models does not expect log records but record dictionaries.
- Removed doubled errors after (repair) action process.

Resolves: https://github.com/pypeclub/pype/issues/291