### PR TITLE
#241 - Implementation of pype-config/presets/plugins/standalonepublisher

### DIFF
--- a/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
@@ -642,39 +642,7 @@
                                     "label": "ffmpeg_args",
                                     "children": [
                                         {
-                                            "type": "list",
-                                            "object_type": "text",
-                                            "key": "input",
-                                            "label": "input"
-                                        },
-                                        {
-                                            "type": "list",
-                                            "object_type": "text",
-                                            "key": "output",
-                                            "label": "output"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "type": "dict",
-                            "collapsable": true,
-                            "key": "ExtractReviewSP",
-                            "label": "ExtractReviewSP",
-                            "is_group": true,
-                            "children": [
-                                {
-                                    "type": "dict",
-                                    "collapsable": false,
-                                    "key": "outputs",
-                                    "label": "outputs",
-                                    "children": [
-                                        {
-                                            "type": "dict",
-                                            "collapsable": false,
-                                            "key": "h264",
-                                            "label": "h264",
+                                            "type": "dict-form",
                                             "children": [
                                                 {
                                                     "type": "list",
@@ -687,17 +655,6 @@
                                                     "object_type": "text",
                                                     "key": "output",
                                                     "label": "output"
-                                                },
-                                                {
-                                                    "type": "list",
-                                                    "object_type": "text",
-                                                    "key": "tags",
-                                                    "label": "tags"
-                                                },
-                                                {
-                                                    "type": "text",
-                                                    "key": "ext",
-                                                    "label": "ext"
                                                 }
                                             ]
                                         }

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
@@ -614,6 +614,100 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "dict",
+            "collapsable": true,
+            "key": "standalonepublisher",
+            "label": "Standalone Publisher",
+            "children": [
+                {
+                    "type": "dict",
+                    "collapsable": true,
+                    "key": "publish",
+                    "label": "Publish plugins",
+                    "is_file": true,
+                    "children": [
+                        {
+                            "type": "dict",
+                            "collapsable": true,
+                            "key": "ExtractThumbnailSP",
+                            "label": "ExtractThumbnailSP",
+                            "is_group": true,
+                            "children": [
+                                {
+                                    "type": "dict",
+                                    "collapsable": false,
+                                    "key": "ffmpeg_args",
+                                    "label": "ffmpeg_args",
+                                    "children": [
+                                        {
+                                            "type": "list",
+                                            "object_type": "text",
+                                            "key": "input",
+                                            "label": "input"
+                                        },
+                                        {
+                                            "type": "list",
+                                            "object_type": "text",
+                                            "key": "output",
+                                            "label": "output"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "dict",
+                            "collapsable": true,
+                            "key": "ExtractReviewSP",
+                            "label": "ExtractReviewSP",
+                            "is_group": true,
+                            "children": [
+                                {
+                                    "type": "dict",
+                                    "collapsable": false,
+                                    "key": "outputs",
+                                    "label": "outputs",
+                                    "children": [
+                                        {
+                                            "type": "dict",
+                                            "collapsable": false,
+                                            "key": "h264",
+                                            "label": "h264",
+                                            "children": [
+                                                {
+                                                    "type": "list",
+                                                    "object_type": "text",
+                                                    "key": "input",
+                                                    "label": "input"
+                                                },
+                                                {
+                                                    "type": "list",
+                                                    "object_type": "text",
+                                                    "key": "output",
+                                                    "label": "output"
+                                                },
+                                                {
+                                                    "type": "list",
+                                                    "object_type": "text",
+                                                    "key": "tags",
+                                                    "label": "tags"
+                                                },
+                                                {
+                                                    "type": "text",
+                                                    "key": "ext",
+                                                    "label": "ext"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Implemented schema for  `pype-config/presets/plugins/standalonepublisher`
![241_standalonepublisher](https://user-images.githubusercontent.com/4457962/93337516-87911000-f829-11ea-8e6b-1507d1704be7.png)


Requires:
pypeclub/pype/#479