### PR TITLE
stop appending of tools environment to existing env

### DIFF
--- a/pype/modules/ftrack/lib/ftrack_app_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_app_handler.py
@@ -213,7 +213,6 @@ class AppAction(BaseAction):
         tools_env = acre.get_tools(tools_attr)
         env = acre.compute(tools_env)
         env = acre.merge(env, current_env=dict(prep_env))
-        env = acre.append(dict(prep_env), env)
 
         # Get path to execute
         st_temp_path = os.environ["PYPE_CONFIG"]


### PR DESCRIPTION
## Problem

Environment variables from tools are appended to existing environment. This behaviour is causing troubles for those variables that are not meant to have multiple values.

**For example:**

You have system-wide variable:
```
OCIO="/path/to/ocio.config
```

and tool environment file **foo.json**:
```javascript
{
    "OCIO": "/foo/bar/ocio.config"
}
```

this will result in `OCIO="/path/to/ocio.config:/foo/bar/ocio.config"` and that is invalid.

## Solution

This PR is disabling this behaviour the same way as we did it for application environments. So if we need to append some variable to another, we have to explicitly state so;
```javascript
{
    "PATH": ["/some/path", "{PATH}"]
}
```

🏴 similar PR is made in pypeclub/avalon-core#161
|---|