### PR TITLE
Dict as widget can't apply project overrides

### DIFF
--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -2442,7 +2442,9 @@ class DictWidget(QtWidgets.QWidget, SettingObject):
         self._state = None
         self._child_state = None
 
-        if not self.as_widget:
+        if self.as_widget:
+            override_values = parent_values
+        else:
             metadata = {}
             groups = tuple()
             override_values = NOT_SET


### PR DESCRIPTION
## Issue
- project override values are not propagated in right way if `dict` is used as widget

## Changes
- values are propagated in right way now