### PR TITLE
Cleanup plugin fail on instances without staging dir

### DIFF
--- a/pype/plugins/global/publish/cleanup.py
+++ b/pype/plugins/global/publish/cleanup.py
@@ -71,12 +71,16 @@ class CleanUp(pyblish.api.InstancePlugin):
         temp_root = tempfile.gettempdir()
         staging_dir = instance.data.get("stagingDir", None)
 
+        if not staging_dir:
+            self.log.info("Staging dir not set.")
+            return
+
         if not os.path.normpath(staging_dir).startswith(temp_root):
             self.log.info("Skipping cleanup. Staging directory is not in the "
                           "temp folder: %s" % staging_dir)
             return
 
-        if not staging_dir or not os.path.exists(staging_dir):
+        if not os.path.exists(staging_dir):
             self.log.info("No staging directory found: %s" % staging_dir)
             return
 


### PR DESCRIPTION
## Problem

This PR fixes cleanup plugin so it won't fail on instances withou staging dir set.