### PR TITLE
Using existing items  for instances.

### DIFF
--- a/pype/plugins/photoshop/create/create_image.py
+++ b/pype/plugins/photoshop/create/create_image.py
@@ -1,12 +1,77 @@
-from avalon import photoshop
+from avalon import api, photoshop
+from avalon.vendor import Qt
 
 
-class CreateImage(photoshop.Creator):
+class CreateImage(api.Creator):
     """Image folder for publish."""
 
     name = "imageDefault"
     label = "Image"
     family = "image"
 
-    def __init__(self, *args, **kwargs):
-        super(CreateImage, self).__init__(*args, **kwargs)
+    def process(self):
+        groups = []
+        layers = []
+        create_group = False
+        group_constant = photoshop.get_com_objects().constants().psLayerSet
+        if (self.options or {}).get("useSelection"):
+            multiple_instances = False
+            selection = photoshop.get_selected_layers()
+
+            if len(selection) > 1:
+                # Ask user whether to create one image or image per selected
+                # item.
+                msg_box = Qt.QtWidgets.QMessageBox()
+                msg_box.setIcon(Qt.QtWidgets.QMessageBox.Warning)
+                msg_box.setText(
+                    "Multiple layers selected."
+                    "\nDo you want to make one image per layer?"
+                )
+                msg_box.setStandardButtons(
+                    Qt.QtWidgets.QMessageBox.Yes |
+                    Qt.QtWidgets.QMessageBox.No |
+                    Qt.QtWidgets.QMessageBox.Cancel
+                )
+                ret = msg_box.exec_()
+                if ret == Qt.QtWidgets.QMessageBox.Yes:
+                    multiple_instances = True
+                elif ret == Qt.QtWidgets.QMessageBox.Cancel:
+                    return
+
+                if multiple_instances:
+                    for item in selection:
+                        if item.LayerType == group_constant:
+                            groups.append(item)
+                        else:
+                            layers.append(item)
+                else:
+                    group = photoshop.group_selected_layers()
+                    group.Name = self.name
+                    groups.append(group)
+
+            elif len(selection) == 1:
+                # One selected item. Use group if its a LayerSet (group), else
+                # create a new group.
+                if selection[0].LayerType == group_constant:
+                    groups.append(selection[0])
+                else:
+                    layers.append(selection[0])
+            elif len(selection) == 0:
+                # No selection creates an empty group.
+                create_group = True
+        else:
+            create_group = True
+
+        if create_group:
+            group = photoshop.app().ActiveDocument.LayerSets.Add()
+            group.Name = self.name
+            groups.append(group)
+
+        for layer in layers:
+            photoshop.select_layers([layer])
+            group = photoshop.group_selected_layers()
+            group.Name = layer.Name
+            groups.append(group)
+
+        for group in groups:
+            photoshop.imprint(group, self.data)

--- a/pype/plugins/photoshop/publish/validate_naming.py
+++ b/pype/plugins/photoshop/publish/validate_naming.py
@@ -1,0 +1,47 @@
+import os
+
+import pyblish.api
+import pype.api
+from avalon import photoshop
+
+
+class ValidateNamingRepair(pyblish.api.Action):
+    """Repair the instance asset."""
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+
+        # Get the errored instances
+        failed = []
+        for result in context.data["results"]:
+            if (result["error"] is not None and result["instance"] is not None
+                    and result["instance"] not in failed):
+                failed.append(result["instance"])
+
+        # Apply pyblish.logic to get the instances for the plug-in
+        instances = pyblish.api.instances_by_plugin(failed, plugin)
+
+        for instance in instances:
+            instance[0].Name = instance.data["name"].replace(" ", "_")
+
+        return True
+
+
+class ValidateNaming(pyblish.api.InstancePlugin):
+    """Validate the instance name.
+
+    Spaces in names are not allowed. Will be replace with underscores.
+    """
+
+    label = "Validate Naming"
+    hosts = ["photoshop"]
+    order = pype.api.ValidateContentsOrder
+    families = ["image"]
+    actions = [ValidateNamingRepair]
+
+    def process(self, instance):
+        msg = "Name \"{}\" is not allowed.".format(instance.data["name"])
+        assert " " not in instance.data["name"], msg

--- a/pype/plugins/photoshop/publish/validate_naming.py
+++ b/pype/plugins/photoshop/publish/validate_naming.py
@@ -1,8 +1,5 @@
-import os
-
 import pyblish.api
 import pype.api
-from avalon import photoshop
 
 
 class ValidateNamingRepair(pyblish.api.Action):


### PR DESCRIPTION
When using the selection in Photoshop for instance creation, you can now use existing folders. Using the selection has the following features:

- No selection creates an empty folder.
- Single item selection
    - Existing group will be used.
    - Layer will be grouped.
- Multiple items selection
    - User gets asked whether to create one group for all or individual groups.
    - If creating individual groups, then each item in selection gets treated as "Single item selection".

closes https://github.com/pypeclub/fourthwall-config/issues/24