### PR TITLE
Multi url support for deadline submitter

### DIFF
--- a/pype/api.py
+++ b/pype/api.py
@@ -40,7 +40,8 @@ from .lib import (
     get_version_from_path,
     get_last_version_from_path,
     modified_environ,
-    add_tool_to_environment
+    add_tool_to_environment,
+    submit_deadline_payload
 )
 
 # Special naming case for subprocess since its a built-in method.

--- a/pype/api.py
+++ b/pype/api.py
@@ -41,6 +41,7 @@ from .lib import (
     get_last_version_from_path,
     modified_environ,
     add_tool_to_environment,
+    get_deadline_url,
     submit_deadline_payload
 )
 
@@ -86,5 +87,9 @@ __all__ = [
     "modified_environ",
     "add_tool_to_environment",
 
-    "subprocess"
+    "subprocess",
+
+    # render farm related
+    "get_deadline_url",
+    "submit_deadline_payload"
 ]

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -690,11 +690,19 @@ def get_deadline_url(url=None):
 
         return requests.get(*args, **kwargs)
 
-    dl_rest_url = url or os.getenv("DEADLINE_REST_URL")
+    if not url:
+        dl_rest_url = os.getenv("DEADLINE_REST_URL")
 
-    if not dl_rest_url:
-        log.info("Deadline REST API url not found.")
-        raise ValueError("Deadline REST API url not found.")
+        if not dl_rest_url:
+            log.info("Deadline REST API url not found.")
+            raise ValueError("Deadline REST API url not found.")
+
+        # adding localhost adress for developers
+        # only in case there is none already
+        if "localhost" not in dl_rest_url:
+            dl_rest_url += ";http://localhost:8082"
+    else:
+        dl_rest_url = url
 
     # create list of urls
     if ";" in dl_rest_url:

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -672,8 +672,8 @@ def submit_deadline_payload(payload, timeout=None):
     # create list of urls
     if ";" in DEADLINE_REST_URL:
         deadline_urls = [
-         "{}/api/jobs".format(url)
-        for url in DEADLINE_REST_URL.split(";")
+            "{}/api/jobs".format(url)
+            for url in DEADLINE_REST_URL.split(";")
         ]
     else:
         deadline_urls = ["{}/api/jobs".format(DEADLINE_REST_URL)]

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -654,13 +654,16 @@ def get_subsets(asset_name,
     return output_dict
 
 
-def get_deadline_url():
+def get_deadline_url(url=None):
     """
     Get Deadline url adress from environment variable `DEADLINE_REST_URL`
 
     It is supporting multi adresses string separated by `;` only.
     When two different adresses are needed for case of the inhouse studio
     and a remote connection is having different IP adresses or domanes.
+
+    Args:
+        url (str)[optional]: deadline rest url ideally single adress
 
     Returns:
         str: url string
@@ -686,7 +689,7 @@ def get_deadline_url():
                 "PYPE_DONT_VERIFY_SSL", True) else True  # noqa
         return requests.get(*args, **kwargs)
 
-    dl_rest_url = os.getenv("DEADLINE_REST_URL")
+    dl_rest_url = url or os.getenv("DEADLINE_REST_URL")
 
     if not dl_rest_url:
         log.info("Deadline REST API url not found.")

--- a/pype/plugins/celaction/publish/submit_celaction_deadline.py
+++ b/pype/plugins/celaction/publish/submit_celaction_deadline.py
@@ -2,9 +2,9 @@ import os
 import json
 import getpass
 
-from avalon.vendor import requests
 import re
 import pyblish.api
+from pype.api import submit_deadline_payload
 
 
 class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
@@ -36,10 +36,6 @@ class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
     def process(self, instance):
         context = instance.context
 
-        DEADLINE_REST_URL = os.environ.get("DEADLINE_REST_URL")
-        assert DEADLINE_REST_URL, "Requires DEADLINE_REST_URL"
-
-        self.deadline_url = "{}/api/jobs".format(DEADLINE_REST_URL)
         self._comment = context.data.get("comment", "")
         self._deadline_user = context.data.get(
             "deadlineUser", getpass.getuser())
@@ -181,12 +177,8 @@ class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
         self.expected_files(instance, render_path)
         self.log.debug("__ expectedFiles: `{}`".format(
             instance.data["expectedFiles"]))
-        response = requests.post(self.deadline_url, json=payload)
 
-        if not response.ok:
-            raise Exception(response.text)
-
-        return response
+        return submit_deadline_payload(payload)
 
     def preflight_check(self, instance):
         """Ensure the startFrame, endFrame and byFrameStep are integers"""

--- a/pype/plugins/global/publish/collect_deadline_rest_url.py
+++ b/pype/plugins/global/publish/collect_deadline_rest_url.py
@@ -1,0 +1,21 @@
+"""
+Requires:
+    None
+Provides:
+    context -> deadlienRestUrl (str)
+"""
+
+import pyblish.api
+from pype.api import get_deadline_url
+
+
+class CollectDeadlineRestUrl(pyblish.api.ContextPlugin):
+    """This plugin is getting deadline rest url into context"""
+
+    label = "Collect Deadline Rest Url"
+    order = pyblish.api.CollectorOrder
+
+    def process(self, context):
+        dl_rest_url = get_deadline_url()
+
+        context.data["deadlienRestUrl"] = dl_rest_url

--- a/pype/plugins/global/publish/collect_deadline_rest_url.py
+++ b/pype/plugins/global/publish/collect_deadline_rest_url.py
@@ -15,6 +15,9 @@ class CollectDeadlineRestUrl(pyblish.api.ContextPlugin):
     label = "Collect Deadline Rest Url"
     order = pyblish.api.CollectorOrder
 
+    # QUESTION: what if we dont wont to have deadline in pipeline?
+    # TODO: https://github.com/pypeclub/pype/issues/449
+
     def process(self, context):
         dl_rest_url = get_deadline_url()
 

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -11,6 +11,8 @@ from avalon.vendor import requests, clique
 
 import pyblish.api
 
+from pype.api import submit_deadline_payload
+
 
 def _get_script():
     """Get path to the image sequence script."""
@@ -280,10 +282,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         self.log.info("Submitting Deadline job ...")
         # self.log.info(json.dumps(payload, indent=4, sort_keys=True))
 
-        url = "{}/api/jobs".format(self.DEADLINE_REST_URL)
-        response = requests.post(url, json=payload, timeout=10)
-        if not response.ok:
-            raise Exception(response.text)
+        return submit_deadline_payload(payload, timeout=10)
 
     def _copy_extend_frames(self, instance, representation):
         """Copy existing frames from latest version.
@@ -597,11 +596,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             )
 
         if submission_type == "deadline":
-            self.DEADLINE_REST_URL = os.environ.get(
-                "DEADLINE_REST_URL", "http://localhost:8082"
-            )
-            assert self.DEADLINE_REST_URL, "Requires DEADLINE_REST_URL"
-
             self._submit_deadline_post_job(instance, render_job)
 
         asset = data.get("asset") or api.Session["AVALON_ASSET"]

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -7,7 +7,7 @@ import re
 from copy import copy
 
 from avalon import api, io
-from avalon.vendor import requests, clique
+from avalon.vendor import clique
 
 import pyblish.api
 
@@ -202,6 +202,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         submitter, so this type of code isn't necessary for it.
 
         """
+        url = instance.context["deadlienRestUrl"]
         data = instance.data.copy()
         subset = data["subset"]
         job_name = "Publish - {subset}".format(subset=subset)
@@ -280,9 +281,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         payload["JobInfo"].pop("SecondaryPool", None)
 
         self.log.info("Submitting Deadline job ...")
-        # self.log.info(json.dumps(payload, indent=4, sort_keys=True))
 
-        return submit_deadline_payload(payload, timeout=10)
+        return submit_deadline_payload(payload, url=url, timeout=10, post=True)
 
     def _copy_extend_frames(self, instance, representation):
         """Copy existing frames from latest version.

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -166,9 +166,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
 
         """Plugin entry point."""
         self._instance = instance
-        self._deadline_url = instance.context.data.get(
-            "deadlienRestUrl",
-            "http://localhost:8082")
+        self._deadline_url = instance.context.data.get("deadlienRestUrl")
 
         context = instance.context
         workspace = context.data["workspaceDir"]

--- a/pype/plugins/maya/publish/validate_deadline_connection.py
+++ b/pype/plugins/maya/publish/validate_deadline_connection.py
@@ -1,6 +1,6 @@
 import pyblish.api
 
-from avalon.vendor import requests
+from pype.api import get_deadline_url
 from pype.plugin import contextplugin_should_run
 import os
 
@@ -16,34 +16,12 @@ class ValidateDeadlineConnection(pyblish.api.ContextPlugin):
         active = False
 
     def process(self, context):
-
         # Workaround bug pyblish-base#250
         if not contextplugin_should_run(self, context):
             return
 
-        try:
-            DEADLINE_REST_URL = os.environ["DEADLINE_REST_URL"]
-        except KeyError:
-            self.log.error("Deadline REST API url not found.")
-            raise ValueError("Deadline REST API url not found.")
+        url = context.data.get("deadlienRestUrl")
+        assert url, "Deadline Rest Url is missing"
 
-        # Check response
-        response = self._requests_get(DEADLINE_REST_URL)
-        assert response.ok, "Response must be ok"
-        assert response.text.startswith("Deadline Web Service "), (
-            "Web service did not respond with 'Deadline Web Service'"
-        )
-
-    def _requests_get(self, *args, **kwargs):
-        """ Wrapper for requests, disabling SSL certificate validation if
-            DONT_VERIFY_SSL environment variable is found. This is useful when
-            Deadline or Muster server are running with self-signed certificates
-            and their certificate is not added to trusted certificates on
-            client machines.
-
-            WARNING: disabling SSL certificate validation is defeating one line
-            of defense SSL is providing and it is not recommended.
-        """
-        if 'verify' not in kwargs:
-            kwargs['verify'] = False if os.getenv("PYPE_DONT_VERIFY_SSL", True) else True  # noqa
-        return requests.get(*args, **kwargs)
+        # test url. Asserts are part of the function
+        get_deadline_url(url)


### PR DESCRIPTION
When the __DEADLINE_REST_URL__ is defined by string of two and more URL addresses separated with semi-column then it will try to submit to all of them in the defined order. It is also supporting only single URL. 

example: `"http://address01:8082;http://address02:8082"`

Submission method has been propagated to pype.lib and added to pype.api