### PR TITLE
Schema type represents one schema

### DIFF
--- a/pype/tools/settings/settings/README.md
+++ b/pype/tools/settings/settings/README.md
@@ -27,10 +27,7 @@
 ```
 {
     "type": "schema",
-    "children": [
-        "my_schema_name",
-        "my_other_schema_name"
-    ]
+    "name": "my_schema_name"
 }
 ```
 

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/0_project_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/0_project_gui_schema.json
@@ -22,9 +22,7 @@
             "children": [
                 {
                     "type": "schema",
-                    "children": [
-                        "1_plugins_gui_schema"
-                    ]
+                    "name": "1_plugins_gui_schema"
                 }
             ]
         }

--- a/pype/tools/settings/settings/gui_schemas/system_schema/0_system_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/0_system_gui_schema.json
@@ -7,12 +7,16 @@
             "key": "global",
             "children": [{
                 "type": "schema",
-                "children": [
-                    "1_tray_items",
-                    "1_applications_gui_schema",
-                    "1_tools_gui_schema",
-                    "1_intents_gui_schema"
-                ]
+                "name": "1_tray_items"
+            }, {
+                "type": "schema",
+                "name": "1_applications_gui_schema"
+            }, {
+                "type": "schema",
+                "name": "1_tools_gui_schema"
+            }, {
+                "type": "schema",
+                "name": "1_intents_gui_schema"
             }]
         }, {
             "type": "dict-invisible",
@@ -29,6 +33,9 @@
                 "label": "Muster - Templates mapping",
                 "is_file": true
             }]
+        }, {
+            "type": "schema",
+            "name": "1_examples"
         }
     ]
 }

--- a/pype/tools/settings/settings/widgets/lib.py
+++ b/pype/tools/settings/settings/widgets/lib.py
@@ -69,12 +69,11 @@ def _fill_inner_schemas(schema_data, schema_collection):
             new_children.append(new_child)
             continue
 
-        for schema_name in child["children"]:
-            new_child = _fill_inner_schemas(
-                schema_collection[schema_name],
-                schema_collection
-            )
-            new_children.append(new_child)
+        new_child = _fill_inner_schemas(
+            schema_collection[child["name"]],
+            schema_collection
+        )
+        new_children.append(new_child)
 
     schema_data["children"] = new_children
     return schema_data


### PR DESCRIPTION
## Issue
- current schema type definition is strange as schema names which should replace the item in schema are in list under key `children`

## Changes
- with this implementation schema type represents only one schema name

### BEFORE
```
{
    ...
    {
        "type": "schema",
        "children": [
            "schema_1",
            "schema_2"
        ]
    }
    ...
}
```

### NOW
```
{
    ...
    {
        "type": "schema",
        "name": "schema_1"
    }, {
        "type": "schema",
        "name": "schema_2"
    }
    ...
}
```