### PR TITLE
add ability to skip integration of rendered frames

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -276,6 +276,9 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
         published_representations = {}
         for idx, repre in enumerate(instance.data["representations"]):
+            if "delete" in repre.get("tags", []):
+                continue
+
             published_files = []
 
             # create template data for Anatomy

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -203,6 +203,9 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
     # script path for publish_filesequence.py
     publishing_script = None
 
+    # poor man exclusion
+    skip_integration_repre_list = []
+
     def _create_metadata_path(self, instance):
         ins_data = instance.data
         # Ensure output dir exists
@@ -466,6 +469,10 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "tags": ["review"] if preview else []
             }
 
+            # poor man exclusion
+            if ext in self.skip_integration_repre_list:
+                rep["tags"].append("delete")
+
             self._solve_families(new_instance, preview)
 
             new_instance["representations"] = [rep]
@@ -545,8 +552,12 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "tags": ["review", "preview"] if preview else [],
             }
 
+            # poor man exclusion
+            if ext in self.skip_integration_repre_list:
+                rep["tags"].append("delete")
+
             if instance.get("multipartExr", False):
-                rep["tags"].append["multipartExr"]
+                rep["tags"].append("multipartExr")
 
             representations.append(rep)
 


### PR DESCRIPTION
Stop integrating representation if they are having `delete` tags in them to lower network / internet trafic