### PR TITLE
Maya: add look assigner to pype menu even if scriptsmenu is not available

### DIFF
--- a/pype/hosts/maya/menu.py
+++ b/pype/hosts/maya/menu.py
@@ -32,6 +32,15 @@ def deferred():
             command=lambda *args: BuildWorkfile().process()
         )
 
+    def add_look_assigner_item():
+        import mayalookassigner
+        cmds.menuItem(divider=True, parent=pipeline._menu)
+        cmds.menuItem(
+            "Maya Look assigner",
+            parent=pipeline._menu,
+            command=lambda *args: mayalookassigner.show()
+        )
+
     log.info("Attempting to install scripts menu..")
 
     try:
@@ -43,6 +52,7 @@ def deferred():
             "'scriptsmenu' module seems unavailable."
         )
         add_build_workfiles_item()
+        add_look_assigner_item()
         return
 
     # load configuration of custom menu

--- a/pype/hosts/maya/menu.py
+++ b/pype/hosts/maya/menu.py
@@ -36,7 +36,7 @@ def deferred():
         import mayalookassigner
         cmds.menuItem(divider=True, parent=pipeline._menu)
         cmds.menuItem(
-            "Maya Look assigner",
+            "Look assigner",
             parent=pipeline._menu,
             command=lambda *args: mayalookassigner.show()
         )

--- a/pype/hosts/maya/menu.py
+++ b/pype/hosts/maya/menu.py
@@ -34,7 +34,6 @@ def deferred():
 
     def add_look_assigner_item():
         import mayalookassigner
-        cmds.menuItem(divider=True, parent=pipeline._menu)
         cmds.menuItem(
             "Look assigner",
             parent=pipeline._menu,
@@ -42,6 +41,9 @@ def deferred():
         )
 
     log.info("Attempting to install scripts menu..")
+
+    add_build_workfiles_item()
+    add_look_assigner_item()
 
     try:
         import scriptsmenu.launchformaya as launchformaya
@@ -51,8 +53,6 @@ def deferred():
             "Skipping studio.menu install, because "
             "'scriptsmenu' module seems unavailable."
         )
-        add_build_workfiles_item()
-        add_look_assigner_item()
         return
 
     # load configuration of custom menu


### PR DESCRIPTION
## Feature

Add **Look Assigner** to Pype/Avalon Maya menu even if [scriptsmenu](https://github.com/Colorbleed/scriptsmenu) is not available.