### PR TITLE
fixing vray rendering on deadline

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -536,6 +536,15 @@ class ExpectedFilesVray(AExpectedFiles):
         prefix = "{}_<aov>".format(prefix)
         return prefix
 
+    def _get_layer_data(self):
+        """Override to get vray specific extension."""
+        layer_data = super(ExpectedFilesVray, self)._get_layer_data()
+        default_ext = cmds.getAttr("vraySettings.imageFormatStr")
+        if default_ext == "exr (multichannel)" or default_ext == "exr (deep)":
+            default_ext = "exr"
+        layer_data["defaultExt"] = default_ext
+        return layer_data
+
     def get_files(self):
         """Get expected files.
 

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -166,8 +166,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         "FTRACK_SERVER",
         "PYPE_METADATA_FILE",
         "AVALON_PROJECT",
-        "PYPE_LOG_NO_COLORS",
-        "PYPE_PYTHON_EXE"
+        "PYPE_LOG_NO_COLORS"
     ]
 
     # custom deadline atributes
@@ -191,6 +190,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
     # list of family names to transfer to new family if present
     families_transfer = ["render3d", "render2d", "ftrack", "slate"]
+    plugin_python_version = "3.7"
 
     def _submit_deadline_post_job(self, instance, job):
         """Submit publish job to Deadline.
@@ -202,9 +202,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         """
         data = instance.data.copy()
         subset = data["subset"]
-        job_name = "{batch} - {subset} [publish image sequence]".format(
-            batch=job["Props"]["Name"], subset=subset
-        )
+        job_name = "Publish - {subset}".format(subset=subset)
 
         output_dir = instance.data["outputDir"]
         # Convert output dir to `{root}/rest/of/path/...` with Anatomy
@@ -240,7 +238,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "OutputDirectory0": output_dir
             },
             "PluginInfo": {
-                "Version": "3.6",
+                "Version": self.plugin_python_version,
                 "ScriptFile": _get_script(),
                 "Arguments": "",
                 "SingleFrameOnly": "True",

--- a/pype/plugins/maya/publish/validate_rendersettings.py
+++ b/pype/plugins/maya/publish/validate_rendersettings.py
@@ -56,7 +56,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
 
         'arnold': 'maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>',
         'redshift': 'maya/<Scene>/<RenderLayer>/<RenderLayer>',
-        'vray': 'maya/<scene>/<Layer>/<Layer>',
+        'vray': 'maya/<Scene>/<Layer>/<Layer>',
         'renderman': '<layer>_<aov>.<f4>.<ext>'
     }
 
@@ -77,7 +77,7 @@ class ValidateRenderSettings(pyblish.api.InstancePlugin):
     R_SCENE_TOKEN = re.compile(r'%s|<scene>', re.IGNORECASE)
 
     DEFAULT_PADDING = 4
-    VRAY_PREFIX = "maya/<scene>/<Layer>/<Layer>"
+    VRAY_PREFIX = "maya/<Scene>/<Layer>/<Layer>"
     DEFAULT_PREFIX = "maya/<Scene>/<RenderLayer>/<RenderLayer>_<RenderPass>"
 
     def process(self, instance):

--- a/pype/plugins/maya/publish/validate_vray_translator_settings.py
+++ b/pype/plugins/maya/publish/validate_vray_translator_settings.py
@@ -46,7 +46,7 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
             invalid = True
 
         vrscene_filename = cmds.getAttr("{}.vrscene_filename".format(node))
-        if vrscene_filename != "vrayscene/<Scene>/<Scene>_<Layer>/<Layer>":
+        if vrscene_filename != "vrayscene/<Scene>/<Layer>/<Layer>":
             cls.log.error("Template for file name is wrong")
             invalid = True
 
@@ -65,5 +65,5 @@ class ValidateVRayTranslatorEnabled(pyblish.api.ContextPlugin):
         cmds.setAttr("{}.vrscene_on".format(node), True)
         cmds.setAttr("{}.misc_eachFrameInFile".format(node), True)
         cmds.setAttr("{}.vrscene_filename".format(node),
-                     "vrayscene/<Scene>/<Scene>_<Layer>/<Layer>",
+                     "vrayscene/<Scene>/<Layer>/<Layer>",
                      type="string")


### PR DESCRIPTION
This PR includes various fixes for bugs preventing sucessful render of Vray scenes on Deadline.

- it is fixing output paths
- moving deadline python plugin python version to class attribute so it can be configured by preset
- removing `PYPE_PYTHON_EXE` from passed variables to job as it was braking Pype self-installing
- fixing Vray file extension detection