### PR TITLE
Maya: auto-open latest workfile

### DIFF
--- a/pype/hooks/maya/prelaunch.py
+++ b/pype/hooks/maya/prelaunch.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Prelaunch hook for Maya.
+
+This hook automatically open latest workfile upon startup.
+"""
+
+import logging
+import os
+from pype.lib import PypeHook
+from pype.api import (
+    Logger,
+    get_last_version_from_path
+)
+
+log = logging.getLogger(__name__)
+
+
+class MayaPrelaunchHook(PypeHook):
+    """Prelaunch hook."""
+
+    workfile_ext = "scn"
+
+    def __init__(self, logger=None):
+        """Constructor."""
+        if not logger:
+            self.log = Logger().get_logger(self.__class__.__name__)
+        else:
+            self.log = logger
+
+        self.signature = "( {} )".format(self.__class__.__name__)
+
+    def execute(self, *args, env: dict = None) -> bool:
+        """Execute method.
+
+        Args:
+            env (dict): environment of application to be launched.
+
+        Returns:
+            True on success.
+
+        """
+        if not env:
+            env = os.environ
+
+        ma = get_last_version_from_path(env.get("AVALON_WORKDIR"), [".ma"])
+        mb = get_last_version_from_path(env.get("AVALON_WORKDIR"), [".mb"])
+
+        if not ma or not mb:
+            return True
+
+        last = sorted([ma, mb])[-1]
+
+        env["PYPE_OPEN_WORKFILE"] = os.path.join(
+            env.get("AVALON_WORKDIR"), last)
+
+        self.log.info("--- using latest workfile at [ {} ]".format(
+            env["PYPE_OPEN_WORKFILE"]))
+        return True


### PR DESCRIPTION
## Feature description

This is utilizing pre-launch hook to open Maya with latest workfile for given task. To find it, it is parsing all scene files in workfile directory and choosing the one with highest version number. The caveat of this is that it won't work correctly if there are more scene file names:

```
model_v001.mb
model_v002.mb
box_v001.ma
box_v002.ma
box_v003.ma
```

This will pick `model_v002.mb` as latest workfile as it is latest alphabetically.

🏴 depends on PR in pypeclub/pype-config#55
|---|