### PR TITLE
Move launcher window to top if launcher action is clicked

### DIFF
--- a/pype/modules/avalon_apps/avalon_app.py
+++ b/pype/modules/avalon_apps/avalon_app.py
@@ -48,6 +48,8 @@ class AvalonApps:
     def show_launcher(self):
         # if app_launcher don't exist create it/otherwise only show main window
         self.app_launcher.show()
+        self.app_launcher.raise_()
+        self.app_launcher.activateWindow()
 
     def show_library_loader(self):
         libraryloader.show(


### PR DESCRIPTION
## Issue
- launcher tool stays hidden if launcher window is shown in back and action is clicked

## Solution
- activate and raise the window to pop it