### PR TITLE
Refresh Ftrack locations on session rollback

### DIFF
--- a/pype/plugins/ftrack/publish/integrate_ftrack_api.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_api.py
@@ -97,6 +97,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
         except Exception:
             tp, value, tb = sys.exc_info()
             session.rollback()
+            session._configure_locations()
             six.reraise(tp, value, tb)
 
     def process(self, instance):
@@ -178,6 +179,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     session.rollback()
+                    session._configure_locations()
                     six.reraise(tp, value, tb)
 
             # Adding metadata
@@ -228,6 +230,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     session.rollback()
+                    session._configure_locations()
                     six.reraise(tp, value, tb)
 
             # Adding metadata
@@ -242,6 +245,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                     session.commit()
                 except Exception:
                     session.rollback()
+                    session._configure_locations()
                     self.log.warning((
                         "Comment was not possible to set for AssetVersion"
                         "\"{0}\". Can't set it's value to: \"{1}\""
@@ -258,6 +262,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                         continue
                     except Exception:
                         session.rollback()
+                        session._configure_locations()
 
                 self.log.warning((
                     "Custom Attrubute \"{0}\""
@@ -272,6 +277,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
             except Exception:
                 tp, value, tb = sys.exc_info()
                 session.rollback()
+                session._configure_locations()
                 six.reraise(tp, value, tb)
 
             # Component
@@ -316,6 +322,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     session.rollback()
+                    session._configure_locations()
                     six.reraise(tp, value, tb)
 
                 # Reset members in memory
@@ -432,6 +439,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     session.rollback()
+                    session._configure_locations()
                     six.reraise(tp, value, tb)
 
             if assetversion_entity not in used_asset_versions:

--- a/pype/plugins/ftrack/publish/integrate_ftrack_note.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_note.py
@@ -145,4 +145,5 @@ class IntegrateFtrackNote(pyblish.api.InstancePlugin):
             except Exception:
                 tp, value, tb = sys.exc_info()
                 session.rollback()
+                session._configure_locations()
                 six.reraise(tp, value, tb)

--- a/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
+++ b/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
@@ -128,6 +128,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     self.session.rollback()
+                    self.session._configure_locations()
                     six.reraise(tp, value, tb)
 
             # TASKS
@@ -156,6 +157,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
                 except Exception:
                     tp, value, tb = sys.exc_info()
                     self.session.rollback()
+                    self.session._configure_locations()
                     six.reraise(tp, value, tb)
 
             # Incoming links.
@@ -165,6 +167,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
             except Exception:
                 tp, value, tb = sys.exc_info()
                 self.session.rollback()
+                self.session._configure_locations()
                 six.reraise(tp, value, tb)
 
             # Create notes.
@@ -185,6 +188,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
             except Exception:
                 tp, value, tb = sys.exc_info()
                 self.session.rollback()
+                self.session._configure_locations()
                 six.reraise(tp, value, tb)
 
             # Import children.
@@ -201,6 +205,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
             except Exception:
                 tp, value, tb = sys.exc_info()
                 self.session.rollback()
+                self.session._configure_locations()
                 six.reraise(tp, value, tb)
 
         # Create new links.
@@ -242,6 +247,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         except Exception:
             tp, value, tb = sys.exc_info()
             self.session.rollback()
+            self.session._configure_locations()
             six.reraise(tp, value, tb)
 
         return task
@@ -256,6 +262,7 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         except Exception:
             tp, value, tb = sys.exc_info()
             self.session.rollback()
+            self.session._configure_locations()
             six.reraise(tp, value, tb)
 
         return entity
@@ -270,7 +277,8 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         except Exception:
             tp, value, tb = sys.exc_info()
             self.session.rollback()
-            raise
+            self.session._configure_locations()
+            six.reraise(tp, value, tb)
 
     def auto_sync_on(self, project):
 
@@ -283,4 +291,5 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
         except Exception:
             tp, value, tb = sys.exc_info()
             self.session.rollback()
-            raise
+            self.session._configure_locations()
+            six.reraise(tp, value, tb)


### PR DESCRIPTION
## Issue
- when integration of ftrack component fails it is executed `session.rollback()` but in that case are lost information about Ftrack loactions in ftrack session so every next component integration will fail with error which says nothing about what happened the first time

## Changes
- session trigger refresh of ftrack locations when `session.rollback()` is called