### PR TITLE
Items are stretched in settings GUI

### DIFF
--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -268,6 +268,10 @@ class SystemWidget(QtWidgets.QWidget):
         self.input_fields.append(item)
         self.content_layout.addWidget(item)
 
+        # Add spacer to stretch children guis
+        spacer = QtWidgets.QWidget(self.content_widget)
+        self.content_layout.addWidget(spacer, 1)
+
 
 class ProjectListView(QtWidgets.QListView):
     left_mouse_released_at = QtCore.Signal(QtCore.QModelIndex)
@@ -529,6 +533,10 @@ class ProjectWidget(QtWidgets.QWidget):
         item = klass(child_configuration, self)
         self.input_fields.append(item)
         self.content_layout.addWidget(item)
+
+        # Add spacer to stretch children guis
+        spacer = QtWidgets.QWidget(self.content_widget)
+        self.content_layout.addWidget(spacer, 1)
 
     def _on_project_change(self):
         project_name = self.project_list_widget.project_name()


### PR DESCRIPTION
## Issue
- items are expanded to all available height because of `GridLabel`

![image](https://user-images.githubusercontent.com/43494761/93860548-8b0c1780-fcbf-11ea-81a6-baf38a9cdffb.png)


## Changes
- system and project widgets add one more spacer widget so all widgets above are stretched