### PR TITLE
Fix: strip dot from repre names in single frame renders

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -428,7 +428,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                                        "to render, don't know what to do "
                                        "with them.")
                 col = rem[0]
-                _, ext = os.path.splitext(col)
+                ext = os.path.splitext(col)[1].lstrip(".")
             else:
                 # but we really expect only one collection.
                 # Nothing else make sense.


### PR DESCRIPTION
## Bug:

single frame renders had `.` in names of their representations.