### PR TITLE
Bugfix/pyblish action error fix

### DIFF
--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -984,7 +984,7 @@ class Window(QtWidgets.QDialog):
             self._suspend_logs
         )
 
-        if "error" in result:
+        if result.get("error"):
             action_state |= PluginActionStates.HasFailed
 
         plugin_item.setData(action_state, Roles.PluginActionProgressRole)


### PR DESCRIPTION
Issue:
Result of action is checked for error with existence of `"error"` key which is always in result. So even successful action seems like is crashed.

Solved:
Changed check of "error" of result after action.