### PR TITLE
Disabled editing of items in launcher

### DIFF
--- a/pype/tools/launcher/widgets.py
+++ b/pype/tools/launcher/widgets.py
@@ -85,6 +85,7 @@ class ActionBar(QtWidgets.QWidget):
         view.setViewMode(QtWidgets.QListView.IconMode)
         view.setResizeMode(QtWidgets.QListView.Adjust)
         view.setSelectionMode(QtWidgets.QListView.NoSelection)
+        view.setEditTriggers(QtWidgets.QListView.NoEditTriggers)
         view.setWrapping(True)
         view.setGridSize(QtCore.QSize(70, 75))
         view.setIconSize(QtCore.QSize(30, 30))
@@ -206,6 +207,7 @@ class TasksWidget(QtWidgets.QWidget):
 
         view = QtWidgets.QTreeView(self)
         view.setIndentation(0)
+        view.setEditTriggers(QtWidgets.QTreeView.NoEditTriggers)
         model = TaskModel(self.dbcon)
         view.setModel(model)
 


### PR DESCRIPTION
## Issue
Currently is possible to edit text of items in task view and actions view.

## Changes
Disable editing of items in tasks and actions view.