### PR TITLE
Hotfix/ftrack remove fix

### DIFF
--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -878,8 +878,9 @@ class SyncToAvalonEvent(BaseEvent):
                 self.process_session.commit()
 
                 found_idx = None
-                for idx, _entity in enumerate(self._avalon_ents):
-                    if _entity["_id"] == avalon_entity["_id"]:
+                proj_doc, asset_docs = self._avalon_ents
+                for idx, asset_doc in enumerate(asset_docs):
+                    if asset_doc["_id"] == avalon_entity["_id"]:
                         found_idx = idx
                         break
 
@@ -894,7 +895,8 @@ class SyncToAvalonEvent(BaseEvent):
                     new_entity_id
                 )
                 # Update cached entities
-                self._avalon_ents[found_idx] = avalon_entity
+                asset_docs[found_idx] = avalon_entity
+                self._avalon_ents = proj_doc, asset_docs
 
                 if self._avalon_ents_by_id is not None:
                     mongo_id = avalon_entity["_id"]

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -717,6 +717,9 @@ class SyncToAvalonEvent(BaseEvent):
         if not self.ftrack_removed:
             return
         ent_infos = self.ftrack_removed
+        self.log.debug(
+            "Processing removed entities: {}".format(str(ent_infos))
+        )
         removable_ids = []
         recreate_ents = []
         removed_names = []
@@ -1260,6 +1263,10 @@ class SyncToAvalonEvent(BaseEvent):
         if not ent_infos:
             return
 
+        self.log.debug(
+            "Processing renamed entities: {}".format(str(ent_infos))
+        )
+
         renamed_tasks = {}
         not_found = {}
         changeable_queue = queue.Queue()
@@ -1454,6 +1461,10 @@ class SyncToAvalonEvent(BaseEvent):
         ent_infos = self.ftrack_added
         if not ent_infos:
             return
+
+        self.log.debug(
+            "Processing added entities: {}".format(str(ent_infos))
+        )
 
         cust_attrs, hier_attrs = self.avalon_cust_attrs
         entity_type_conf_ids = {}
@@ -1731,6 +1742,10 @@ class SyncToAvalonEvent(BaseEvent):
         if not self.ftrack_moved:
             return
 
+        self.log.debug(
+            "Processing moved entities: {}".format(str(self.ftrack_moved))
+        )
+
         ftrack_moved = {k: v for k, v in sorted(
             self.ftrack_moved.items(),
             key=(lambda line: len(
@@ -1860,6 +1875,10 @@ class SyncToAvalonEvent(BaseEvent):
         # Only custom attributes changes should get here
         if not self.ftrack_updated:
             return
+
+        self.log.debug(
+            "Processing updated entities: {}".format(str(self.ftrack_updated))
+        )
 
         ent_infos = self.ftrack_updated
         ftrack_mongo_mapping = {}

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -2144,6 +2144,7 @@ class SyncEntitiesFactory:
             "name": _name,
             "parent": parent_entity
         })
+        self.session.commit()
 
         final_entity = {}
         for k, v in av_entity.items():


### PR DESCRIPTION
## Issue
- issue happens when user remove Ftrack entity that has published content
    - recreating of removed entity in SyncToAvalon action is crashing because is trying to modify not yet existing entity
    - recreating of removed entity in SyncToAvalon event is crashing because of changed type of one attribute

## Changes
- both should be fixed now
- added few debug logs to sync to avalon event

## Note
- marked as hotfix since it may affect productions