### PR TITLE
Base of pype module manager

### DIFF
--- a/pype/modules/__init__.py
+++ b/pype/modules/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .base import PypeModule
 
 __all__ = (

--- a/pype/modules/__init__.py
+++ b/pype/modules/__init__.py
@@ -1,0 +1,5 @@
+from .base import PypeModule
+
+__all__ = (
+    "PypeModule",
+)

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -1,0 +1,26 @@
+from uuid import uuid4
+from pype.api import Logger
+
+
+class PypeModule:
+    """Base class of pype module."""
+    enabled = False
+    name = None
+    _id = None
+
+    def __init__(self, settings):
+        if self.name is None:
+            self.name = self.__class__.__name__
+
+        self.log = Logger().get_logger(self.name)
+
+        self.settings = settings.get(self.name)
+        self.enabled = settings.get("enabled", False)
+        self._id = uuid4()
+
+    @property
+    def id(self):
+        return self._id
+
+    def startup_environments(self):
+        return {}

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -1,10 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Base class for Pype Modules."""
 from uuid import uuid4
-from abc import ABC
+from abc import ABC, abstractmethod
 from pype.api import Logger
 
 
 class PypeModule(ABC):
-    """Base class of pype module."""
+    """Base class of pype module.
+
+    Attributes:
+        id (UUID): Module id.
+        enabled (bool): Is module enabled.
+        name (str): Module name.
+    """
+
     enabled = False
     name = None
     _id = None
@@ -23,5 +32,7 @@ class PypeModule(ABC):
     def id(self):
         return self._id
 
+    @abstractmethod
     def startup_environments(self):
+        """Get startup environments for module."""
         return {}

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -1,8 +1,9 @@
 from uuid import uuid4
+from abc import ABC
 from pype.api import Logger
 
 
-class PypeModule:
+class PypeModule(ABC):
     """Base class of pype module."""
     enabled = False
     name = None

--- a/pype/modules_manager.py
+++ b/pype/modules_manager.py
@@ -43,7 +43,6 @@ class PypeModuleManager:
                 modules.append(
                     __import__(import_name, fromlist=[""])
                 )
-                print(import_name, sys.modules.get("PyQt5"))
 
             except Exception:
                 self.log.warning(

--- a/pype/modules_manager.py
+++ b/pype/modules_manager.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import inspect
 
 import pype.modules

--- a/pype/modules_manager.py
+++ b/pype/modules_manager.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import inspect
+
+import pype.modules
+from pype.modules import PypeModule
+from pype.settings import system_settings
+from pype.api import Logger
+
+
+class PypeModuleManager:
+    skip_module_names = ("__pycache__", )
+
+    def __init__(self):
+        self.log = Logger().get_logger(
+            "{}.{}".format(__name__, self.__class__.__name__)
+        )
+
+        self.pype_modules = self.find_pype_modules()
+
+    def modules_environments(self):
+        environments = {}
+        for pype_module in self.pype_modules.values():
+            environments.update(pype_module.startup_environments())
+        return environments
+
+    def find_pype_modules(self):
+        settings = system_settings()
+        modules = []
+        dirpath = os.path.dirname(pype.modules.__file__)
+        for module_name in os.listdir(dirpath):
+            # Check if path lead to a folder
+            full_path = os.path.join(dirpath, module_name)
+            if not os.path.isdir(full_path):
+                continue
+
+            # Skip known invalid names
+            if module_name in self.skip_module_names:
+                continue
+
+            import_name = "pype.modules.{}".format(module_name)
+            try:
+                modules.append(
+                    __import__(import_name, fromlist=[""])
+                )
+                print(import_name, sys.modules.get("PyQt5"))
+
+            except Exception:
+                self.log.warning(
+                    "Couldn't import {}".format(import_name), exc_info=True
+                )
+
+        pype_module_classes = []
+        for module in modules:
+            try:
+                pype_module_classes.extend(
+                    self._classes_from_module(PypeModule, module)
+                )
+            except Exception:
+                self.log.warning(
+                    "Couldn't import {}".format(import_name), exc_info=True
+                )
+
+        pype_modules = {}
+        for pype_module_class in pype_module_classes:
+            try:
+                pype_module = pype_module_class(settings)
+                if pype_module.enabled:
+                    pype_modules[pype_module.id] = pype_module
+            except Exception:
+                self.log.warning(
+                    "Couldn't create instance of {}".format(
+                        pype_module_class.__class__.__name__
+                    ),
+                    exc_info=True
+                )
+        return pype_modules
+
+    def _classes_from_module(self, superclass, module):
+        classes = list()
+
+        def recursive_bases(klass):
+            output = []
+            output.extend(klass.__bases__)
+            for base in klass.__bases__:
+                output.extend(recursive_bases(base))
+            return output
+
+        for name in dir(module):
+            # It could be anything at this point
+            obj = getattr(module, name)
+
+            if not inspect.isclass(obj) or not len(obj.__bases__) > 0:
+                continue
+
+            # Use string comparison rather than `issubclass`
+            # in order to support reloading of this module.
+            bases = recursive_bases(obj)
+            if not any(base.__name__ == superclass.__name__ for base in bases):
+                continue
+
+            classes.append(obj)
+
+        return classes


### PR DESCRIPTION
## Description
- currently we don't have manager for pype modules which can be used in any case and be able access modules in headless mode
    - this PR does not allow that yet too, just prepare basic parts to be able to do that in future
- implemented `PypeModule` class which should be used as Base for all modules
    - this is not done yet since current modules use here and there widgets and can't be used in headless at all and are created for tray module manager
- imeplemented `PypeModuleManager` which should collect all available modules, and connect them
- with this we can add modules that are not used in tray at all

## TODO in next PRs
- modify modules to be ready for `PypeModuleManager`
    - without GUI imports and separate logic
- create wrapper for tray usage
- requires to modify all current modules as they are tray based now