### PR TITLE
Grid label tweaks in settings GUI

### DIFF
--- a/pype/tools/settings/settings/widgets/widgets.py
+++ b/pype/tools/settings/settings/widgets/widgets.py
@@ -266,6 +266,9 @@ class GridLabelWidget(QtWidgets.QWidget):
         layout.addWidget(label_proxy, 0)
         layout.addWidget(spacer_widget_v, 1)
 
+        label_proxy.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        label_widget.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+
         self.label_widget = label_widget
 
     def setProperty(self, name, value):

--- a/pype/tools/settings/settings/widgets/widgets.py
+++ b/pype/tools/settings/settings/widgets/widgets.py
@@ -243,10 +243,11 @@ class GridLabelWidget(QtWidgets.QWidget):
         self.properties = {}
 
         layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(0, 2, 0, 0)
         layout.setSpacing(0)
 
         label_proxy = QtWidgets.QWidget(self)
+
         label_proxy_layout = QtWidgets.QHBoxLayout(label_proxy)
         label_proxy_layout.setContentsMargins(0, 0, 0, 0)
         label_proxy_layout.setSpacing(0)


### PR DESCRIPTION
## Description
- label widget in `GridLabel ` is offset by 2 pixels to be more "like" in right place next to input widget
- all widgets in `GridLabel` are transparent so consistency of background is not broken when parent has different bg color