### PR TITLE
change deprecated -intra parameter in ffmpeg to new `-g`

### DIFF
--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -528,6 +528,9 @@ def burnins_from_data(
         if pix_fmt:
             ffmpeg_args.append("-pix_fmt {}".format(pix_fmt))
 
+    # Use group one (same as `-intra` argument, which is deprecated)
+    ffmpeg_args.append("-g 1")
+
     ffmpeg_args_str = " ".join(ffmpeg_args)
     burnin.render(
         output_path, args=ffmpeg_args_str, overwrite=overwrite, **data


### PR DESCRIPTION
## Issue
- output from burnin script has wrong keyframes

## Suggested solution
- add ffmpeg argument `-g 1` (replacement of deprecated `-intra`) in burnin script so output should have right keyframes

### Warnings
- @jezscha can you test it as you have ready testing data
- @mkolar PR is to master, is it OK?