### PR TITLE
Nuke: skip thumbnail creation on farm submission.

### DIFF
--- a/pype/plugins/global/publish/extract_jpeg.py
+++ b/pype/plugins/global/publish/extract_jpeg.py
@@ -81,6 +81,11 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             jpeg_items.append("-i {}".format(full_input_path))
             # output arguments from presets
             jpeg_items.extend(ffmpeg_args.get("output") or [])
+
+            # If its a movie file, we just want one frame.
+            if repre["ext"] == "mov":
+                jpeg_items.append("-vframes 1")
+
             # output file
             jpeg_items.append(full_output_path)
 

--- a/pype/plugins/nuke/publish/extract_thumbnail.py
+++ b/pype/plugins/nuke/publish/extract_thumbnail.py
@@ -15,10 +15,12 @@ class ExtractThumbnail(pype.api.Extractor):
     order = pyblish.api.ExtractorOrder + 0.01
     label = "Extract Thumbnail"
 
-    families = ["review", "render.farm"]
+    families = ["review"]
     hosts = ["nuke"]
 
     def process(self, instance):
+        if "render.farm" in instance.data["families"]:
+            return
 
         with anlib.maintained_selection():
             self.log.debug("instance: {}".format(instance))


### PR DESCRIPTION
The thumbnail is being created when publishing from the baked colourspace movie.