### PR TITLE
hotfix/allow not set template names

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -727,7 +727,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
         task_name = io.Session.get("AVALON_TASK")
         family = self.main_family_from_instance(instance)
 
-        matching_profiles = None
+        matching_profiles = {}
         highest_value = -1
         self.log.info(self.template_name_profiles)
         for name, filters in self.template_name_profiles.items():
@@ -745,7 +745,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 value += 1
 
             if value > highest_value:
-                matching_profiles = {}
                 highest_value = value
 
             if value == highest_value:


### PR DESCRIPTION
## Issue
Plugin `IntegrateAssetNew` has attribute `template_name_profiles` which helps to identify which template key will be used for publishing. Publishing will crash if `template_name_profiles` is set and default template name (`"publish"`) is not defined in `template_name_profiles`.

## Solution
Don't use None as default value when looking for matching template key