### PR TITLE
Hotfix/last changes before release2115

### DIFF
--- a/pype/modules/standalonepublish/widgets/widget_drop_frame.py
+++ b/pype/modules/standalonepublish/widgets/widget_drop_frame.py
@@ -18,7 +18,7 @@ class DropDataFrame(QtWidgets.QFrame):
         ".jng", ".jpeg", ".jpeg-ls", ".jpeg", ".2000", ".jpg", ".xr",
         ".jpeg", ".xt", ".jpeg-hdr", ".kra", ".mng", ".miff", ".nrrd",
         ".ora", ".pam", ".pbm", ".pgm", ".ppm", ".pnm", ".pcx", ".pgf",
-        ".pictor", ".png", ".psd", ".psb", ".psp", ".qtvr", ".ras",
+        ".pictor", ".png", ".psb", ".psp", ".qtvr", ".ras",
         ".rgbe", ".logluv", ".tiff", ".sgi", ".tga", ".tiff", ".tiff/ep",
         ".tiff/it", ".ufo", ".ufp", ".wbmp", ".webp", ".xbm", ".xcf",
         ".xpm", ".xwd"
@@ -37,7 +37,6 @@ class DropDataFrame(QtWidgets.QFrame):
         "image_file": image_extensions,
         "video_file": video_extensions
     }
-    ffprobe_ignore_extensions = [".psd"]
 
     def __init__(self, parent):
         super().__init__()
@@ -284,12 +283,7 @@ class DropDataFrame(QtWidgets.QFrame):
         if 'file_info' in data:
             file_info = data['file_info']
 
-        if (
-            ext not in self.ffprobe_ignore_extensions
-            and (
-                ext in self.image_extensions or ext in self.video_extensions
-            )
-        ):
+        if ext in self.image_extensions or ext in self.video_extensions:
             probe_data = self.load_data_with_probe(filepath)
             if 'fps' not in data:
                 # default value

--- a/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
@@ -117,7 +117,7 @@ class ExtractBGMainGroups(pype.api.Extractor):
                 ).format(layer.name))
                 continue
 
-            filename = "{}.png".format(layer_name)
+            filename = "{:0>2}_{}.png".format(layer_idx, layer_name)
             layer_data = {
                 "index": layer_idx,
                 "name": layer.name,


### PR DESCRIPTION
## Changes
- Standalone publisher does not have ".psd" extentsion as image so it is not used for ffprobe and psd files are not handled same way as images and grouped to sequences
- Added index number to the start of filename in bg main group extractor for PSD batch