### PR TITLE
Hotfix/allow enable disable suspending logs

### DIFF
--- a/pype/modules/standalonepublish/publish.py
+++ b/pype/modules/standalonepublish/publish.py
@@ -83,6 +83,8 @@ def cli_publish(data, gui=True):
     envcopy["SAPUBLISH_INPATH"] = json_data_path
     envcopy["PYBLISHGUI"] = "pyblish_pype"
     envcopy["PUBLISH_PATHS"] = os.pathsep.join(PUBLISH_PATHS)
+    if data.get("family", "").lower() == "editorial":
+        envcopy["PYBLISH_SUSPEND_LOGS"] = "1"
 
     result = execute(
         [sys.executable, PUBLISH_SCRIPT_PATH],

--- a/pype/tools/pyblish_pype/util.py
+++ b/pype/tools/pyblish_pype/util.py
@@ -309,3 +309,12 @@ class OrderGroups:
             return group_range
 
         return float(group_range)
+
+
+def env_variable_to_bool(env_key):
+    value = os.environ.get(env_key)
+    if value is not None:
+        value = value.lower()
+        if value in ("true", "1", "yes"):
+            return True
+    return False

--- a/pype/tools/pyblish_pype/window.py
+++ b/pype/tools/pyblish_pype/window.py
@@ -55,6 +55,7 @@ class Window(QtWidgets.QDialog):
         super(Window, self).__init__(parent=parent)
 
         self._suspend_logs = False
+
         # Use plastique style for specific ocations
         # TODO set style name via environment variable
         low_keys = {
@@ -511,6 +512,10 @@ class Window(QtWidgets.QDialog):
 
         self.tabs[current_page].setChecked(True)
 
+        self.apply_log_suspend_value(
+            util.env_variable_to_bool("PYBLISH_SUSPEND_LOGS")
+        )
+
     # -------------------------------------------------------------------------
     #
     # Event handlers
@@ -633,8 +638,11 @@ class Window(QtWidgets.QDialog):
         self.footer_button_play.setEnabled(False)
         self.footer_button_stop.setEnabled(False)
 
-    def on_suspend_clicked(self):
-        self._suspend_logs = not self._suspend_logs
+    def on_suspend_clicked(self, value=None):
+        self.apply_log_suspend_value(not self._suspend_logs)
+
+    def apply_log_suspend_value(self, value):
+        self._suspend_logs = value
         if self.state["current_page"] == "terminal":
             self.on_tab_changed("overview")
 


### PR DESCRIPTION
## Issue
- editorial publishing is slow because of logs updates in gui

## Changes
- pyblish pype has possibility to enable suspending of logs with environment variable `PYBLISH_SUSPEND_LOGS`
- if editorial is published from standalone publisher the `PYBLISH_SUSPEND_LOGS` is automatically set to `"1"`