### PR TITLE
Fix: allow thumbnail creation for single frame renders

### DIFF
--- a/pype/plugins/global/publish/extract_jpeg.py
+++ b/pype/plugins/global/publish/extract_jpeg.py
@@ -48,7 +48,9 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
                 continue
 
             if not isinstance(repre['files'], (list, tuple)):
-                continue
+                input_file = repre['files']
+            else:
+                input_file = repre['files'][0]
 
             stagingdir = os.path.normpath(repre.get("stagingDir"))
             input_file = repre['files'][0]


### PR DESCRIPTION
## Problem

When publishing single frame renders, thumbnail was not created. This is fixing how file name is determined from non-list entry `files` in representation.