### PR TITLE
feature/pype version in tray

### DIFF
--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -105,10 +105,7 @@ class TrayManager:
         if items and self.services_submenu is not None:
             self.add_separator(self.tray_widget.menu)
 
-        version_string = self._version_string()
-        version_action = QtWidgets.QAction(version_string, self.tray_widget)
-        self.tray_widget.menu.addAction(version_action)
-        self.add_separator(self.tray_widget.menu)
+        self._add_version_item()
 
         # Add Exit action to menu
         aExit = QtWidgets.QAction("&Exit", self.tray_widget)
@@ -119,30 +116,37 @@ class TrayManager:
         self.connect_modules()
         self.start_modules()
 
-    def _version_string(self):
-        subversion = None
-        client_name = None
+    def _add_version_item(self):
         config_file_path = os.path.join(
             os.environ["PYPE_SETUP_PATH"], "pypeapp", "config.ini"
         )
-        version_string = pype.version.__version__
-        if os.path.exists(config_file_path):
-            config = configparser.ConfigParser()
-            config.read(config_file_path)
-            try:
-                default_config = config["CLIENT"]
-            except Exception:
-                default_config = {}
-            subversion = default_config.get("subversion")
-            client_name = default_config.get("client_name")
+        if not os.path.exists(config_file_path):
+            return
 
+        subversion = None
+        client_name = None
+
+        config = configparser.ConfigParser()
+        config.read(config_file_path)
+        try:
+            default_config = config["CLIENT"]
+        except Exception:
+            default_config = {}
+        subversion = default_config.get("subversion")
+        client_name = default_config.get("client_name")
+        if not subversion and not client_name:
+            return
+
+        version_string = pype.version.__version__
         if subversion:
             version_string += " ({})".format(subversion)
 
         if client_name:
             version_string += ", {}".format(client_name)
 
-        return version_string
+        version_action = QtWidgets.QAction(version_string, self.tray_widget)
+        self.tray_widget.menu.addAction(version_action)
+        self.add_separator(self.tray_widget.menu)
 
     def process_items(self, items, parent_menu):
         """ Loop through items and add them to parent_menu.

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -120,22 +120,18 @@ class TrayManager:
         config_file_path = os.path.join(
             os.environ["PYPE_SETUP_PATH"], "pypeapp", "config.ini"
         )
-        if not os.path.exists(config_file_path):
-            return
 
-        subversion = None
-        client_name = None
+        default_config = {}
+        if os.path.exists(config_file_path):
+            config = configparser.ConfigParser()
+            config.read(config_file_path)
+            try:
+                default_config = config["CLIENT"]
+            except Exception:
+                pass
 
-        config = configparser.ConfigParser()
-        config.read(config_file_path)
-        try:
-            default_config = config["CLIENT"]
-        except Exception:
-            default_config = {}
         subversion = default_config.get("subversion")
         client_name = default_config.get("client_name")
-        if not subversion and not client_name:
-            return
 
         version_string = pype.version.__version__
         if subversion:

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -4,6 +4,11 @@ import platform
 from avalon import style
 from Qt import QtCore, QtGui, QtWidgets, QtSvg
 from pype.api import config, Logger, resources
+import pype.version
+try:
+    import configparser
+except Exception:
+    import ConfigParser as configparser
 
 
 class TrayManager:
@@ -100,6 +105,11 @@ class TrayManager:
         if items and self.services_submenu is not None:
             self.add_separator(self.tray_widget.menu)
 
+        version_string = self._version_string()
+        version_action = QtWidgets.QAction(version_string, self.tray_widget)
+        self.tray_widget.menu.addAction(version_action)
+        self.add_separator(self.tray_widget.menu)
+
         # Add Exit action to menu
         aExit = QtWidgets.QAction("&Exit", self.tray_widget)
         aExit.triggered.connect(self.tray_widget.exit)
@@ -108,6 +118,31 @@ class TrayManager:
         # Tell each module which modules were imported
         self.connect_modules()
         self.start_modules()
+
+    def _version_string(self):
+        subversion = None
+        client_name = None
+        config_file_path = os.path.join(
+            os.environ["PYPE_SETUP_PATH"], "pypeapp", "config.ini"
+        )
+        version_string = pype.version.__version__
+        if os.path.exists(config_file_path):
+            config = configparser.ConfigParser()
+            config.read(config_file_path)
+            try:
+                default_config = config["CLIENT"]
+            except Exception:
+                default_config = {}
+            subversion = default_config.get("subversion")
+            client_name = default_config.get("client_name")
+
+        if subversion:
+            version_string += " ({})".format(subversion)
+
+        if client_name:
+            version_string += ", {}".format(client_name)
+
+        return version_string
 
     def process_items(self, items, parent_menu):
         """ Loop through items and add them to parent_menu.


### PR DESCRIPTION
## Changes
- added item to tray menu with version, client version and client name
- client version and client name can be set in config.ini in pype-setup e.g.:
```
[CLIENT]
subversion=1
client_name=Pype Club
```
- `subversion` and `client_name` are optional
    - menu item with version is shown only if at least one key is set

![image](https://user-images.githubusercontent.com/43494761/88377262-23108200-cd9f-11ea-96d0-5f3cadb4b63b.png)
