### PR TITLE
#241 - Implemented pype-config/presets/plugins/nukestudio/filter.json

### DIFF
--- a/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
@@ -532,53 +532,11 @@
             "label": "NukeStudio",
             "children": [
                 {
-                    "type": "dict",
+                    "type": "raw-json",
                     "collapsable": true,
                     "key": "filter",
-                    "label": "Filter",
-                    "is_file": true,
-                    "children": [
-                        {
-                            "type": "dict",
-                            "collapsable": true,
-                            "checkbox_key": "enabled",
-                            "key": "strict",
-                            "label": "strict",
-                            "is_group": true,
-                            "children": [
-                                {
-                                    "type": "boolean",
-                                    "key": "ValidateVersion",
-                                    "label": "ValidateVersion"
-                                },
-                                {
-                                    "type": "boolean",
-                                    "key": "VersionUpWorkfile",
-                                    "label": "VersionUpWorkfile"
-                                }
-                            ]
-                        },
-                        {
-                            "type": "dict",
-                            "collapsable": true,
-                            "checkbox_key": "enabled",
-                            "key": "benevolent",
-                            "label": "benevolent",
-                            "is_group": true,
-                            "children": [
-                                {
-                                    "type": "boolean",
-                                    "key": "ValidateVersion",
-                                    "label": "ValidateVersion"
-                                },
-                                {
-                                    "type": "boolean",
-                                    "key": "VersionUpWorkfile",
-                                    "label": "VersionUpWorkfile"
-                                }
-                            ]
-                        }
-                    ]
+                    "label": "Publish GUI Filters",
+                    "is_file": true
                 },
                 {
                     "type": "dict",

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
@@ -534,6 +534,55 @@
                 {
                     "type": "dict",
                     "collapsable": true,
+                    "key": "filter",
+                    "label": "Filter",
+                    "is_file": true,
+                    "children": [
+                        {
+                            "type": "dict",
+                            "collapsable": true,
+                            "checkbox_key": "enabled",
+                            "key": "strict",
+                            "label": "strict",
+                            "is_group": true,
+                            "children": [
+                                {
+                                    "type": "boolean",
+                                    "key": "ValidateVersion",
+                                    "label": "ValidateVersion"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "VersionUpWorkfile",
+                                    "label": "VersionUpWorkfile"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "dict",
+                            "collapsable": true,
+                            "checkbox_key": "enabled",
+                            "key": "benevolent",
+                            "label": "benevolent",
+                            "is_group": true,
+                            "children": [
+                                {
+                                    "type": "boolean",
+                                    "key": "ValidateVersion",
+                                    "label": "ValidateVersion"
+                                },
+                                {
+                                    "type": "boolean",
+                                    "key": "VersionUpWorkfile",
+                                    "label": "VersionUpWorkfile"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
+                    "collapsable": true,
                     "key": "publish",
                     "label": "Publish plugins",
                     "is_file": true,


### PR DESCRIPTION
Added filter.json implementation for GUI settings

Not sure if there isn't better option as these check-boxes seem of two disjunctive sets (either strict OR benevolent). But current .json allowed nonsensical variants too.

![241_nukestudio](https://user-images.githubusercontent.com/4457962/93357908-2117ec00-f841-11ea-8224-51299396887d.png)
