### PR TITLE
Feature/optional last workfile launch

### DIFF
--- a/pype/modules/ftrack/lib/ftrack_app_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_app_handler.py
@@ -8,7 +8,9 @@ import getpass
 from pype import lib as pypelib
 from pype.api import config, Anatomy
 from .ftrack_action_handler import BaseAction
-from avalon.api import last_workfile, HOST_WORKFILE_EXTENSIONS
+from avalon.api import (
+    last_workfile, HOST_WORKFILE_EXTENSIONS, should_start_last_workfile
+)
 
 
 class AppAction(BaseAction):
@@ -219,8 +221,22 @@ class AppAction(BaseAction):
             "AVALON_HIERARCHY": hierarchy,
             "AVALON_WORKDIR": workdir
         })
-        if last_workfile_path and os.path.exists(last_workfile_path):
+
+        start_last_workfile = should_start_last_workfile(
+            project_name, host_name, task_name
+        )
+        # Store boolean as "0"(False) or "1"(True)
+        prep_env["AVALON_OPEN_LAST_WORKFILE"] = (
+            str(int(bool(start_last_workfile)))
+        )
+
+        if (
+            start_last_workfile
+            and last_workfile_path
+            and os.path.exists(last_workfile_path)
+        ):
             prep_env["AVALON_LAST_WORKFILE"] = last_workfile_path
+
         prep_env.update(anatomy.roots_obj.root_environments())
 
         # collect all parents from the task

--- a/pype/modules/ftrack/lib/ftrack_app_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_app_handler.py
@@ -142,6 +142,9 @@ class AppAction(BaseAction):
         """
 
         entity = entities[0]
+
+        task_name = entity["name"]
+
         project_name = entity["project"]["full_name"]
 
         database = pypelib.get_avalon_database()
@@ -164,7 +167,7 @@ class AppAction(BaseAction):
                 "name": entity["project"]["full_name"],
                 "code": entity["project"]["name"]
             },
-            "task": entity["name"],
+            "task": task_name,
             "asset": asset_name,
             "app": host_name,
             "hierarchy": hierarchy
@@ -210,8 +213,8 @@ class AppAction(BaseAction):
         prep_env.update({
             "AVALON_PROJECT": project_name,
             "AVALON_ASSET": asset_name,
-            "AVALON_TASK": entity["name"],
-            "AVALON_APP": self.identifier.split("_")[0],
+            "AVALON_TASK": task_name,
+            "AVALON_APP": host_name,
             "AVALON_APP_NAME": self.identifier,
             "AVALON_HIERARCHY": hierarchy,
             "AVALON_WORKDIR": workdir


### PR DESCRIPTION
## Issue
- launching of last workfile is implemented but is not possible to turn it off (in Maya)

## Enhancement
- would be good to be able set opening last workfile also per task name

## Changes
- definition of opening is based on presets `~/pype-config/tools/workfiles.json`
    - filtering is similar to extract review
- presets structure
```
{
    # Is list of dictionaries
    "last_workfile_on_startup": [
        # Host `maya` won't open last workfile by default
        {
            "hosts": ["maya"],
            "startup": false
        },
        # Last workfile is opened if `maya` is launched on task `animation`
        {
            "hosts": ["maya"],
            "tasks": ["animation"],
            "startup": true
        },
        # Item with not set `hosts` and `tasks` can be used as default value
        {
            "startup": true
        }
    ]
}
```
- function `should_start_last_workfile` for determination is implemented in avalon-core to be able use it for launching from avalon-launcher
- by default opening of the last workfile is turned off (in case there is missing preset or is not set at all)
- the default value when preset is not set can be overriden with environment variable `AVALON_OPEN_LAST_WORKFILE`
    - valid values are `"true", "false", "yes", "no", "1", "0"`
    - the environment variable is overriden with `"1"` (as True) or `"0"` (as false) when application is launched to be able access result of `should_start_last_workfile` inside application (may be handy e.g. for triggering workfiles tool if there is none workfile yet)

## Important
Implementation of opening the last workfile for each host is not part of this PR!!!


|:black_flag: This PR depends on||
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/167|
|pype-config|https://github.com/pypeclub/pype-config/pull/69|