### PR TITLE
hotfix/photoshop save as is explicit

### DIFF
--- a/pype/plugins/photoshop/publish/extract_image.py
+++ b/pype/plugins/photoshop/publish/extract_image.py
@@ -36,16 +36,16 @@ class ExtractImage(pype.api.Extractor):
                     "png": photoshop.com_objects.PNGSaveOptions(),
                     "jpg": photoshop.com_objects.JPEGSaveOptions()
                 }
-
+                file_basename = os.path.splitext(
+                    photoshop.app().ActiveDocument.Name
+                )[0]
                 for extension, save_option in save_options.items():
+                    _filename = "{}.{}".format(file_basename, extension)
+                    files[extension] = _filename
+
+                    full_filename = os.path.join(staging_dir, _filename)
                     photoshop.app().ActiveDocument.SaveAs(
-                        staging_dir, save_option, True
-                    )
-                    files[extension] = "{} copy.{}".format(
-                        os.path.splitext(
-                            photoshop.app().ActiveDocument.Name
-                        )[0],
-                        extension
+                        full_filename, save_option, True
                     )
 
         representations = []

--- a/pype/plugins/photoshop/publish/extract_review.py
+++ b/pype/plugins/photoshop/publish/extract_review.py
@@ -24,9 +24,10 @@ class ExtractReview(pype.api.Extractor):
             layers.append(image_instance[0])
 
         # Perform extraction
-        output_image = "{} copy.jpg".format(
+        output_image = "{}.jpg".format(
             os.path.splitext(photoshop.app().ActiveDocument.Name)[0]
         )
+        output_image_path = os.path.join(staging_dir, output_image)
         with photoshop.maintained_visibility():
             # Hide all other layers.
             extract_ids = [
@@ -39,7 +40,9 @@ class ExtractReview(pype.api.Extractor):
                     layer.Visible = False
 
             photoshop.app().ActiveDocument.SaveAs(
-                staging_dir, photoshop.com_objects.JPEGSaveOptions(), True
+                output_image_path,
+                photoshop.com_objects.JPEGSaveOptions(),
+                True
             )
 
         ffmpeg_path = pype.lib.get_ffmpeg_tool_path("ffmpeg")
@@ -56,7 +59,7 @@ class ExtractReview(pype.api.Extractor):
         thumbnail_path = os.path.join(staging_dir, "thumbnail.jpg")
         args = [
             ffmpeg_path, "-y",
-            "-i", os.path.join(staging_dir, output_image),
+            "-i", output_image_path,
             "-vf", "scale=300:-1",
             "-vframes", "1",
             thumbnail_path
@@ -77,7 +80,7 @@ class ExtractReview(pype.api.Extractor):
         mov_path = os.path.join(staging_dir, "review.mov")
         args = [
             ffmpeg_path, "-y",
-            "-i", os.path.join(staging_dir, output_image),
+            "-i", output_image_path,
             "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",
             "-vframes", "1",
             mov_path


### PR DESCRIPTION
## Issue
- extract plugins in photoshop were saving files to folder without specifying filename and expected that saved file will end with `"{basename} copy.{extension}"` because the `copy` is hardcoded it won't work on different languages (e.g. French will have `copie`)

## Changes
- it is send full path to expected file to SaveAs method