### PR TITLE
List and Modifiable Dictionary items has modified object specification

### DIFF
--- a/pype/tools/settings/settings/README.md
+++ b/pype/tools/settings/settings/README.md
@@ -84,8 +84,8 @@
     "type": "list",
     "key": "profiles",
     "label": "Profiles",
-    "object_type": "dict-item",
-    "input_modifiers": {
+    "object_type": {
+        "type": "dict-item",
         "children": [
             {
                 "key": "families",
@@ -199,19 +199,32 @@
 - output is list
 - items can be added and removed
 - items in list must be the same type
-    - type of items is defined with key `"object_type"` where Pure input name is entered (e.g. `number`)
-    - because Pure inputs may have modifiers (`number` input has `minimum`, `maximum` and `decimals`) you can set these in key `"input_modifiers"`
+- type of items is defined with key `"object_type"`
+- there are 2 possible ways how to set the type:
+    1.) dictionary with item modifiers (`number` input has `minimum`, `maximum` and `decimals`) in that case item type must be set as value of `"type"` (example below)
+    2.) item type name as string without modifiers (e.g. `text`)
 
+1.) with item modifiers
 ```
 {
     "type": "list",
-    "object_type": "number",
     "key": "exclude_ports",
     "label": "Exclude ports",
-    "input_modifiers": {
-        "minimum": 1,
-        "maximum": 65535
+    "object_type": {
+        "type": "number", # number item type
+        "minimum": 1, # minimum modifier
+        "maximum": 65535 # maximum modifier
     }
+}
+```
+
+2.) without modifiers
+```
+{
+    "type": "list",
+    "key": "exclude_ports",
+    "label": "Exclude ports",
+    "object_type": "text"
 }
 ```
 
@@ -219,20 +232,35 @@
 - one of dictionary inputs, this is only used as value input
 - items in this input can be removed and added same way as in `list` input
 - value items in dictionary must be the same type
-    - type of items is defined with key `"object_type"` where Pure input name is entered (e.g. `number`)
-    - because Pure inputs may have modifiers (`number` input has `minimum`, `maximum` and `decimals`) you can set these in key `"input_modifiers"`
+- type of items is defined with key `"object_type"`
+- there are 2 possible ways how to set the type:
+    1.) dictionary with item modifiers (`number` input has `minimum`, `maximum` and `decimals`) in that case item type must be set as value of `"type"` (example below)
+    2.) item type name as string without modifiers (e.g. `text`)
 - this input can be expandable
     - that can be set with key `"expandable"` as `True`/`False` (Default: `True`)
         - with key `"expanded"` as `True`/`False` can be set that is expanded when GUI is opened (Default: `False`)
 
+1.) with item modifiers
 ```
 {
     "type": "dict-modifiable",
-    "object_type": "number",
-    "input_modifiers": {
+    "object_type": {
+        "type": "number",
         "minimum": 0,
         "maximum": 300
     },
+    "is_group": true,
+    "key": "templates_mapping",
+    "label": "Muster - Templates mapping",
+    "is_file": true
+}
+```
+
+2.) without modifiers
+```
+{
+    "type": "dict-modifiable",
+    "object_type": "text",
     "is_group": true,
     "key": "templates_mapping",
     "label": "Muster - Templates mapping",

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/1_plugins_gui_schema.json
@@ -172,8 +172,8 @@
                                     "type": "list",
                                     "key": "profiles",
                                     "label": "Profiles",
-                                    "object_type": "dict",
-                                    "input_modifiers": {
+                                    "object_type": {
+                                        "type": "dict",
                                         "children": [
                                             {
                                                 "key": "families",
@@ -192,8 +192,8 @@
                                                 "label": "Output Definitions",
                                                 "type": "dict-modifiable",
                                                 "highlight_content": true,
-                                                "object_type": "dict",
-                                                "input_modifiers": {
+                                                "object_type": {
+                                                    "type": "dict",
                                                     "children": [
                                                       {
                                                           "key": "ext",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/1_examples.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/1_examples.json
@@ -67,16 +67,16 @@
                     "type": "list",
                     "key": "list_item_of_multiline_texts",
                     "label": "List of multiline texts",
-                    "object_type": "text",
-                    "input_modifiers": {
+                    "object_type": {
+                        "type": "text",
                         "multiline": true
                     }
                 }, {
                     "type": "list",
                     "key": "list_item_of_floats",
                     "label": "List of floats",
-                    "object_type": "number",
-                    "input_modifiers": {
+                    "object_type": {
+                        "type": "number",
                         "decimal": 3,
                         "minimum": 1000,
                         "maximum": 2000
@@ -85,8 +85,8 @@
                     "type": "dict-modifiable",
                     "key": "modifiable_dict_of_integers",
                     "label": "Modifiable dict of integers",
-                    "object_type": "number",
-                    "input_modifiers": {
+                    "object_type": {
+                        "type": "number",
                         "decimal": 0,
                         "minimum": 10,
                         "maximum": 100
@@ -213,8 +213,8 @@
                     "type": "list",
                     "key": "dict_item",
                     "label": "DictItem in List",
-                    "object_type": "dict-item",
-                    "input_modifiers": {
+                    "object_type": {
+                        "type": "dict-item",
                         "children": [
                             {
                                 "key": "families",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/1_modules_gui_schema.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/1_modules_gui_schema.json
@@ -80,8 +80,8 @@
               "type": "list",
               "key": "statuses_name_change",
               "label": "Status name change",
-              "object_type": "text",
-              "input_modifiers": {
+              "object_type": {
+                "type": "text",
                 "multiline": false
               }
             }]
@@ -96,9 +96,9 @@
             "type": "dict-modifiable",
             "key": "status_update",
             "label": "Status Updates",
-            "object_type": "list",
-            "input_modifiers": {
-              "object_type": "text"
+            "object_type": {
+                "type": "list",
+                "object_type": "text"
             }
           },
             {
@@ -133,10 +133,10 @@
         },
         {
           "type": "list",
-          "object_type": "number",
           "key": "exclude_ports",
           "label": "Exclude ports",
-          "input_modifiers": {
+          "object_type": {
+            "type": "number",
             "minimum": 1,
             "maximum": 65535
           }
@@ -213,8 +213,8 @@
           "label": "Muster Resl URL"
         },{
           "type": "dict-modifiable",
-          "object_type": "number",
-          "input_modifiers": {
+          "object_type": {
+              "type": "number",
               "minimum": 0,
               "maximum": 300
           },

--- a/pype/tools/settings/settings/widgets/anatomy_types.py
+++ b/pype/tools/settings/settings/widgets/anatomy_types.py
@@ -271,9 +271,9 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         )
         multiroot_data = {
             "key": self.key,
-            "object_type": "path-widget",
             "expandable": False,
-            "input_modifiers": {
+            "object_type": {
+                "type": "path-widget",
                 "multiplatform": True
             }
         }

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1464,9 +1464,7 @@ class ListWidget(QtWidgets.QWidget, InputObject):
 
     def add_row(self, row=None, value=None, is_empty=False):
         # Create new item
-        item_widget = ListItem(
-            self.object_type, self.input_modifiers, self, self.inputs_widget
-        )
+        item_widget = ListItem(self.item_schema, self, self.inputs_widget)
 
         previous_field = None
         next_field = None
@@ -1652,11 +1650,8 @@ class ListStrictWidget(QtWidgets.QWidget, InputObject):
 
         children_item_mapping = []
         for child_configuration in input_data["object_types"]:
-            object_type = child_configuration["type"]
-
             item_widget = ListItem(
-                object_type, child_configuration, self, self.inputs_widget,
-                is_strict=True
+                child_configuration, self, self.inputs_widget, is_strict=True
             )
 
             self.input_fields.append(item_widget)
@@ -2030,9 +2025,6 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
 
         self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
 
-        self.object_type = input_data["object_type"]
-        self.input_modifiers = input_data.get("input_modifiers") or {}
-
         self.add_row(is_empty=True)
 
     def count(self):
@@ -2132,7 +2124,7 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
     def add_row(self, row=None, key=None, value=None, is_empty=False):
         # Create new item
         item_widget = ModifiableDictItem(
-            self.object_type, self.input_modifiers, self, self.content_widget
+            self.item_schema, self, self.content_widget
         )
         if is_empty:
             item_widget.set_as_empty()

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1190,8 +1190,7 @@ class ListItem(QtWidgets.QWidget, SettingObject):
     value_changed = QtCore.Signal(object)
 
     def __init__(
-        self, object_type, input_modifiers, config_parent, parent,
-        is_strict=False
+        self, item_schema, config_parent, parent, is_strict=False
     ):
         super(ListItem, self).__init__(parent)
 
@@ -1243,9 +1242,9 @@ class ListItem(QtWidgets.QWidget, SettingObject):
             layout.addWidget(self.add_btn, 0)
             layout.addWidget(self.remove_btn, 0)
 
-        ItemKlass = TypeToKlass.types[object_type]
+        ItemKlass = TypeToKlass.types[item_schema["type"]]
         self.value_input = ItemKlass(
-            input_modifiers,
+            item_schema,
             self,
             as_widget=True,
             label_widget=None
@@ -1759,7 +1758,7 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
     _btn_size = 20
     value_changed = QtCore.Signal(object)
 
-    def __init__(self, object_type, input_modifiers, config_parent, parent):
+    def __init__(self, item_schema, config_parent, parent):
         super(ModifiableDictItem, self).__init__(parent)
 
         self._set_default_attributes()
@@ -1779,13 +1778,13 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(3)
 
-        ItemKlass = TypeToKlass.types[object_type]
+        ItemKlass = TypeToKlass.types[item_schema["type"]]
 
         self.key_input = QtWidgets.QLineEdit(self)
         self.key_input.setObjectName("DictKey")
 
         self.value_input = ItemKlass(
-            input_modifiers,
+            item_schema,
             self,
             as_widget=True,
             label_widget=None

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1381,8 +1381,21 @@ class ListWidget(QtWidgets.QWidget, InputObject):
 
         self.initial_attributes(input_data, parent, as_widget)
 
-        self.object_type = input_data["object_type"]
-        self.input_modifiers = input_data.get("input_modifiers") or {}
+        object_type = input_data["object_type"]
+        if isinstance(object_type, dict):
+            self.item_schema = object_type
+        else:
+            self.item_schema = {
+                "type": object_type
+            }
+            # Backwards compatibility
+            input_modifiers = input_data.get("input_modifiers") or {}
+            if input_modifiers:
+                self.log.info((
+                    "Used deprecated key `input_modifiers` to define item."
+                    " Rather use `object_type` as dictionary with modifiers."
+                ))
+                self.item_schema.update(input_modifiers)
 
         self.input_fields = []
 
@@ -1948,6 +1961,22 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
         self.input_fields = []
 
         self.key = input_data["key"]
+
+        object_type = input_data["object_type"]
+        if isinstance(object_type, dict):
+            self.item_schema = object_type
+        else:
+            # Backwards compatibility
+            self.item_schema = {
+                "type": object_type
+            }
+            input_modifiers = input_data.get("input_modifiers") or {}
+            if input_modifiers:
+                self.log.info((
+                    "Used deprecated key `input_modifiers` to define item."
+                    " Rather use `object_type` as dictionary with modifiers."
+                ))
+                self.item_schema.update(input_modifiers)
 
         if input_data.get("highlight_content", False):
             content_state = "hightlighted"

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1391,7 +1391,7 @@ class ListWidget(QtWidgets.QWidget, InputObject):
             # Backwards compatibility
             input_modifiers = input_data.get("input_modifiers") or {}
             if input_modifiers:
-                self.log.info((
+                self.log.warning((
                     "Used deprecated key `input_modifiers` to define item."
                     " Rather use `object_type` as dictionary with modifiers."
                 ))
@@ -1967,7 +1967,7 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
             }
             input_modifiers = input_data.get("input_modifiers") or {}
             if input_modifiers:
-                self.log.info((
+                self.log.warning((
                     "Used deprecated key `input_modifiers` to define item."
                     " Rather use `object_type` as dictionary with modifiers."
                 ))

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import collections
 from Qt import QtWidgets, QtCore, QtGui
 from .widgets import (
@@ -11,6 +10,7 @@ from .widgets import (
 )
 from .multiselection_combobox import MultiSelectionComboBox
 from .lib import NOT_SET, METADATA_KEY, TypeToKlass, CHILD_OFFSET
+from pype.api import Logger
 from avalon.vendor import qtawesome
 
 
@@ -111,7 +111,7 @@ class SettingObject:
     def log(self):
         """Auto created logger for debugging."""
         if self._log is None:
-            self._log = logging.getLogger(self.__class__.__name__)
+            self._log = Logger().get_logger(self.__class__.__name__)
         return self._log
 
     @property


### PR DESCRIPTION
## Changes
- changed way how to define `object_type` for `list` and `dict-modifiable`
- currently `"object_type"` keep information about `"type"` and `"input_modifiers"` defined other possible modifiers like `"minimum"`, etc.
    - this has been changed and `"input_modifiers"`  key is skipped

- `"object_type"` can have full definition
```javascript
{
    "type": "list",
    "key": "exclude_ports",
    "label": "Exclude ports",
     // Full definiton
    "object_type": {
        "type": "number",
        "minimum": 1,
        "maximum": 65535
    }
}
```

- also if possible to enter only type if do not want to specify any modifiers
```javascript
{
    "key": "families",
    "label": "Families",
    "type": "list",
     // Only type definition
    "object_type": "text"
}
```