### PR TITLE
Copy file and file path are working in Maya 2020

### DIFF
--- a/pype/plugins/global/load/copy_file.py
+++ b/pype/plugins/global/load/copy_file.py
@@ -20,8 +20,8 @@ class CopyFile(api.Loader):
     def copy_file_to_clipboard(path):
         from avalon.vendor.Qt import QtCore, QtWidgets
 
-        app = QtWidgets.QApplication.instance()
-        assert app, "Must have running QApplication instance"
+        clipboard = QtWidgets.QApplication.clipboard()
+        assert clipboard, "Must have running QApplication instance"
 
         # Build mime data for clipboard
         data = QtCore.QMimeData()
@@ -29,5 +29,4 @@ class CopyFile(api.Loader):
         data.setUrls([url])
 
         # Set to Clipboard
-        clipboard = app.clipboard()
         clipboard.setMimeData(data)

--- a/pype/plugins/global/load/copy_file_path.py
+++ b/pype/plugins/global/load/copy_file_path.py
@@ -19,11 +19,10 @@ class CopyFilePath(api.Loader):
 
     @staticmethod
     def copy_path_to_clipboard(path):
-        from avalon.vendor.Qt import QtCore, QtWidgets
+        from avalon.vendor.Qt import QtWidgets
 
-        app = QtWidgets.QApplication.instance()
-        assert app, "Must have running QApplication instance"
+        clipboard = QtWidgets.QApplication.clipboard()
+        assert clipboard, "Must have running QApplication instance"
 
         # Set to Clipboard
-        clipboard = app.clipboard()
         clipboard.setText(os.path.normpath(path))


### PR DESCRIPTION
## Issue
- `CopyFile` and `CopyFilePath` are not working when Qt is running `QCoreApplication`

## Changes
- using static methods for the same approach instead