### PR TITLE
celaction deadline rendering

### DIFF
--- a/pype/plugins/celaction/publish/collect_render_path.py
+++ b/pype/plugins/celaction/publish/collect_render_path.py
@@ -10,9 +10,14 @@ class CollectRenderPath(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.495
     families = ["render.farm"]
 
+    # Presets
+    anatomy_render_key = None
+    anatomy_publish_render_key = None
+
     def process(self, instance):
         anatomy = instance.context.data["anatomy"]
         anatomy_data = copy.deepcopy(instance.data["anatomyData"])
+        anatomy_data["family"] = "render"
         padding = anatomy.templates.get("frame_padding", 4)
         anatomy_data.update({
             "frame": f"%0{padding}d",
@@ -21,12 +26,28 @@ class CollectRenderPath(pyblish.api.InstancePlugin):
 
         anatomy_filled = anatomy.format(anatomy_data)
 
-        render_dir = anatomy_filled["render_tmp"]["folder"]
-        render_path = anatomy_filled["render_tmp"]["path"]
+        # get anatomy rendering keys
+        anatomy_render_key = self.anatomy_render_key or "render"
+        anatomy_publish_render_key = self.anatomy_publish_render_key or "render"
+
+        # get folder and path for rendering images from celaction
+        render_dir = anatomy_filled[anatomy_render_key]["folder"]
+        render_path = anatomy_filled[anatomy_render_key]["path"]
 
         # create dir if it doesnt exists
-        os.makedirs(render_dir, exist_ok=True)
+        try:
+            if not os.path.isdir(render_dir):
+                os.makedirs(render_dir, exist_ok=True)
+        except OSError:
+            # directory is not available
+            self.log.warning("Path is unreachable: `{}`".format(render_dir))
 
+        # add rendering path to instance data
         instance.data["path"] = render_path
+
+        # get anatomy for published renders folder path
+        if anatomy_filled.get(anatomy_publish_render_key):
+            instance.data["publishRenderFolder"] = anatomy_filled[
+                anatomy_publish_render_key]["folder"]
 
         self.log.info(f"Render output path set to: `{render_path}`")

--- a/pype/plugins/celaction/publish/submit_celaction_deadline.py
+++ b/pype/plugins/celaction/publish/submit_celaction_deadline.py
@@ -74,6 +74,7 @@ class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
         resolution_width = instance.data["resolutionWidth"]
         resolution_height = instance.data["resolutionHeight"]
         render_dir = os.path.normpath(os.path.dirname(render_path))
+        render_path = os.path.normpath(render_path)
         script_name = os.path.basename(script_path)
         jobname = "%s - %s" % (script_name, instance.name)
 
@@ -98,6 +99,7 @@ class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
         args = [
             f"<QUOTE>{script_path}<QUOTE>",
             "-a",
+            "-16",
             "-s <STARTFRAME>",
             "-e <ENDFRAME>",
             f"-d <QUOTE>{render_dir}<QUOTE>",
@@ -135,8 +137,10 @@ class ExtractCelactionDeadline(pyblish.api.InstancePlugin):
 
                 # Optional, enable double-click to preview rendered
                 # frames from Deadline Monitor
-                "OutputFilename0": output_filename_0.replace("\\", "/")
+                "OutputFilename0": output_filename_0.replace("\\", "/"),
 
+                # # Asset dependency to wait for at least the scene file to sync.
+                # "AssetDependency0": script_path
             },
             "PluginInfo": {
                 # Input

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -551,12 +551,12 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         # copy file with speedcopy and check if size of files are simetrical
         while True:
+            import shutil
             try:
                 copyfile(src, dst)
-            except (OSError, AttributeError) as e:
-                self.log.warning(e)
-                # try it again with shutil
-                import shutil
+            except shutil.SameFileError as sfe:
+                self.log.critical("files are the same {} to {}".format(src, dst))
+                os.remove(dst)
                 try:
                     shutil.copyfile(src, dst)
                     self.log.debug("Copying files with shutil...")

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -12,7 +12,15 @@ from avalon.vendor import requests, clique
 import pyblish.api
 
 
-def _get_script():
+def _get_script(path):
+
+    # pass input path if exists
+    if path:
+        if os.path.exists(path):
+            return str(path)
+        else:
+            raise
+
     """Get path to the image sequence script."""
     try:
         from pathlib import Path
@@ -192,6 +200,38 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     families_transfer = ["render3d", "render2d", "ftrack", "slate"]
     plugin_python_version = "3.7"
 
+    # script path for publish_filesequence.py
+    publishing_script = None
+
+    def _create_metadata_path(self, instance):
+        ins_data = instance.data
+        # Ensure output dir exists
+        output_dir = ins_data.get("publishRenderFolder", ins_data["outputDir"])
+
+        try:
+            if not os.path.isdir(output_dir):
+                os.makedirs(output_dir)
+        except OSError:
+            # directory is not available
+            self.log.warning("Path is unreachable: `{}`".format(output_dir))
+
+        metadata_filename = "{}_metadata.json".format(ins_data["subset"])
+
+        metadata_path = os.path.join(output_dir, metadata_filename)
+
+        # Convert output dir to `{root}/rest/of/path/...` with Anatomy
+        success, roothless_mtdt_p = self.anatomy.find_root_template_from_path(
+            metadata_path)
+        if not success:
+            # `rootless_path` is not set to `output_dir` if none of roots match
+            self.log.warning((
+                "Could not find root path for remapping \"{}\"."
+                " This may cause issues on farm."
+            ).format(output_dir))
+            roothless_mtdt_p = metadata_path
+
+        return (metadata_path, roothless_mtdt_p)
+
     def _submit_deadline_post_job(self, instance, job):
         """Submit publish job to Deadline.
 
@@ -205,17 +245,6 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         job_name = "Publish - {subset}".format(subset=subset)
 
         output_dir = instance.data["outputDir"]
-        # Convert output dir to `{root}/rest/of/path/...` with Anatomy
-        success, rootless_path = (
-            self.anatomy.find_root_template_from_path(output_dir)
-        )
-        if not success:
-            # `rootless_path` is not set to `output_dir` if none of roots match
-            self.log.warning((
-                "Could not find root path for remapping \"{}\"."
-                " This may cause issues on farm."
-            ).format(output_dir))
-            rootless_path = output_dir
 
         # Generate the payload for Deadline submission
         payload = {
@@ -239,7 +268,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             },
             "PluginInfo": {
                 "Version": self.plugin_python_version,
-                "ScriptFile": _get_script(),
+                "ScriptFile": _get_script(self.publishing_script),
                 "Arguments": "",
                 "SingleFrameOnly": "True",
             },
@@ -249,11 +278,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
 
         # Transfer the environment from the original job to this dependent
         # job so they use the same environment
-        metadata_filename = "{}_metadata.json".format(subset)
-        metadata_path = os.path.join(rootless_path, metadata_filename)
+        metadata_path, roothless_metadata_path = self._create_metadata_path(
+            instance)
 
         environment = job["Props"].get("Env", {})
-        environment["PYPE_METADATA_FILE"] = metadata_path
+        environment["PYPE_METADATA_FILE"] = roothless_metadata_path
         environment["AVALON_PROJECT"] = io.Session["AVALON_PROJECT"]
         environment["PYPE_LOG_NO_COLORS"] = "1"
         try:
@@ -854,14 +883,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             }
             publish_job.update({"ftrack": ftrack})
 
-        # Ensure output dir exists
-        output_dir = instance.data["outputDir"]
-        if not os.path.isdir(output_dir):
-            os.makedirs(output_dir)
+        metadata_path, roothless_metadata_path = self._create_metadata_path(
+            instance)
 
-        metadata_filename = "{}_metadata.json".format(subset)
-
-        metadata_path = os.path.join(output_dir, metadata_filename)
         self.log.info("Writing json file: {}".format(metadata_path))
         with open(metadata_path, "w") as f:
             json.dump(publish_job, f, indent=4, sort_keys=True)


### PR DESCRIPTION
- fixing CelAction render paths to be separated for rendering and publish render (client wants to separate targets for optimalisation of rendering). This publishing path is then passed in instance.data for later Global submiter to use it in metadata json file creation
- rewriting the way metadata json file path is created in global submitter to farm
- make file paths slashes consistent
- fixing the `shutil.SameFileError` error in integrate_new which is perhaps related to Google Drive Stream storing mechanism