### PR TITLE
Maya: fix maya scene type preset exception

### DIFF
--- a/pype/plugins/maya/publish/extract_camera_mayaScene.py
+++ b/pype/plugins/maya/publish/extract_camera_mayaScene.py
@@ -101,7 +101,7 @@ class ExtractCameraMayaScene(pype.api.Extractor):
                     self.log.info(
                         "Using {} as scene type".format(self.scene_type))
                     break
-                except AttributeError:
+                except KeyError:
                     # no preset found
                     pass
 

--- a/pype/plugins/maya/publish/extract_maya_scene_raw.py
+++ b/pype/plugins/maya/publish/extract_maya_scene_raw.py
@@ -33,7 +33,7 @@ class ExtractMayaSceneRaw(pype.api.Extractor):
                     self.log.info(
                         "Using {} as scene type".format(self.scene_type))
                     break
-                except AttributeError:
+                except KeyError:
                     # no preset found
                     pass
         # Define extract output file path

--- a/pype/plugins/maya/publish/extract_model.py
+++ b/pype/plugins/maya/publish/extract_model.py
@@ -41,7 +41,7 @@ class ExtractModel(pype.api.Extractor):
                     self.log.info(
                         "Using {} as scene type".format(self.scene_type))
                     break
-                except AttributeError:
+                except KeyError:
                     # no preset found
                     pass
         # Define extract output file path

--- a/pype/plugins/maya/publish/extract_yeti_rig.py
+++ b/pype/plugins/maya/publish/extract_yeti_rig.py
@@ -111,7 +111,7 @@ class ExtractYetiRig(pype.api.Extractor):
                     self.log.info(
                         "Using {} as scene type".format(self.scene_type))
                     break
-                except AttributeError:
+                except KeyError:
                     # no preset found
                     pass
         yeti_nodes = cmds.ls(instance, type="pgYetiMaya")


### PR DESCRIPTION
## Bug

We were catching wrong exception (`AttributeError` instead of `KeyError` when deciding what preset to use, so when `ext_mapping.json` was used, extractor were crashing.