### PR TITLE
Maya: bake custom attributes to camera during export

### DIFF
--- a/pype/plugins/maya/publish/extract_camera_alembic.py
+++ b/pype/plugins/maya/publish/extract_camera_alembic.py
@@ -19,6 +19,7 @@ class ExtractCameraAlembic(pype.api.Extractor):
     label = "Camera (Alembic)"
     hosts = ["maya"]
     families = ["camera"]
+    bake_attributes = []
 
     def process(self, instance):
 
@@ -65,6 +66,14 @@ class ExtractCameraAlembic(pype.api.Extractor):
                 job_str += ' -worldSpace -root {0}'.format(transform)
 
             job_str += ' -file "{0}"'.format(path)
+
+            # bake specified attributes in preset
+            assert isinstance(self.bake_attributes, (list, tuple)), (
+                "Attributes to bake must be specified as a list"
+            )
+            for attr in self.bake_attributes:
+                self.log.info("Adding {} attribute".format(attr))
+                job_str += " -attr {0}".format(attr)
 
             with lib.evaluation("off"):
                 with avalon.maya.suspended_refresh():


### PR DESCRIPTION
## New feature

When exporting camera (either as maya scene or alembic) custom attributes can be specfied to bake into the file. It can be done using standard preset way:

**maya/publish.json:**
```javascript
{
"ExtractCameraMayaAscii": {
    "bake_attributes": ["vrayCameraPhysicalFocusDistance"]
},
"ExtractCameraAlembic": {
    "bake_attributes": ["vrayCameraPhysicalFocusDistance"]
 }
}
```

This will add baked **vrayCameraPhysicalFocusDistance** to camera.

🌞 **Freshdesk ticker**: [#27](https://pype.freshdesk.com/a/tickets/27)
|---|