### PR TITLE
set port variable to None so the variable exists

### DIFF
--- a/pype/modules/websocket_server/websocket_server.py
+++ b/pype/modules/websocket_server/websocket_server.py
@@ -31,6 +31,7 @@ class WebSocketServer():
         self.client = None
         self.handlers = {}
 
+        port = None
         websocket_url = os.getenv("WEBSOCKET_URL")
         if websocket_url:
             parsed = urllib.parse.urlparse(websocket_url)

--- a/pype/modules/websocket_server/websocket_server.py
+++ b/pype/modules/websocket_server/websocket_server.py
@@ -37,7 +37,7 @@ class WebSocketServer():
             parsed = urllib.parse.urlparse(websocket_url)
             port = parsed.port
         if not port:
-            port = 8099  # fallback
+            port = 8098  # fallback
 
         self.app = web.Application()
 


### PR DESCRIPTION
## Issue
- websocket module raise exception because of missing variable 
```
Traceback (most recent call last):
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\tools\tray\pype_tray.py", line 225, in add_module
    obj = module.tray_init(self.tray_widget, self.main_window)
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\modules\websocket_server\__init__.py", line 5, in tray_init
    return WebSocketServer()
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\modules\websocket_server\websocket_server.py", line 38, in __init__
    if not port:
UnboundLocalERROR: local variable 'port' referenced before assignment
Traceback (most recent call last):
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\tools\tray\pype_tray.py", line 225, in add_module
    obj = module.tray_init(self.tray_widget, self.main_window)
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\modules\websocket_server\__init__.py", line 5, in tray_init
    return WebSocketServer()
  File "C:\CODE\__PYPE\dev\pype-setup\repos\pype\pype\modules\websocket_server\websocket_server.py", line 38, in __init__
    if not port:
UnboundLocalError: local variable 'port' referenced before assignment
```

## Changes
- set port variable to None so the variable exists