### PR TITLE
Bugfix/empty enumerator attributes

### DIFF
--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -409,6 +409,10 @@ class CustomAttributes(BaseAction):
                     ))
                 )
             )
+
+        # Make sure there is at least one item
+        if not app_definitions:
+            app_definitions.append({"empty": "< Empty >"})
         return app_definitions
 
     def applications_attribute(self, event):
@@ -431,6 +435,10 @@ class CustomAttributes(BaseAction):
         for tool_name, usage in tool_usages.items():
             if usage:
                 tools_data.append({tool_name: tool_name})
+
+        # Make sure there is at least one item
+        if not tools_data:
+            tools_data.append({"empty": "< Empty >"})
 
         tools_custom_attr_data = {
             "label": "Tools",


### PR DESCRIPTION
## Issue
Enumerator custom attribute definition in Ftrack does not allow to have empty list in possible values. If none of tools or applications is set to True (as using) the attribute creation will crash.

## Suggested solution
Make sure tools and applications attributes always have at least one item in, to not raise an exception. The item name and label is `"empty": "< Empty"`.