### PR TITLE
Bugfix/mongo url components

### DIFF
--- a/pype/modules/ftrack/ftrack_server/lib.py
+++ b/pype/modules/ftrack/ftrack_server/lib.py
@@ -44,15 +44,8 @@ def get_ftrack_event_mongo_info():
     mongo_url = os.environ.get("FTRACK_EVENTS_MONGO_URL")
     if mongo_url is not None:
         components = decompose_url(mongo_url)
-        _used_ftrack_url = True
     else:
         components = get_default_components()
-        _used_ftrack_url = False
-
-    if not _used_ftrack_url or components["database"] is None:
-        components["database"] = database_name
-
-    components.pop("collection", None)
 
     uri = compose_url(**components)
 

--- a/pype/modules/ftrack/ftrack_server/lib.py
+++ b/pype/modules/ftrack/ftrack_server/lib.py
@@ -26,7 +26,7 @@ from pype.api import (
     compose_url
 )
 
-from pype.modules.ftrack.lib.custom_db_connector import DbConnector
+from pype.modules.ftrack.lib.custom_db_connector import CustomDbConnector
 
 
 TOPIC_STATUS_SERVER = "pype.event.server.status"
@@ -166,10 +166,10 @@ class ProcessEventHub(SocketBaseEventHub):
     pypelog = Logger().get_logger("Session Processor")
 
     def __init__(self, *args, **kwargs):
-        self.dbcon = DbConnector(
+        self.dbcon = CustomDbConnector(
             self.uri,
-            self.port,
             self.database,
+            self.port,
             self.table_name
         )
         super(ProcessEventHub, self).__init__(*args, **kwargs)

--- a/pype/modules/ftrack/ftrack_server/sub_event_storer.py
+++ b/pype/modules/ftrack/ftrack_server/sub_event_storer.py
@@ -12,7 +12,7 @@ from pype.modules.ftrack.ftrack_server.lib import (
     get_ftrack_event_mongo_info,
     TOPIC_STATUS_SERVER, TOPIC_STATUS_SERVER_RESULT
 )
-from pype.modules.ftrack.lib.custom_db_connector import DbConnector
+from pype.modules.ftrack.lib.custom_db_connector import CustomDbConnector
 from pype.api import Logger
 
 log = Logger().get_logger("Event storer")
@@ -24,7 +24,7 @@ class SessionFactory:
 
 
 uri, port, database, table_name = get_ftrack_event_mongo_info()
-dbcon = DbConnector(uri, port, database, table_name)
+dbcon = CustomDbConnector(uri, database, port, table_name)
 
 # ignore_topics = ["ftrack.meta.connected"]
 ignore_topics = []

--- a/pype/modules/ftrack/lib/custom_db_connector.py
+++ b/pype/modules/ftrack/lib/custom_db_connector.py
@@ -40,7 +40,7 @@ def auto_reconnect(func):
 
 
 def check_active_table(func):
-    """Check if DbConnector has active table before db method is called"""
+    """Check if CustomDbConnector has active collection."""
     @functools.wraps(func)
     def decorated(obj, *args, **kwargs):
         if not obj.active_table:
@@ -49,7 +49,7 @@ def check_active_table(func):
     return decorated
 
 
-class DbConnector:
+class CustomDbConnector:
     log = logging.getLogger(__name__)
     timeout = 1000
 
@@ -85,7 +85,7 @@ class DbConnector:
         # not all methods of PyMongo database are implemented with this it is
         # possible to use them too
         try:
-            return super(DbConnector, self).__getattribute__(attr)
+            return super(CustomDbConnector, self).__getattribute__(attr)
         except AttributeError:
             if self.active_table is None:
                 raise NotActiveTable()

--- a/pype/modules/ftrack/lib/custom_db_connector.py
+++ b/pype/modules/ftrack/lib/custom_db_connector.py
@@ -49,17 +49,6 @@ def check_active_table(func):
     return decorated
 
 
-def check_active_table(func):
-    """Handling auto reconnect in 3 retry times"""
-    @functools.wraps(func)
-    def decorated(obj, *args, **kwargs):
-        if not obj.active_table:
-            raise NotActiveTable("Active table is not set. (This is bug)")
-        return func(obj, *args, **kwargs)
-
-    return decorated
-
-
 class DbConnector:
     log = logging.getLogger(__name__)
     timeout = 1000

--- a/pype/modules/ftrack/lib/custom_db_connector.py
+++ b/pype/modules/ftrack/lib/custom_db_connector.py
@@ -54,7 +54,7 @@ class DbConnector:
     timeout = 1000
 
     def __init__(
-        self, uri, port=None, database_name=None, table_name=None
+        self, uri, database_name, port=None, table_name=None
     ):
         self._mongo_client = None
         self._sentry_client = None

--- a/pype/modules/ftrack/lib/custom_db_connector.py
+++ b/pype/modules/ftrack/lib/custom_db_connector.py
@@ -68,9 +68,6 @@ class DbConnector:
             port = components.get("port")
 
         if database_name is None:
-            database_name = components.get("database")
-
-        if database_name is None:
             raise ValueError(
                 "Database is not defined for connection. {}".format(uri)
             )


### PR DESCRIPTION
## Changes
- changed name of class of `DbConnection` to `CustomDbConnector` in `~/pype/module/ftrack/lib/custom_db_connector.py`
- argument `database_name` is now required in `CustomDbConnector`
- Mongo url is not composed with database name and collection name