### PR TITLE
Enhanced Ftrack credentials GUI

### DIFF
--- a/pype/modules/ftrack/tray/ftrack_module.py
+++ b/pype/modules/ftrack/tray/ftrack_module.py
@@ -78,10 +78,13 @@ class FtrackModule:
     def on_login_change(self):
         self.bool_logged = True
 
-        self.action_credentials.setIcon(self.icon_logged)
-        self.action_credentials.setToolTip(
-            "Logged as user \"{}\"".format(self.widget_login.user_input.text())
-        )
+        if self.action_credentials:
+            self.action_credentials.setIcon(self.icon_logged)
+            self.action_credentials.setToolTip(
+                "Logged as user \"{}\"".format(
+                    self.widget_login.user_input.text()
+                )
+            )
 
         self.set_menu_visibility()
         self.start_action_server()
@@ -90,8 +93,9 @@ class FtrackModule:
         credentials.clear_credentials()
         self.stop_action_server()
 
-        self.action_credentials.setIcon(self.icon_not_logged)
-        self.action_credentials.setToolTip("Logged out")
+        if self.action_credentials:
+            self.action_credentials.setIcon(self.icon_not_logged)
+            self.action_credentials.setToolTip("Logged out")
 
         log.info("Logged out of Ftrack")
         self.bool_logged = False

--- a/pype/modules/ftrack/tray/ftrack_module.py
+++ b/pype/modules/ftrack/tray/ftrack_module.py
@@ -2,7 +2,7 @@ import os
 import time
 import datetime
 import threading
-from Qt import QtCore, QtWidgets
+from Qt import QtCore, QtWidgets, QtGui
 
 import ftrack_api
 from ..ftrack_server.lib import check_ftrack_url
@@ -10,7 +10,7 @@ from ..ftrack_server import socket_thread
 from ..lib import credentials
 from . import login_dialog
 
-from pype.api import Logger
+from pype.api import Logger, resources
 
 
 log = Logger().get_logger("FtrackModule", "ftrack")
@@ -19,7 +19,7 @@ log = Logger().get_logger("FtrackModule", "ftrack")
 class FtrackModule:
     def __init__(self, main_parent=None, parent=None):
         self.parent = parent
-        self.widget_login = login_dialog.Login_Dialog_ui(self)
+
         self.thread_action_server = None
         self.thread_socket_server = None
         self.thread_timer = None
@@ -29,8 +29,22 @@ class FtrackModule:
         self.bool_action_thread_running = False
         self.bool_timer_event = False
 
+        self.widget_login = login_dialog.CredentialsDialog()
+        self.widget_login.login_changed.connect(self.on_login_change)
+        self.widget_login.logout_signal.connect(self.on_logout)
+
+        self.action_credentials = None
+        self.icon_logged = QtGui.QIcon(
+            resources.get_resource("icons", "circle_green.png")
+        )
+        self.icon_not_logged = QtGui.QIcon(
+            resources.get_resource("icons", "circle_orange.png")
+        )
+
     def show_login_widget(self):
         self.widget_login.show()
+        self.widget_login.activateWindow()
+        self.widget_login.raise_()
 
     def validate(self):
         validation = False
@@ -39,9 +53,10 @@ class FtrackModule:
         ft_api_key = cred.get("api_key")
         validation = credentials.check_credentials(ft_user, ft_api_key)
         if validation:
+            self.widget_login.set_credentials(ft_user, ft_api_key)
             credentials.set_env(ft_user, ft_api_key)
             log.info("Connected to Ftrack successfully")
-            self.loginChange()
+            self.on_login_change()
 
             return validation
 
@@ -60,14 +75,23 @@ class FtrackModule:
         return validation
 
     # Necessary - login_dialog works with this method after logging in
-    def loginChange(self):
+    def on_login_change(self):
         self.bool_logged = True
+
+        self.action_credentials.setIcon(self.icon_logged)
+        self.action_credentials.setToolTip(
+            "Logged as user \"{}\"".format(self.widget_login.user_input.text())
+        )
+
         self.set_menu_visibility()
         self.start_action_server()
 
-    def logout(self):
+    def on_logout(self):
         credentials.clear_credentials()
         self.stop_action_server()
+
+        self.action_credentials.setIcon(self.icon_not_logged)
+        self.action_credentials.setToolTip("Logged out")
 
         log.info("Logged out of Ftrack")
         self.bool_logged = False
@@ -218,43 +242,45 @@ class FtrackModule:
     # Definition of Tray menu
     def tray_menu(self, parent_menu):
         # Menu for Tray App
-        self.menu = QtWidgets.QMenu('Ftrack', parent_menu)
-        self.menu.setProperty('submenu', 'on')
-
-        # Actions - server
-        self.smActionS = self.menu.addMenu("Action server")
-
-        self.aRunActionS = QtWidgets.QAction(
-            "Run action server", self.smActionS
-        )
-        self.aResetActionS = QtWidgets.QAction(
-            "Reset action server", self.smActionS
-        )
-        self.aStopActionS = QtWidgets.QAction(
-            "Stop action server", self.smActionS
-        )
-
-        self.aRunActionS.triggered.connect(self.start_action_server)
-        self.aResetActionS.triggered.connect(self.reset_action_server)
-        self.aStopActionS.triggered.connect(self.stop_action_server)
-
-        self.smActionS.addAction(self.aRunActionS)
-        self.smActionS.addAction(self.aResetActionS)
-        self.smActionS.addAction(self.aStopActionS)
+        tray_menu = QtWidgets.QMenu("Ftrack", parent_menu)
 
         # Actions - basic
-        self.aLogin = QtWidgets.QAction("Login", self.menu)
-        self.aLogin.triggered.connect(self.validate)
-        self.aLogout = QtWidgets.QAction("Logout", self.menu)
-        self.aLogout.triggered.connect(self.logout)
+        action_credentials = QtWidgets.QAction("Credentials", tray_menu)
+        action_credentials.triggered.connect(self.show_login_widget)
+        if self.bool_logged:
+            icon = self.icon_logged
+        else:
+            icon = self.icon_not_logged
+        action_credentials.setIcon(icon)
+        tray_menu.addAction(action_credentials)
+        self.action_credentials = action_credentials
 
-        self.menu.addAction(self.aLogin)
-        self.menu.addAction(self.aLogout)
+        # Actions - server
+        tray_server_menu = tray_menu.addMenu("Action server")
 
+        self.action_server_run = QtWidgets.QAction(
+            "Run action server", tray_server_menu
+        )
+        self.action_server_reset = QtWidgets.QAction(
+            "Reset action server", tray_server_menu
+        )
+        self.action_server_stop = QtWidgets.QAction(
+            "Stop action server", tray_server_menu
+        )
+
+        self.action_server_run.triggered.connect(self.start_action_server)
+        self.action_server_reset.triggered.connect(self.reset_action_server)
+        self.action_server_stop.triggered.connect(self.stop_action_server)
+
+        tray_server_menu.addAction(self.action_server_run)
+        tray_server_menu.addAction(self.action_server_reset)
+        tray_server_menu.addAction(self.action_server_stop)
+
+        self.tray_server_menu = tray_server_menu
         self.bool_logged = False
         self.set_menu_visibility()
 
-        parent_menu.addMenu(self.menu)
+        parent_menu.addMenu(tray_menu)
 
     def tray_start(self):
         self.validate()
@@ -264,19 +290,15 @@ class FtrackModule:
 
     # Definition of visibility of each menu actions
     def set_menu_visibility(self):
-
-        self.smActionS.menuAction().setVisible(self.bool_logged)
-        self.aLogin.setVisible(not self.bool_logged)
-        self.aLogout.setVisible(self.bool_logged)
-
+        self.tray_server_menu.menuAction().setVisible(self.bool_logged)
         if self.bool_logged is False:
             if self.bool_timer_event is True:
                 self.stop_timer_thread()
             return
 
-        self.aRunActionS.setVisible(not self.bool_action_server_running)
-        self.aResetActionS.setVisible(self.bool_action_thread_running)
-        self.aStopActionS.setVisible(self.bool_action_server_running)
+        self.action_server_run.setVisible(not self.bool_action_server_running)
+        self.action_server_reset.setVisible(self.bool_action_thread_running)
+        self.action_server_stop.setVisible(self.bool_action_server_running)
 
         if self.bool_timer_event is False:
             self.start_timer_thread()

--- a/pype/modules/ftrack/tray/login_dialog.py
+++ b/pype/modules/ftrack/tray/login_dialog.py
@@ -232,7 +232,6 @@ class CredentialsDialog(QtWidgets.QDialog):
 
         # If there is an existing server thread running we need to stop it.
         if self._login_server_thread:
-            self._login_server_thread.stop()
             self._login_server_thread.join()
             self._login_server_thread = None
 

--- a/pype/modules/ftrack/tray/login_dialog.py
+++ b/pype/modules/ftrack/tray/login_dialog.py
@@ -224,6 +224,8 @@ class CredentialsDialog(QtWidgets.QDialog):
             self.set_error(
                 "We're unable to sign in to Ftrack with these credentials"
             )
+        else:
+            self._close_widget()
 
     def _on_ftrack_login_clicked(self):
         url = self.check_url(self.ftsite_input.text())
@@ -251,6 +253,7 @@ class CredentialsDialog(QtWidgets.QDialog):
             ))
         else:
             self.set_is_logged(True)
+            self._close_widget()
 
     def login_with_credentials(self, username, api_key):
         verification = credentials.check_credentials(username, api_key)

--- a/pype/modules/ftrack/tray/login_dialog.py
+++ b/pype/modules/ftrack/tray/login_dialog.py
@@ -35,6 +35,8 @@ class CredentialsDialog(QtWidgets.QDialog):
         self.setMaximumSize(QtCore.QSize(self.SIZE_W + 100, self.SIZE_H + 100))
         self.setStyleSheet(style.load_stylesheet())
 
+        self.login_changed.connect(self._on_login)
+
         self.ui_init()
 
     def ui_init(self):
@@ -202,6 +204,10 @@ class CredentialsDialog(QtWidgets.QDialog):
     def _invalid_input(self, input_widget):
         input_widget.setStyleSheet("border: 1px solid red;")
 
+    def _on_login(self):
+        self.set_is_logged(True)
+        self._close_widget()
+
     def _on_login_clicked(self):
         username = self.user_input.text().strip()
         api_key = self.api_input.text().strip()
@@ -224,8 +230,6 @@ class CredentialsDialog(QtWidgets.QDialog):
             self.set_error(
                 "We're unable to sign in to Ftrack with these credentials"
             )
-        else:
-            self._close_widget()
 
     def _on_ftrack_login_clicked(self):
         url = self.check_url(self.ftsite_input.text())
@@ -251,9 +255,6 @@ class CredentialsDialog(QtWidgets.QDialog):
                 "Somthing happened with Ftrack login."
                 " Try enter Username and API key manually."
             ))
-        else:
-            self.set_is_logged(True)
-            self._close_widget()
 
     def login_with_credentials(self, username, api_key):
         verification = credentials.check_credentials(username, api_key)

--- a/pype/modules/ftrack/tray/login_tools.py
+++ b/pype/modules/ftrack/tray/login_tools.py
@@ -2,7 +2,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib import parse
 import webbrowser
 import functools
-from Qt import QtCore
+import threading
 from pype.api import resources
 
 
@@ -55,20 +55,17 @@ class LoginServerHandler(BaseHTTPRequestHandler):
             )
 
 
-class LoginServerThread(QtCore.QThread):
+class LoginServerThread(threading.Thread):
     '''Login server thread.'''
 
-    # Login signal.
-    loginSignal = QtCore.Signal(object, object, object)
-
-    def start(self, url):
-        '''Start thread.'''
+    def __init__(self, url, callback):
         self.url = url
-        super(LoginServerThread, self).start()
+        self.callback = callback
+        super(LoginServerThread, self).__init__()
 
     def _handle_login(self, api_user, api_key):
         '''Login to server with *api_user* and *api_key*.'''
-        self.loginSignal.emit(self.url, api_user, api_key)
+        self.callback(api_user, api_key)
 
     def run(self):
         '''Listen for events.'''

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -537,6 +537,14 @@ class PypeTrayApplication(QtWidgets.QApplication):
         super(self.__class__, self).__init__(sys.argv)
         # Allows to close widgets without exiting app
         self.setQuitOnLastWindowClosed(False)
+
+        # Allow show icon istead of python icon in task bar (Windows)
+        if os.name == "nt":
+            import ctypes
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+                u"pype_tray"
+            )
+
         # Sets up splash
         splash_widget = self.set_splash()
 


### PR DESCRIPTION
## Changes
- Skipped Login/Logout actions in tray menu, replaced with `Credentials` action which shows credentials window
- Credentials action has Green icon when logged and orange when not logged
    - I tried to visualize if is logged or not, maybe would be better to use 2 different icons instead of color images
- Credentials window has 2 states Simple/Advanced
    - Simple has button `Ftrack login` without user and api key inputs
    - Advanced has button `Login` and both user and api key inputs are visible
- When logged in, the user and api key inputs are visible and showing currently logged user (not editable)
    - Not sure if API key should be visible too? It can be handy to be able the key...

## Menu when logged in
![image](https://user-images.githubusercontent.com/43494761/91295681-bae8fd80-e79b-11ea-8565-7ce663fdaa58.png)

## Menu when not logged in
![image](https://user-images.githubusercontent.com/43494761/91296270-a48f7180-e79c-11ea-8e26-77a134052439.png)

## Credentials widget Simple
![image](https://user-images.githubusercontent.com/43494761/91296301-b113ca00-e79c-11ea-96d2-4f18d08a6d42.png)

## Credentials widget Advanced
![image](https://user-images.githubusercontent.com/43494761/91296319-b7a24180-e79c-11ea-92a7-ffb266659841.png)

## Credentials widget when logged in
![image](https://user-images.githubusercontent.com/43494761/91296220-904b7480-e79c-11ea-8d0c-8edc883fa6ad.png)