### PR TITLE
simplify apps and tools configuration

### DIFF
--- a/pype/lib.py
+++ b/pype/lib.py
@@ -520,14 +520,6 @@ def set_io_database():
     io.install()
 
 
-def get_all_avalon_projects():
-    db = get_avalon_database()
-    projects = []
-    for name in db.collection_names():
-        projects.append(db[name].find_one({'type': 'project'}))
-    return projects
-
-
 def filter_pyblish_plugins(plugins):
     """
     This servers as plugin filter / modifier for pyblish. It will load plugin

--- a/pype/modules/ftrack/actions/action_application_loader.py
+++ b/pype/modules/ftrack/actions/action_application_loader.py
@@ -75,6 +75,16 @@ def register(session, plugins_presets={}):
         }
         apps.append(app_data)
 
+    if missing_app_names:
+        log.debug(
+            "Apps not defined in applications usage. ({})".format(
+                ", ".join((
+                    "\"{}\"".format(app_name)
+                    for app_name in missing_app_names
+                ))
+            )
+        )
+
     apps = sorted(apps, key=lambda app: app["name"])
     app_counter = 0
     for app in apps:

--- a/pype/modules/ftrack/actions/action_application_loader.py
+++ b/pype/modules/ftrack/actions/action_application_loader.py
@@ -3,8 +3,7 @@ import toml
 import time
 from pype.modules.ftrack.lib import AppAction
 from avalon import lib
-from pype.api import Logger
-from pype.lib import get_all_avalon_projects
+from pype.api import Logger, config
 
 log = Logger().get_logger(__name__)
 
@@ -49,17 +48,26 @@ def registerApp(app, session, plugins_presets):
 
 
 def register(session, plugins_presets={}):
-    # WARNING getting projects only helps to check connection to mongo
-    # - without will `discover` of ftrack apps actions take ages
-    result = get_all_avalon_projects()
+    app_usages = (
+        config.get_presets()
+        .get("global", {})
+        .get("applications")
+    ) or {}
 
     apps = []
-
+    missing_app_names = []
     launchers_path = os.path.join(os.environ["PYPE_CONFIG"], "launchers")
     for file in os.listdir(launchers_path):
         filename, ext = os.path.splitext(file)
         if ext.lower() != ".toml":
             continue
+
+        app_usage = app_usages.get(filename)
+        if not app_usage:
+            if app_usage is None:
+                missing_app_names.append(filename)
+            continue
+
         loaded_data = toml.load(os.path.join(launchers_path, file))
         app_data = {
             "name": filename,
@@ -67,7 +75,7 @@ def register(session, plugins_presets={}):
         }
         apps.append(app_data)
 
-    apps = sorted(apps, key=lambda x: x['name'])
+    apps = sorted(apps, key=lambda app: app["name"])
     app_counter = 0
     for app in apps:
         try:
@@ -76,7 +84,7 @@ def register(session, plugins_presets={}):
                 time.sleep(0.1)
             app_counter += 1
         except Exception as exc:
-            log.exception(
+            log.warning(
                 "\"{}\" - not a proper App ({})".format(app['name'], str(exc)),
                 exc_info=True
             )

--- a/pype/modules/ftrack/actions/action_clean_hierarchical_attributes.py
+++ b/pype/modules/ftrack/actions/action_clean_hierarchical_attributes.py
@@ -1,7 +1,7 @@
 import collections
 import ftrack_api
 from pype.modules.ftrack.lib import BaseAction, statics_icon
-from pype.modules.ftrack.lib.avalon_sync import get_avalon_attr
+from pype.modules.ftrack.lib.avalon_sync import get_pype_attr
 
 
 class CleanHierarchicalAttrsAction(BaseAction):
@@ -48,7 +48,7 @@ class CleanHierarchicalAttrsAction(BaseAction):
         )
         entity_ids_joined = ", ".join(all_entities_ids)
 
-        attrs, hier_attrs = get_avalon_attr(session)
+        attrs, hier_attrs = get_pype_attr(session)
 
         for attr in hier_attrs:
             configuration_key = attr["key"]

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -398,7 +398,9 @@ class CustomAttributes(BaseAction):
     def custom_attributes_from_file(self, event):
         presets = config.get_presets()["ftrack"]["ftrack_custom_attributes"]
         for cust_attr_data in presets:
-            self.process_attr_data(cust_attr_data, event)
+            key = applications.get("key")
+            if key != "applications":
+                self.process_attr_data(cust_attr_data, event)
 
     def process_attr_data(self, cust_attr_data, event):
         cust_attr_name = cust_attr_data.get(

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -12,92 +12,109 @@ from pype.api import config
 
 """
 This action creates/updates custom attributes.
-- first part take care about avalon_mongo_id attribute
-- second part is based on json file in templates:
-    ~/PYPE-TEMPLATES/presets/ftrack/ftrack_custom_attributes.json
-    - you can add Custom attributes based on these conditions
+## First part take care about special attributes
+    - `avalon_mongo_id` for storing Avalon MongoID
+    - `applications` based on applications usages
+    - `tools` based on tools usages
+
+## Second part is based on json file in ftrack module.
+File location: `~/pype/pype/modules/ftrack/ftrack_custom_attributes.json`
+
+Data in json file is nested dictionary. Keys in first dictionary level
+represents Ftrack entity type (task, show, assetversion, user, list, asset)
+and dictionary value define attribute.
+
+There is special key for hierchical attributes `is_hierarchical`.
+
+Entity types `task` requires to define task object type (Folder, Shot,
+Sequence, Task, Library, Milestone, Episode, Asset Build, etc.) at second
+dictionary level, task's attributes are nested more.
+
+*** Not Changeable *********************************************************
+
+group (string)
+    - name of group
+    - based on attribute `pype.modules.ftrack.lib.CUST_ATTR_GROUP`
+        - "pype" by default
 
 *** Required ***************************************************************
 
 label (string)
-  - label that will show in ftrack
+    - label that will show in ftrack
 
 key (string)
-  - must contain only chars [a-z0-9_]
+    - must contain only chars [a-z0-9_]
 
 type (string)
-  - type of custom attribute
-  - possibilities: text, boolean, date, enumerator, dynamic enumerator, number
+    - type of custom attribute
+    - possibilities:
+        text, boolean, date, enumerator, dynamic enumerator, number
 
 *** Required with conditions ***********************************************
 
-entity_type (string)
-  - if 'is_hierarchical' is set to False
-  - type of entity
-  - possibilities: task, show, assetversion, user, list, asset
-
 config (dictionary)
-   - for each entity type different requirements and possibilities:
-       - enumerator:    multiSelect = True/False(default: False)
-                        data = {key_1:value_1,key_2:value_2,..,key_n:value_n}
-                        - 'data' is Required value with enumerator
-                        - 'key' must contain only chars [a-z0-9_]
+    - for each attribute type different requirements and possibilities:
+        - enumerator:
+            multiSelect = True/False(default: False)
+            data = {key_1:value_1,key_2:value_2,..,key_n:value_n}
+                - 'data' is Required value with enumerator
+                - 'key' must contain only chars [a-z0-9_]
 
-       - number:        isdecimal = True/False(default: False)
+        - number:
+            isdecimal = True/False(default: False)
 
-       - text:          markdown = True/False(default: False)
+        - text:
+            markdown = True/False(default: False)
 
-object_type (string)
-  - IF ENTITY_TYPE is set to 'task'
-  - default possibilities: Folder, Shot, Sequence, Task, Library,
-                           Milestone, Episode, Asset Build,...
-
-*** Optional ***************************************************************
+*** Presetable keys **********************************************************
 
 write_security_roles/read_security_roles (array of strings)
-  - default: ["ALL"]
-  - strings should be role names (e.g.: ["API", "Administrator"])
-  - if set to ["ALL"] - all roles will be availabled
-  - if first is 'except' - roles will be set to all except roles in array
-       - Warning: Be carefull with except - roles can be different by company
-       - example:
-          write_security_roles = ["except", "User"]
-          read_security_roles = ["ALL"]
-              - User is unable to write but can read
-
-group (string)
-  - default: None
-  - name of group
+    - default: ["ALL"]
+    - strings should be role names (e.g.: ["API", "Administrator"])
+    - if set to ["ALL"] - all roles will be availabled
+    - if first is 'except' - roles will be set to all except roles in array
+        - Warning: Be carefull with except - roles can be different by company
+        - example:
+            write_security_roles = ["except", "User"]
+            read_security_roles = ["ALL"] # (User is can only read)
 
 default
-  - default: None
-  - sets default value for custom attribute:
-       - text -> string
-       - number -> integer
-       - enumerator -> array with string of key/s
-       - boolean -> bool true/false
-       - date -> string in format: 'YYYY.MM.DD' or 'YYYY.MM.DD HH:mm:ss'
-             - example: "2018.12.24" / "2018.1.1 6:0:0"
-       - dynamic enumerator -> DON'T HAVE DEFAULT VALUE!!!
+    - default: None
+    - sets default value for custom attribute:
+        - text -> string
+        - number -> integer
+        - enumerator -> array with string of key/s
+        - boolean -> bool true/false
+        - date -> string in format: 'YYYY.MM.DD' or 'YYYY.MM.DD HH:mm:ss'
+            - example: "2018.12.24" / "2018.1.1 6:0:0"
+        - dynamic enumerator -> DON'T HAVE DEFAULT VALUE!!!
 
-is_hierarchical (bool)
-  - default: False
-  - will set hierachical attribute
-  - False by default
-
-EXAMPLE:
-{
+Example:
+```
+"show": {
     "avalon_auto_sync": {
-        "label": "Avalon auto-sync",
-        "key": "avalon_auto_sync",
-        "type": "boolean",
-        "entity_type": "show",
-        "group": "avalon",
-        "default": false,
-        "write_security_role": ["API","Administrator"],
-        "read_security_role": ["API","Administrator"]
+      "label": "Avalon auto-sync",
+      "type": "boolean",
+      "write_security_role": ["API", "Administrator"],
+      "read_security_role": ["API", "Administrator"]
+    }
+},
+"is_hierarchical": {
+    "fps": {
+        "label": "FPS",
+        "type": "number",
+        "config": {"isdecimal": true}
+    }
+},
+"task": {
+    "library": {
+        "my_attr_name": {
+            "label": "My Attr",
+            "type": "number"
+        }
     }
 }
+```
 """
 
 

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -1,4 +1,6 @@
+import os
 import collections
+import toml
 import json
 import arrow
 import ftrack_api
@@ -144,6 +146,7 @@ class CustomAttributes(BaseAction):
         try:
             self.prepare_global_data(session)
             self.avalon_mongo_id_attributes(session, event)
+            self.applications_attribute(event)
             self.custom_attributes_from_file(event)
 
             job['status'] = 'done'
@@ -377,6 +380,20 @@ class CustomAttributes(BaseAction):
                 )
             )
         return app_definitions
+
+    def applications_attribute(self, event):
+        applications_custom_attr_data = {
+            "label": "Applications",
+            "key": "applications",
+            "type": "enumerator",
+            "entity_type": "show",
+            "group": "avalon",
+            "config": {
+                "multiselect": True,
+                "data": self.application_definitions()
+            }
+        }
+        self.process_attr_data(applications_custom_attr_data, event)
 
     def custom_attributes_from_file(self, event):
         presets = config.get_presets()["ftrack"]["ftrack_custom_attributes"]

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -455,10 +455,20 @@ class CustomAttributes(BaseAction):
 
         # Prepare data of entity specific attributes
         for entity_type, cust_attr_datas in cust_attr_def.items():
-            for key, cust_attr_data in cust_attr_datas.items():
-                cust_attr_data["key"] = key
-                cust_attr_data["entity_type"] = entity_type
-                attrs_data.append(cust_attr_data)
+            if entity_type.lower() != "task":
+                for key, cust_attr_data in cust_attr_datas.items():
+                    cust_attr_data["key"] = key
+                    cust_attr_data["entity_type"] = entity_type
+                    attrs_data.append(cust_attr_data)
+                continue
+
+            # Task should have nested level for object type
+            for object_type, _cust_attr_datas in cust_attr_datas.items():
+                for key, cust_attr_data in _cust_attr_datas.items():
+                    cust_attr_data["key"] = key
+                    cust_attr_data["entity_type"] = entity_type
+                    cust_attr_data["object_type"] = object_type
+                    attrs_data.append(cust_attr_data)
 
         # Process prepared data
         for cust_attr_data in attrs_data:

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -144,7 +144,7 @@ class CustomAttributes(BaseAction):
         try:
             self.prepare_global_data(session)
             self.avalon_mongo_id_attributes(session, event)
-            self.custom_attributes_from_file(session, event)
+            self.custom_attributes_from_file(event)
 
             job['status'] = 'done'
             session.commit()
@@ -335,36 +335,40 @@ class CustomAttributes(BaseAction):
                     exc_info=True
                 )
 
-    def custom_attributes_from_file(self, session, event):
-        presets = config.get_presets()['ftrack']['ftrack_custom_attributes']
 
-        for cust_attr_data in presets:
-            cust_attr_name = cust_attr_data.get(
-                'label',
-                cust_attr_data.get('key')
             )
-            try:
-                data = {}
-                # Get key, label, type
-                data.update(self.get_required(cust_attr_data))
-                # Get hierachical/ entity_type/ object_id
-                data.update(self.get_entity_type(cust_attr_data))
-                # Get group, default, security roles
-                data.update(self.get_optional(cust_attr_data))
-                # Process data
-                self.process_attribute(data)
 
-            except CustAttrException as cae:
-                if cust_attr_name:
-                    msg = 'Custom attribute error "{}" - {}'.format(
-                        cust_attr_name, str(cae)
-                    )
-                else:
-                    msg = 'Custom attribute error - {}'.format(str(cae))
-                self.log.warning(msg, exc_info=True)
-                self.show_message(event, msg)
+    def custom_attributes_from_file(self, event):
+        presets = config.get_presets()["ftrack"]["ftrack_custom_attributes"]
+        for cust_attr_data in presets:
+            self.process_attr_data(cust_attr_data, event)
 
-        return True
+    def process_attr_data(self, cust_attr_data, event):
+        cust_attr_name = cust_attr_data.get(
+            "label",
+            cust_attr_data.get("key")
+        )
+
+        try:
+            data = {}
+            # Get key, label, type
+            data.update(self.get_required(cust_attr_data))
+            # Get hierachical/ entity_type/ object_id
+            data.update(self.get_entity_type(cust_attr_data))
+            # Get group, default, security roles
+            data.update(self.get_optional(cust_attr_data))
+            # Process data
+            self.process_attribute(data)
+
+        except CustAttrException as cae:
+            if cust_attr_name:
+                msg = 'Custom attribute error "{}" - {}'.format(
+                    cust_attr_name, str(cae)
+                )
+            else:
+                msg = 'Custom attribute error - {}'.format(str(cae))
+            self.log.warning(msg, exc_info=True)
+            self.show_message(event, msg)
 
     def process_attribute(self, data):
         existing_atr = self.session.query('CustomAttributeConfiguration').all()

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -395,6 +395,61 @@ class CustomAttributes(BaseAction):
         }
         self.process_attr_data(applications_custom_attr_data, event)
 
+    def tools_attribute(self, event):
+        tool_usages = self.presets.get("global", {}).get("tools") or {}
+        tools_data = []
+        for tool_name, usage in tool_usages.items():
+            if usage:
+                tools_data.append({tool_name: tool_name})
+
+        tools_custom_attr_data = {
+            "label": "Tools",
+            "key": "tools_env",
+            "type": "enumerator",
+            "is_hierarchical": True,
+            "group": CUST_ATTR_GROUP,
+            "config": {
+                "multiselect": True,
+                "data": tools_data
+            }
+        }
+        self.process_attr_data(tools_custom_attr_data, event)
+
+    def intent_attribute(self, event):
+        intent_key_values = (
+            self.presets
+            .get("global", {})
+            .get("intent", {})
+            .get("items", {})
+        ) or {}
+
+        intent_values = []
+        for key, label in intent_key_values.items():
+            if not key or not label:
+                self.log.info((
+                    "Skipping intent row: {{\"{}\": \"{}\"}}"
+                    " because of empty key or label."
+                ).format(key, label))
+                continue
+
+            intent_values.append({key: label})
+
+        if not intent_values:
+            return
+
+        intent_custom_attr_data = {
+            "label": "Intent",
+            "key": "intent",
+            "type": "enumerator",
+            "entity_type": "assetversion",
+            "group": CUST_ATTR_GROUP,
+            "config": {
+                "multiselect": False,
+                "data": intent_values
+            }
+        }
+        self.process_attr_data(intent_custom_attr_data, event)
+
     def custom_attributes_from_file(self, event):
         presets = config.get_presets()["ftrack"]["ftrack_custom_attributes"]
         for cust_attr_data in presets:

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -11,7 +11,7 @@ from avalon.vendor import filelink
 
 from pype.api import Anatomy
 from pype.modules.ftrack.lib import BaseAction, statics_icon
-from pype.modules.ftrack.lib.avalon_sync import CustAttrIdKey
+from pype.modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 from pype.modules.ftrack.lib.io_nonsingleton import DbConnector
 
 
@@ -243,7 +243,7 @@ class Delivery(BaseAction):
             version = entity["version"]
 
             parent = asset["parent"]
-            parent_mongo_id = parent["custom_attributes"].get(CustAttrIdKey)
+            parent_mongo_id = parent["custom_attributes"].get(CUST_ATTR_ID_KEY)
             if parent_mongo_id:
                 parent_mongo_id = ObjectId(parent_mongo_id)
             else:

--- a/pype/modules/ftrack/actions/action_prepare_project.py
+++ b/pype/modules/ftrack/actions/action_prepare_project.py
@@ -3,7 +3,7 @@ import json
 
 from pype.modules.ftrack.lib import BaseAction, statics_icon
 from pype.api import config, Anatomy, project_overrides_dir_path
-from pype.modules.ftrack.lib.avalon_sync import get_avalon_attr
+from pype.modules.ftrack.lib.avalon_sync import get_pype_attr
 
 
 class PrepareProject(BaseAction):
@@ -221,7 +221,7 @@ class PrepareProject(BaseAction):
     def _attributes_to_set(self, project_defaults):
         attributes_to_set = {}
 
-        cust_attrs, hier_cust_attrs = get_avalon_attr(self.session, True)
+        cust_attrs, hier_cust_attrs = get_pype_attr(self.session, True)
 
         for attr in hier_cust_attrs:
             key = attr["key"]

--- a/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
+++ b/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
@@ -8,7 +8,7 @@ from pype.modules.ftrack.lib import BaseAction, statics_icon
 from pype.api import Anatomy
 from pype.modules.ftrack.lib.io_nonsingleton import DbConnector
 
-from pype.modules.ftrack.lib.avalon_sync import CustAttrIdKey
+from pype.modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 
 
 class StoreThumbnailsToAvalon(BaseAction):
@@ -390,7 +390,7 @@ class StoreThumbnailsToAvalon(BaseAction):
             return output
 
         asset_ent = None
-        asset_mongo_id = parent["custom_attributes"].get(CustAttrIdKey)
+        asset_mongo_id = parent["custom_attributes"].get(CUST_ATTR_ID_KEY)
         if asset_mongo_id:
             try:
                 asset_mongo_id = ObjectId(asset_mongo_id)

--- a/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
+++ b/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
@@ -1,5 +1,5 @@
 from pype.modules.ftrack.lib import BaseEvent
-from pype.modules.ftrack.lib.avalon_sync import CustAttrIdKey
+from pype.modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 from pype.modules.ftrack.events.event_sync_to_avalon import SyncToAvalonEvent
 
 
@@ -29,7 +29,7 @@ class DelAvalonIdFromNew(BaseEvent):
 
                 elif (
                     entity.get('action', None) == 'update' and
-                    CustAttrIdKey in entity['keys'] and
+                    CUST_ATTR_ID_KEY in entity['keys'] and
                     entity_id in created
                 ):
                     ftrack_entity = session.get(
@@ -38,11 +38,11 @@ class DelAvalonIdFromNew(BaseEvent):
                     )
 
                     cust_attr = ftrack_entity['custom_attributes'][
-                        CustAttrIdKey
+                        CUST_ATTR_ID_KEY
                     ]
 
                     if cust_attr != '':
-                        ftrack_entity['custom_attributes'][CustAttrIdKey] = ''
+                        ftrack_entity['custom_attributes'][CUST_ATTR_ID_KEY] = ''
                         session.commit()
 
             except Exception:

--- a/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
+++ b/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
@@ -37,12 +37,9 @@ class DelAvalonIdFromNew(BaseEvent):
                         entity_id
                     )
 
-                    cust_attr = ftrack_entity['custom_attributes'][
-                        CUST_ATTR_ID_KEY
-                    ]
-
-                    if cust_attr != '':
-                        ftrack_entity['custom_attributes'][CUST_ATTR_ID_KEY] = ''
+                    cust_attrs = ftrack_entity["custom_attributes"]
+                    if cust_attrs[CUST_ATTR_ID_KEY]:
+                        cust_attrs[CUST_ATTR_ID_KEY] = ""
                         session.commit()
 
             except Exception:

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -1166,7 +1166,9 @@ class SyncToAvalonEvent(BaseEvent):
                 self.process_session.rolback()
                 # TODO logging
                 # TODO report
-                error_msg = "Failed to store MongoID to entity's custom attribute"
+                error_msg = (
+                    "Failed to store MongoID to entity's custom attribute"
+                )
                 report_msg = (
                     "{}||SyncToAvalon action may solve this issue"
                 ).format(error_msg)

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -14,7 +14,7 @@ from avalon import schema
 
 from pype.modules.ftrack.lib import avalon_sync
 from pype.modules.ftrack.lib.avalon_sync import (
-    CustAttrIdKey, CustAttrAutoSync, EntitySchemas
+    CUST_ATTR_ID_KEY, CUST_ATTR_AUTO_SYNC, EntitySchemas
 )
 import ftrack_api
 from pype.modules.ftrack import BaseEvent
@@ -103,7 +103,7 @@ class SyncToAvalonEvent(BaseEvent):
     @property
     def avalon_cust_attrs(self):
         if self._avalon_cust_attrs is None:
-            self._avalon_cust_attrs = avalon_sync.get_avalon_attr(
+            self._avalon_cust_attrs = avalon_sync.get_pype_attr(
                 self.process_session
             )
         return self._avalon_cust_attrs
@@ -220,7 +220,7 @@ class SyncToAvalonEvent(BaseEvent):
     def avalon_custom_attributes(self):
         """Return info about changeability of entity and it's parents."""
         if self._avalon_custom_attributes is None:
-            self._avalon_custom_attributes = avalon_sync.get_avalon_attr(
+            self._avalon_custom_attributes = avalon_sync.get_pype_attr(
                 self.process_session
             )
         return self._avalon_custom_attributes
@@ -557,10 +557,10 @@ class SyncToAvalonEvent(BaseEvent):
                 continue
 
             changes = ent_info["changes"]
-            if CustAttrAutoSync not in changes:
+            if CUST_ATTR_AUTO_SYNC not in changes:
                 continue
 
-            auto_sync = changes[CustAttrAutoSync]["new"]
+            auto_sync = changes[CUST_ATTR_AUTO_SYNC]["new"]
             if auto_sync == "1":
                 # Trigger sync to avalon action if auto sync was turned on
                 ft_project = self.cur_project
@@ -593,16 +593,16 @@ class SyncToAvalonEvent(BaseEvent):
 
         ft_project = self.cur_project
         # Check if auto-sync custom attribute exists
-        if CustAttrAutoSync not in ft_project["custom_attributes"]:
+        if CUST_ATTR_AUTO_SYNC not in ft_project["custom_attributes"]:
             # TODO should we sent message to someone?
             self.log.error((
                 "Custom attribute \"{}\" is not created or user \"{}\" used"
                 " for Event server don't have permissions to access it!"
-            ).format(CustAttrAutoSync, self.session.api_user))
+            ).format(CUST_ATTR_AUTO_SYNC, self.session.api_user))
             return True
 
         # Skip if auto-sync is not set
-        auto_sync = ft_project["custom_attributes"][CustAttrAutoSync]
+        auto_sync = ft_project["custom_attributes"][CUST_ATTR_AUTO_SYNC]
         if auto_sync is not True:
             return True
 
@@ -844,7 +844,7 @@ class SyncToAvalonEvent(BaseEvent):
 
                     new_entity["custom_attributes"][key] = val
 
-                new_entity["custom_attributes"][CustAttrIdKey] = (
+                new_entity["custom_attributes"][CUST_ATTR_ID_KEY] = (
                     str(avalon_entity["_id"])
                 )
                 ent_path = self.get_ent_path(new_entity_id)
@@ -1097,7 +1097,7 @@ class SyncToAvalonEvent(BaseEvent):
                 continue
             final_entity["data"][key] = val
 
-        _mongo_id_str = cust_attrs.get(CustAttrIdKey)
+        _mongo_id_str = cust_attrs.get(CUST_ATTR_ID_KEY)
         if _mongo_id_str:
             try:
                 _mongo_id = ObjectId(_mongo_id_str)
@@ -1158,8 +1158,8 @@ class SyncToAvalonEvent(BaseEvent):
             self.log.debug("Entity was synchronized <{}>".format(ent_path))
 
         mongo_id_str = str(mongo_id)
-        if mongo_id_str != ftrack_ent["custom_attributes"][CustAttrIdKey]:
-            ftrack_ent["custom_attributes"][CustAttrIdKey] = mongo_id_str
+        if mongo_id_str != ftrack_ent["custom_attributes"][CUST_ATTR_ID_KEY]:
+            ftrack_ent["custom_attributes"][CUST_ATTR_ID_KEY] = mongo_id_str
             try:
                 self.process_session.commit()
             except Exception:
@@ -1247,7 +1247,7 @@ class SyncToAvalonEvent(BaseEvent):
             self.process_session, entity, hier_keys, defaults
         )
         for key, val in hier_values.items():
-            if key == CustAttrIdKey:
+            if key == CUST_ATTR_ID_KEY:
                 continue
             output[key] = val
 
@@ -1689,7 +1689,7 @@ class SyncToAvalonEvent(BaseEvent):
         if "_hierarchical" not in temp_dict:
             hier_mongo_id_configuration_id = None
             for attr in hier_attrs:
-                if attr["key"] == CustAttrIdKey:
+                if attr["key"] == CUST_ATTR_ID_KEY:
                     hier_mongo_id_configuration_id = attr["id"]
                     break
             temp_dict["_hierarchical"] = hier_mongo_id_configuration_id
@@ -1706,7 +1706,7 @@ class SyncToAvalonEvent(BaseEvent):
 
         for attr in cust_attrs:
             key = attr["key"]
-            if key != CustAttrIdKey:
+            if key != CUST_ATTR_ID_KEY:
                 continue
 
             if attr["entity_type"] != ent_info["entityType"]:

--- a/pype/modules/ftrack/events/event_user_assigment.py
+++ b/pype/modules/ftrack/events/event_user_assigment.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 
 from pype.modules.ftrack import BaseEvent
-from pype.modules.ftrack.lib.avalon_sync import CustAttrIdKey
+from pype.modules.ftrack.lib.avalon_sync import CUST_ATTR_ID_KEY
 from pype.modules.ftrack.lib.io_nonsingleton import DbConnector
 
 from bson.objectid import ObjectId
@@ -106,7 +106,7 @@ class UserAssigmentEvent(BaseEvent):
         self.db_con.Session['AVALON_PROJECT'] = task['project']['full_name']
 
         avalon_entity = None
-        parent_id = parent['custom_attributes'].get(CustAttrIdKey)
+        parent_id = parent['custom_attributes'].get(CUST_ATTR_ID_KEY)
         if parent_id:
             parent_id = ObjectId(parent_id)
             avalon_entity = self.db_con.find_one({

--- a/pype/modules/ftrack/lib/__init__.py
+++ b/pype/modules/ftrack/lib/__init__.py
@@ -5,7 +5,7 @@ from .ftrack_event_handler import BaseEvent
 from .ftrack_action_handler import BaseAction, statics_icon
 from .ftrack_app_handler import AppAction
 
-__all__ = [
+__all__ = (
     "avalon_sync",
     "credentials",
     "BaseHandler",
@@ -13,4 +13,4 @@ __all__ = [
     "BaseAction",
     "statics_icon",
     "AppAction"
-]
+)

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -28,6 +28,9 @@ EntitySchemas = {
     "config": "avalon-core:config-1.0"
 }
 
+# Group name of custom attributes
+CUST_ATTR_GROUP = "pype"
+
 # name of Custom attribute that stores mongo_id from avalon db
 CustAttrIdKey = "avalon_mongo_id"
 CustAttrAutoSync = "avalon_auto_sync"

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -62,10 +62,11 @@ def check_regex(name, entity_type, in_schema=None, schema_patterns=None):
         if not schema_obj:
             name_pattern = default_pattern
         else:
-            name_pattern = schema_obj.get(
-                "properties", {}).get(
-                "name", {}).get(
-                "pattern", default_pattern
+            name_pattern = (
+                schema_obj
+                .get("properties", {})
+                .get("name", {})
+                .get("pattern", default_pattern)
             )
         if schema_patterns is not None:
             schema_patterns[schema_name] = name_pattern

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1124,7 +1124,9 @@ class SyncEntitiesFactory:
                             continue
 
                         _entity_dict = self.entities_dict[_ftrack_id]
-                        _mongo_id = _entity_dict["avalon_attrs"][CUST_ATTR_ID_KEY]
+                        _mongo_id = (
+                            _entity_dict["avalon_attrs"][CUST_ATTR_ID_KEY]
+                        )
                         _av_ent_by_mongo_id = self.avalon_ents_by_id.get(
                             _mongo_id
                         )

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1,6 +1,7 @@
 import os
 import re
 import queue
+import json
 import collections
 import copy
 
@@ -30,6 +31,13 @@ EntitySchemas = {
 # name of Custom attribute that stores mongo_id from avalon db
 CustAttrIdKey = "avalon_mongo_id"
 CustAttrAutoSync = "avalon_auto_sync"
+def default_custom_attributes_definition():
+    json_file_path = os.path.join(
+        os.path.dirname(__file__), "custom_attributes.json"
+    )
+    with open(json_file_path, "r") as json_stream:
+        data = json.load(json_stream)
+    return data
 
 
 def check_regex(name, entity_type, in_schema=None, schema_patterns=None):

--- a/pype/modules/ftrack/lib/custom_attributes.json
+++ b/pype/modules/ftrack/lib/custom_attributes.json
@@ -1,0 +1,60 @@
+{
+    "show": {
+        "avalon_auto_sync": {
+          "label": "Avalon auto-sync",
+          "type": "boolean",
+          "write_security_role": ["API", "Administrator"],
+          "read_security_role": ["API", "Administrator"]
+        },
+        "library_project": {
+          "label": "Library Project",
+          "type": "boolean",
+          "write_security_role": ["API", "Administrator"],
+          "read_security_role": ["API", "Administrator"]
+        }
+    },
+    "is_hierarchical": {
+        "fps": {
+            "label": "FPS",
+            "type": "number",
+            "config": {"isdecimal": true}
+        },
+        "clipIn": {
+            "label": "Clip in",
+            "type": "number"
+        },
+        "clipOut": {
+            "label": "Clip out",
+            "type": "number"
+        },
+        "frameStart": {
+            "label": "Frame start",
+            "type": "number"
+        },
+        "frameEnd": {
+            "label": "Frame end",
+            "type": "number"
+        },
+        "resolutionWidth": {
+            "label": "Resolution Width",
+            "type": "number"
+        },
+        "resolutionHeight": {
+            "label": "Resolution Height",
+            "type": "number"
+        },
+        "pixelAspect": {
+            "label": "Pixel aspect",
+            "type": "number",
+            "config": {"isdecimal": true}
+        },
+        "handleStart": {
+            "label": "Frame handles start",
+            "type": "number"
+        },
+        "handleEnd": {
+            "label": "Frame handles end",
+            "type": "number"
+        }
+    }
+}

--- a/pype/tools/pyblish_pype/model.py
+++ b/pype/tools/pyblish_pype/model.py
@@ -106,7 +106,7 @@ class IntentModel(QtGui.QStandardItemModel):
         intents_preset = (
             config.get_presets()
             .get("global", {})
-            .get("intents", {})
+            .get("intent", {})
         )
 
         default = intents_preset.get("default")

--- a/pype/tools/pyblish_pype/model.py
+++ b/pype/tools/pyblish_pype/model.py
@@ -105,11 +105,10 @@ class IntentModel(QtGui.QStandardItemModel):
 
         intents_preset = (
             config.get_presets()
-            .get("tools", {})
-            .get("pyblish", {})
-            .get("ui", {})
+            .get("global", {})
             .get("intents", {})
         )
+
         default = intents_preset.get("default")
         items = intents_preset.get("items", {})
         if not items:


### PR DESCRIPTION
## Main Changes
- In config is possible to define applications, tools usage and intent values available for studio. (apps and tools with boolean)

### Create/Update Custom attributes action changes
- definition of custom attributes is not in pype-config anymore
    - in pype-config can be set only read/write permissions and default values (OPTIONALLY!!!)
    - Structure of custom attributes has changed.
        - Instead of list it is a dictionary with "entity type" at first level and it's definition as value.
        - Second level for "object type" is required if "entity type" is `"task"` (Not used in with current attributes).
- applications and tools attributes are registered by boolean in global apps and tools presets
    - application label is used from application's toml file
- intent values are filled with global intent values (except empty value and default value)
- Ftrack custom attribute group renamed from `avalon` to `pype`
- fixed few bugs in custom attributes update

### Side changes:
- function `get_avalon_attr` renamed to `get_pype_attr`
- removed unused function `get_all_avalon_projects` (+ avalon has own implementation of this function)
- renamed constants `CustAttrIdKey` to `CUST_ATTR_ID_KEY` and `CustAttrAutoSync` to `CUST_ATTR_AUTO_SYNC`

## Changes on studio side
### Must
- run `Create/Update Custom attributes` action (to update custom attributes group)
- check if studio has set custom `intent` values and move values to `~/config/presets/global/intent.json`

### Optional
- set true/false on application and tools by studio usage (eliminate app list in Ftrack and time for registering Ftrack ations)

:black_flag: this depends on https://github.com/pypeclub/pype-config/pull/62
|---|