### PR TITLE
Maya: render setup update and removal implementation

### DIFF
--- a/pype/plugins/maya/load/load_rendersetup.py
+++ b/pype/plugins/maya/load/load_rendersetup.py
@@ -1,14 +1,23 @@
-from avalon import api
-import maya.app.renderSetup.model.renderSetup as renderSetup
-from avalon.maya import lib
-from maya import cmds
+# -*- coding: utf-8 -*-
+"""Load and update RenderSetup settings.
+
+Working with RenderSetup setting is Maya is done utilizing json files.
+When this json is loaded, it will overwrite all settings on RenderSetup
+instance.
+"""
+
 import json
+
+from avalon import api
+from avalon.maya import lib
+from pype.hosts.maya import lib as pypelib
+
+from maya import cmds
+import maya.app.renderSetup.model.renderSetup as renderSetup
 
 
 class RenderSetupLoader(api.Loader):
-    """
-    This will load json preset for RenderSetup, overwriting current one.
-    """
+    """Load json preset for RenderSetup overwriting current one."""
 
     families = ["rendersetup"]
     representations = ["json"]
@@ -19,7 +28,7 @@ class RenderSetupLoader(api.Loader):
     color = "orange"
 
     def load(self, context, name, namespace, data):
-
+        """Load RenderSetup settings."""
         from avalon.maya.pipeline import containerise
         # from pype.hosts.maya.lib import namespaced
 
@@ -48,3 +57,41 @@ class RenderSetupLoader(api.Loader):
             nodes=nodes,
             context=context,
             loader=self.__class__.__name__)
+
+    def remove(self, container):
+        """Remove RenderSetup settings instance."""
+        from maya import cmds
+
+        namespace = container["namespace"]
+        container_name = container["objectName"]
+
+        self.log.info("Removing '%s' from Maya.." % container["name"])
+
+        container_content = cmds.sets(container_name, query=True)
+        nodes = cmds.ls(container_content, long=True)
+
+        nodes.append(container_name)
+
+        try:
+            cmds.delete(nodes)
+        except ValueError:
+            # Already implicitly deleted by Maya upon removing reference
+            pass
+
+        cmds.namespace(removeNamespace=namespace, deleteNamespaceContent=True)
+
+    def update(self, container, representation):
+        """Update RenderSetup setting by overwriting existing settings."""
+        pypelib.show_message(
+            "Render setup update",
+            "Render setup setting will be overwritten by new version. All "
+            "setting specified by user not included in loaded version "
+            "will be lost.")
+        path = api.get_representation_path(representation)
+        with open(path, "r") as file:
+            renderSetup.instance().decode(
+                json.load(file), renderSetup.DECODE_AND_OVERWRITE, None)
+
+    def switch(self, container, representation):
+        """Switch representations."""
+        self.update(container, representation)


### PR DESCRIPTION
## Feature

Our render setup instance implementation was fast and dirty, allowing loading but nothing more. This PR adds ability to update and remove instance. It will show notification about overwriting all user modifications on render setup that are not published.

🎫 **Freshdesk ticked ID:** [#65](https://pype.freshdesk.com/a/tickets/65)
|---|