### PR TITLE
bugfix/Blender local objects duplicated

### DIFF
--- a/pype/hosts/blender/plugin.py
+++ b/pype/hosts/blender/plugin.py
@@ -45,8 +45,9 @@ def get_unique_number(
 
 def prepare_data(data, container_name):
     name = data.name
-    data = data.make_local()
-    data.name = f"{name}:{container_name}"
+    local_data = data.make_local()
+    local_data.name = f"{name}:{container_name}"
+    return local_data
 
 
 def create_blender_context(active: Optional[bpy.types.Object] = None,

--- a/pype/plugins/blender/load/load_camera.py
+++ b/pype/plugins/blender/load/load_camera.py
@@ -51,26 +51,26 @@ class BlendCameraLoader(pype.hosts.blender.plugin.AssetLoader):
         objects_list = []
 
         for obj in camera_container.objects:
-            obj = obj.make_local()
-            obj.data.make_local()
+            local_obj = obj.make_local()
+            local_obj.data.make_local()
 
-            if not obj.get(blender.pipeline.AVALON_PROPERTY):
-                obj[blender.pipeline.AVALON_PROPERTY] = dict()
+            if not local_obj.get(blender.pipeline.AVALON_PROPERTY):
+                local_obj[blender.pipeline.AVALON_PROPERTY] = dict()
 
-            avalon_info = obj[blender.pipeline.AVALON_PROPERTY]
+            avalon_info = local_obj[blender.pipeline.AVALON_PROPERTY]
             avalon_info.update({"container_name": container_name})
 
             if actions[0] is not None:
-                if obj.animation_data is None:
-                    obj.animation_data_create()
-                obj.animation_data.action = actions[0]
+                if local_obj.animation_data is None:
+                    local_obj.animation_data_create()
+                local_obj.animation_data.action = actions[0]
 
             if actions[1] is not None:
-                if obj.data.animation_data is None:
-                    obj.data.animation_data_create()
-                obj.data.animation_data.action = actions[1]
+                if local_obj.data.animation_data is None:
+                    local_obj.data.animation_data_create()
+                local_obj.data.animation_data.action = actions[1]
 
-            objects_list.append(obj)
+            objects_list.append(local_obj)
 
         camera_container.pop(blender.pipeline.AVALON_PROPERTY)
 
@@ -190,7 +190,16 @@ class BlendCameraLoader(pype.hosts.blender.plugin.AssetLoader):
 
         camera = objects[0]
 
-        actions = (camera.animation_data.action, camera.data.animation_data.action)
+        camera_action = None
+        camera_data_action = None
+
+        if camera.animation_data and camera.animation_data.action:
+            camera_action = camera.animation_data.action
+
+        if camera.data.animation_data and camera.data.animation_data.action:
+            camera_data_action = camera.data.animation_data.action
+
+        actions = (camera_action, camera_data_action)
 
         self._remove(objects, lib_container)
 

--- a/pype/plugins/blender/load/load_layout.py
+++ b/pype/plugins/blender/load/load_layout.py
@@ -79,21 +79,21 @@ class BlendLayoutLoader(plugin.AssetLoader):
         # The armature is unparented for all the non-local meshes,
         # when it is made local.
         for obj in objects + armatures:
-            obj.make_local()
+            local_obj = obj.make_local()
             if obj.data:
                 obj.data.make_local()
 
-            if not obj.get(blender.pipeline.AVALON_PROPERTY):
-                obj[blender.pipeline.AVALON_PROPERTY] = dict()
+            if not local_obj.get(blender.pipeline.AVALON_PROPERTY):
+                local_obj[blender.pipeline.AVALON_PROPERTY] = dict()
 
-            avalon_info = obj[blender.pipeline.AVALON_PROPERTY]
+            avalon_info = local_obj[blender.pipeline.AVALON_PROPERTY]
             avalon_info.update({"container_name": container_name})
 
-            action = actions.get(obj.name, None)
+            action = actions.get(local_obj.name, None)
 
-            if obj.type == 'ARMATURE' and action is not None:
-                obj.animation_data.action = action
-            
+            if local_obj.type == 'ARMATURE' and action is not None:
+                local_obj.animation_data.action = action
+
         layout_container.pop(blender.pipeline.AVALON_PROPERTY)
 
         bpy.ops.object.select_all(action='DESELECT')
@@ -222,6 +222,7 @@ class BlendLayoutLoader(plugin.AssetLoader):
 
         for obj in objects:
             if obj.type == 'ARMATURE':
+                if obj.animation_data and obj.animation_data.action:
                 actions[obj.name] = obj.animation_data.action
 
         self._remove(objects, obj_container)

--- a/pype/plugins/blender/load/load_layout.py
+++ b/pype/plugins/blender/load/load_layout.py
@@ -223,7 +223,7 @@ class BlendLayoutLoader(plugin.AssetLoader):
         for obj in objects:
             if obj.type == 'ARMATURE':
                 if obj.animation_data and obj.animation_data.action:
-                actions[obj.name] = obj.animation_data.action
+                    actions[obj.name] = obj.animation_data.action
 
         self._remove(objects, obj_container)
 

--- a/pype/plugins/blender/load/load_model.py
+++ b/pype/plugins/blender/load/load_model.py
@@ -53,16 +53,16 @@ class BlendModelLoader(plugin.AssetLoader):
         model_container.name = container_name
 
         for obj in model_container.objects:
-            plugin.prepare_data(obj, container_name)
-            plugin.prepare_data(obj.data, container_name)
+            local_obj = plugin.prepare_data(obj, container_name)
+            plugin.prepare_data(local_obj.data, container_name)
 
-            for material_slot in obj.material_slots:
+            for material_slot in local_obj.material_slots:
                 plugin.prepare_data(material_slot.material, container_name)
 
             if not obj.get(blender.pipeline.AVALON_PROPERTY):
-                obj[blender.pipeline.AVALON_PROPERTY] = dict()
+                local_obj[blender.pipeline.AVALON_PROPERTY] = dict()
 
-            avalon_info = obj[blender.pipeline.AVALON_PROPERTY]
+            avalon_info = local_obj[blender.pipeline.AVALON_PROPERTY]
             avalon_info.update({"container_name": container_name})
 
         model_container.pop(blender.pipeline.AVALON_PROPERTY)

--- a/pype/plugins/blender/load/load_rig.py
+++ b/pype/plugins/blender/load/load_rig.py
@@ -63,24 +63,24 @@ class BlendRigLoader(plugin.AssetLoader):
         ]
 
         for child in rig_container.children:
-            plugin.prepare_data(child, container_name)
-            meshes.extend(child.objects)
+            local_child = plugin.prepare_data(child, container_name)
+            meshes.extend(local_child.objects)
 
         # Link meshes first, then armatures.
         # The armature is unparented for all the non-local meshes,
         # when it is made local.
         for obj in meshes + armatures:
-            plugin.prepare_data(obj, container_name)
-            plugin.prepare_data(obj.data, container_name)
+            local_obj = plugin.prepare_data(obj, container_name)
+            plugin.prepare_data(local_obj.data, container_name)
 
-            if not obj.get(blender.pipeline.AVALON_PROPERTY):
-                obj[blender.pipeline.AVALON_PROPERTY] = dict()
+            if not local_obj.get(blender.pipeline.AVALON_PROPERTY):
+                local_obj[blender.pipeline.AVALON_PROPERTY] = dict()
 
-            avalon_info = obj[blender.pipeline.AVALON_PROPERTY]
+            avalon_info = local_obj[blender.pipeline.AVALON_PROPERTY]
             avalon_info.update({"container_name": container_name})
 
-            if obj.type == 'ARMATURE' and action is not None:
-                obj.animation_data.action = action
+            if local_obj.type == 'ARMATURE' and action is not None:
+                local_obj.animation_data.action = action
 
         rig_container.pop(blender.pipeline.AVALON_PROPERTY)
 
@@ -214,7 +214,9 @@ class BlendRigLoader(plugin.AssetLoader):
         armatures = [obj for obj in objects if obj.type == 'ARMATURE']
         assert(len(armatures) == 1)
 
-        action = armatures[0].animation_data.action
+        action = None
+        if armatures[0].animation_data and armatures[0].animation_data.action:
+            action = armatures[0].animation_data.action
 
         parent = plugin.get_parent_collection(obj_container)
 


### PR DESCRIPTION
Some of the objects are duplicated when calling Blender's method `make_local()`. This fix handles this behaviour.