### PR TITLE
Feature/item label click reacts to item

### DIFF
--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -285,65 +285,75 @@ class SettingObject:
 
         return "-".join(items) or ""
 
+    def show_actions_menu(self, event=None):
+        if event and event.button() != QtCore.Qt.RightButton:
+            return
+
+        if not self.allow_actions:
+            if event:
+                return self.mouseReleaseEvent(event)
+            return
+
+        menu = QtWidgets.QMenu()
+
+        actions_mapping = {}
+        if self.child_modified:
+            action = QtWidgets.QAction("Discard changes")
+            actions_mapping[action] = self._discard_changes
+            menu.addAction(action)
+
+        if (
+            self.is_overidable
+            and not self.is_overriden
+            and not self.any_parent_is_group
+        ):
+            action = QtWidgets.QAction("Set project override")
+            actions_mapping[action] = self._set_as_overriden
+            menu.addAction(action)
+
+        if (
+            not self.is_overidable
+            and (
+                self.has_studio_override
+            )
+        ):
+            action = QtWidgets.QAction("Reset to pype default")
+            actions_mapping[action] = self._reset_to_pype_default
+            menu.addAction(action)
+
+        if (
+            not self.is_overidable
+            and not self.is_overriden
+            and not self.any_parent_is_group
+            and not self._had_studio_override
+        ):
+            action = QtWidgets.QAction("Set studio default")
+            actions_mapping[action] = self._set_studio_default
+            menu.addAction(action)
+
+        if (
+            not self.any_parent_overriden()
+            and (self.is_overriden or self.child_overriden)
+        ):
+            # TODO better label
+            action = QtWidgets.QAction("Remove project override")
+            actions_mapping[action] = self._remove_overrides
+            menu.addAction(action)
+
+        if not actions_mapping:
+            action = QtWidgets.QAction("< No action >")
+            actions_mapping[action] = None
+            menu.addAction(action)
+
+        result = menu.exec_(QtGui.QCursor.pos())
+        if result:
+            to_run = actions_mapping[result]
+            if to_run:
+                to_run()
+
     def mouseReleaseEvent(self, event):
         if self.allow_actions and event.button() == QtCore.Qt.RightButton:
-            menu = QtWidgets.QMenu()
-
-            actions_mapping = {}
-            if self.child_modified:
-                action = QtWidgets.QAction("Discard changes")
-                actions_mapping[action] = self._discard_changes
-                menu.addAction(action)
-
-            if (
-                self.is_overidable
-                and not self.is_overriden
-                and not self.any_parent_is_group
-            ):
-                action = QtWidgets.QAction("Set project override")
-                actions_mapping[action] = self._set_as_overriden
-                menu.addAction(action)
-
-            if (
-                not self.is_overidable
-                and (
-                    self.has_studio_override
-                )
-            ):
-                action = QtWidgets.QAction("Reset to pype default")
-                actions_mapping[action] = self._reset_to_pype_default
-                menu.addAction(action)
-
-            if (
-                not self.is_overidable
-                and not self.is_overriden
-                and not self.any_parent_is_group
-                and not self._had_studio_override
-            ):
-                action = QtWidgets.QAction("Set studio default")
-                actions_mapping[action] = self._set_studio_default
-                menu.addAction(action)
-
-            if (
-                not self.any_parent_overriden()
-                and (self.is_overriden or self.child_overriden)
-            ):
-                # TODO better label
-                action = QtWidgets.QAction("Remove project override")
-                actions_mapping[action] = self._remove_overrides
-                menu.addAction(action)
-
-            if not actions_mapping:
-                action = QtWidgets.QAction("< No action >")
-                actions_mapping[action] = None
-                menu.addAction(action)
-
-            result = menu.exec_(QtGui.QCursor.pos())
-            if result:
-                to_run = actions_mapping[result]
-                if to_run:
-                    to_run()
-            return
+            return self.show_actions_menu()
 
         mro = type(self).mro()
         index = mro.index(self.__class__)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -5,7 +5,8 @@ from Qt import QtWidgets, QtCore, QtGui
 from .widgets import (
     ExpandingWidget,
     NumberSpinBox,
-    PathInput
+    PathInput,
+    GridLabelWidget
 )
 from .lib import NOT_SET, METADATA_KEY, TypeToKlass, CHILD_OFFSET
 from avalon.vendor import qtawesome
@@ -2227,16 +2228,14 @@ class DictWidget(QtWidgets.QWidget, SettingObject):
         if not klass.expand_in_grid:
             label = child_configuration.get("label")
             if label is not None:
-                label_widget = QtWidgets.QLabel(label, self)
-                self.content_layout.addWidget(
-                    label_widget, row, 0, 1, 1,
-                    alignment=QtCore.Qt.AlignRight | QtCore.Qt.AlignTop
-                )
+                label_widget = GridLabelWidget(label, self)
+                self.content_layout.addWidget(label_widget, row, 0, 1, 1)
 
         item = klass(child_configuration, self, label_widget=label_widget)
         item.value_changed.connect(self._on_value_change)
 
         if label_widget:
+            label_widget.input_field = item
             self.content_layout.addWidget(item, row, 1, 1, 1)
         else:
             self.content_layout.addWidget(item, row, 0, 1, 2)
@@ -2535,16 +2534,14 @@ class DictInvisible(QtWidgets.QWidget, SettingObject):
         if not klass.expand_in_grid:
             label = child_configuration.get("label")
             if label is not None:
-                label_widget = QtWidgets.QLabel(label, self)
-                self.content_layout.addWidget(
-                    label_widget, row, 0, 1, 1,
-                    alignment=QtCore.Qt.AlignRight | QtCore.Qt.AlignTop
-                )
+                label_widget = GridLabelWidget(label, self)
+                self.content_layout.addWidget(label_widget, row, 0, 1, 1)
 
         item = klass(child_configuration, self, label_widget=label_widget)
         item.value_changed.connect(self._on_value_change)
 
         if label_widget:
+            label_widget.input_field = item
             self.content_layout.addWidget(item, row, 1, 1, 1)
         else:
             self.content_layout.addWidget(item, row, 0, 1, 2)

--- a/pype/tools/settings/settings/widgets/widgets.py
+++ b/pype/tools/settings/settings/widgets/widgets.py
@@ -226,3 +226,56 @@ class UnsavedChangesDialog(QtWidgets.QDialog):
 
     def on_discard_pressed(self):
         self.done(2)
+
+
+class SpacerWidget(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super(SpacerWidget, self).__init__(parent)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+
+
+class GridLabelWidget(QtWidgets.QWidget):
+    def __init__(self, label, parent=None):
+        super(GridLabelWidget, self).__init__(parent)
+
+        self.input_field = None
+
+        self.properties = {}
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        label_proxy = QtWidgets.QWidget(self)
+        label_proxy_layout = QtWidgets.QHBoxLayout(label_proxy)
+        label_proxy_layout.setContentsMargins(0, 0, 0, 0)
+        label_proxy_layout.setSpacing(0)
+
+        label_widget = QtWidgets.QLabel(label, label_proxy)
+        spacer_widget_h = SpacerWidget(label_proxy)
+        label_proxy_layout.addWidget(
+            spacer_widget_h, 0, alignment=QtCore.Qt.AlignRight
+        )
+        label_proxy_layout.addWidget(
+            label_widget, 0, alignment=QtCore.Qt.AlignRight
+        )
+
+        spacer_widget_v = SpacerWidget(self)
+
+        layout.addWidget(label_proxy, 0)
+        layout.addWidget(spacer_widget_v, 1)
+
+        self.label_widget = label_widget
+
+    def setProperty(self, name, value):
+        cur_value = self.properties.get(name)
+        if cur_value == value:
+            return
+
+        self.label_widget.setProperty(name, value)
+        self.label_widget.style().polish(self.label_widget)
+
+    def mouseReleaseEvent(self, event):
+        if self.input_field:
+            return self.input_field.show_actions_menu(event)
+        return super(GridLabelWidget, self).mouseReleaseEvent(event)


### PR DESCRIPTION
## Changes
- right click on item label under `dict` or `dict-invisible` item is equal to right click on item itself

## Before this PR
- Actions showed with right click on `"Multiline text"` label in the image are related to `"Examples"` item, not the input value of `"Multiline text"`
![image](https://user-images.githubusercontent.com/43494761/93791867-0e345b80-fc35-11ea-98a9-7cbab6fac2c2.png)