### PR TITLE
Increase socket thread timeout.

### DIFF
--- a/pype/modules/ftrack/ftrack_server/socket_thread.py
+++ b/pype/modules/ftrack/ftrack_server/socket_thread.py
@@ -11,7 +11,7 @@ from pype.api import Logger
 class SocketThread(threading.Thread):
     """Thread that checks suprocess of storer of processor of events"""
 
-    MAX_TIMEOUT = 35
+    MAX_TIMEOUT = 120
 
     def __init__(self, name, port, filepath, additional_args=[]):
         super(SocketThread, self).__init__()

--- a/pype/modules/ftrack/ftrack_server/socket_thread.py
+++ b/pype/modules/ftrack/ftrack_server/socket_thread.py
@@ -11,7 +11,7 @@ from pype.api import Logger
 class SocketThread(threading.Thread):
     """Thread that checks suprocess of storer of processor of events"""
 
-    MAX_TIMEOUT = 120
+    MAX_TIMEOUT = int(os.environ.get("PYPE_FTRACK_SOCKET_TIMEOUT", 45))
 
     def __init__(self, name, port, filepath, additional_args=[]):
         super(SocketThread, self).__init__()


### PR DESCRIPTION
I'm not sure how to tackle this. A client user was having issues with the current timeout, so just increasing it solved the issue.

Should this maybe be configurable or look at something like `AVALON_TIMEOUT`?