### PR TITLE
Bugfix/206 ftrack delete action cause circular error

### DIFF
--- a/pype/modules/ftrack/actions/action_delete_asset.py
+++ b/pype/modules/ftrack/actions/action_delete_asset.py
@@ -538,16 +538,16 @@ class DeleteAssetSubset(BaseAction):
                 self._filter_entities_to_delete(ftrack_ids_to_delete, session)
             )
             for entity in ftrack_ents_to_delete:
-                self.session.delete(entity)
+                session.delete(entity)
                 try:
-                    self.session.commit()
+                    session.commit()
                 except Exception:
                     ent_path = "/".join(
                         [ent["name"] for ent in entity["link"]]
                     )
                     msg = "Failed to delete entity"
                     report_messages[msg].append(ent_path)
-                    self.session.rollback()
+                    session.rollback()
                     self.log.warning(
                         "{} <{}>".format(msg, ent_path),
                         exc_info=True
@@ -563,7 +563,7 @@ class DeleteAssetSubset(BaseAction):
                 for name in asset_names_to_delete
             ])
             # Find assets of selected entities with names of checked subsets
-            assets = self.session.query((
+            assets = session.query((
                 "select id from Asset where"
                 " context_id in ({}) and name in ({})"
             ).format(joined_not_deleted, joined_asset_names)).all()
@@ -573,11 +573,11 @@ class DeleteAssetSubset(BaseAction):
                 ", ".join([asset["id"] for asset in assets])
             ))
             for asset in assets:
-                self.session.delete(asset)
+                session.delete(asset)
                 try:
-                    self.session.commit()
+                    session.commit()
                 except Exception:
-                    self.session.rollback()
+                    session.rollback()
                     msg = "Failed to delete asset"
                     report_messages[msg].append(asset["id"])
                     self.log.warning(

--- a/pype/modules/ftrack/actions/action_delete_asset.py
+++ b/pype/modules/ftrack/actions/action_delete_asset.py
@@ -497,9 +497,8 @@ class DeleteAssetSubset(BaseAction):
             for entity in entities:
                 ftrack_id = entity["id"]
                 ftrack_id_name_map[ftrack_id] = entity["name"]
-                if ftrack_id in ftrack_ids_to_delete:
-                    continue
-                not_deleted_entities_id.append(ftrack_id)
+                if ftrack_id not in ftrack_ids_to_delete:
+                    not_deleted_entities_id.append(ftrack_id)
 
         mongo_proc_txt = "MongoProcessing: "
         ftrack_proc_txt = "Ftrack processing: "
@@ -581,7 +580,7 @@ class DeleteAssetSubset(BaseAction):
                     msg = "Failed to delete asset"
                     report_messages[msg].append(asset["id"])
                     self.log.warning(
-                        "{} <{}>".format(asset["id"]),
+                        "Asset: {} <{}>".format(asset["name"], asset["id"]),
                         exc_info=True
                     )
 


### PR DESCRIPTION
## Changes
Hierarchical entities to delete are filtered. Only top hierarchy entities are set for deletion to avoid circular dependency error.

This fix worked with my testing data, best would be to test with production (they may be more complex)...

Resolves: https://github.com/pypeclub/pype/issues/206