### PR TITLE
Standalone publisher editorial plugins interfering

### DIFF
--- a/pype/plugins/global/publish/extract_hierarchy_avalon.py
+++ b/pype/plugins/global/publish/extract_hierarchy_avalon.py
@@ -1,6 +1,6 @@
 import pyblish.api
 from avalon import io
-
+from copy import deepcopy
 
 class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
     """Create entities in Avalon based on collected data."""
@@ -14,14 +14,12 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
         if "hierarchyContext" not in context.data:
             self.log.info("skipping IntegrateHierarchyToAvalon")
             return
+        hierarchy_context = deepcopy(context.data["hierarchyContext"])
 
         if not io.Session:
             io.install()
 
         active_assets = []
-        hierarchy_context = context.data["hierarchyContext"]
-        hierarchy_assets = self._get_assets(hierarchy_context)
-
         # filter only the active publishing insatnces
         for instance in context:
             if instance.data.get("publish") is False:
@@ -32,13 +30,13 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
 
             active_assets.append(instance.data["asset"])
 
-        # filter out only assets which are activated as isntances
-        new_hierarchy_assets = {k: v for k, v in hierarchy_assets.items()
-                                if k in active_assets}
+        # remove duplicity in list
+        self.active_assets = list(set(active_assets))
+        self.log.debug("__ self.active_assets: {}".format(self.active_assets))
 
-        # modify the hierarchy context so there are only fitred assets
-        self._set_assets(hierarchy_context, new_hierarchy_assets)
+        hierarchy_context = self._get_assets(hierarchy_context)
 
+        self.log.debug("__ hierarchy_context: {}".format(hierarchy_context))
         input_data = context.data["hierarchyContext"] = hierarchy_context
 
         self.project = None
@@ -178,14 +176,21 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
             Usually the last part of deep dictionary which
             is not having any children
         """
+        input_dict_copy = deepcopy(input_dict)
+
         for key in input_dict.keys():
+            self.log.debug("__ key: {}".format(key))
             # check if child key is available
             if input_dict[key].get("childs"):
                 # loop deeper
-                return self._get_assets(input_dict[key]["childs"])
+                input_dict_copy[key]["childs"] = self._get_assets(
+                    input_dict[key]["childs"])
             else:
-                # give the dictionary with assets
-                return input_dict
+                # filter out unwanted assets
+                if key not in self.active_assets:
+                    input_dict_copy.pop(key, None)
+
+        return input_dict_copy
 
     def _set_assets(self, input_dict, new_assets=None):
         """ Modify the hierarchy context dictionary.

--- a/pype/plugins/global/publish/extract_hierarchy_avalon.py
+++ b/pype/plugins/global/publish/extract_hierarchy_avalon.py
@@ -191,27 +191,3 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
                     input_dict_copy.pop(key, None)
 
         return input_dict_copy
-
-    def _set_assets(self, input_dict, new_assets=None):
-        """ Modify the hierarchy context dictionary.
-            It will replace the asset dictionary with only the filtred one.
-        """
-        for key in input_dict.keys():
-            # check if child key is available
-            if input_dict[key].get("childs"):
-                # return if this is just for testing purpose and no
-                # new_assets property is avalable
-                if not new_assets:
-                    return True
-
-                # test for deeper inner children availabelity
-                if self._set_assets(input_dict[key]["childs"]):
-                    # if one level deeper is still children available
-                    # then process farther
-                    self._set_assets(input_dict[key]["childs"], new_assets)
-                else:
-                    # or just assign the filtred asset ditionary
-                    input_dict[key]["childs"] = new_assets
-            else:
-                # test didnt find more childs in input dictionary
-                return None

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -453,6 +453,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         if audio_filters:
             all_args.append("-filter:a {}".format(",".join(audio_filters)))
 
+        all_args.append('-vf pad="width=ceil(iw/2)*2:height=ceil(ih/2)*2"')
         all_args.extend(output_args)
 
         return all_args

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -453,7 +453,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
         if audio_filters:
             all_args.append("-filter:a {}".format(",".join(audio_filters)))
 
-        all_args.append('-vf pad="width=ceil(iw/2)*2:height=ceil(ih/2)*2"')
         all_args.extend(output_args)
 
         return all_args

--- a/pype/plugins/standalonepublisher/publish/collect_clip_instances.py
+++ b/pype/plugins/standalonepublisher/publish/collect_clip_instances.py
@@ -17,13 +17,13 @@ class CollectClipInstances(pyblish.api.InstancePlugin):
     subsets = {
         "referenceMain": {
             "family": "review",
-            "families": ["review", "ftrack"],
+            "families": ["clip", "ftrack"],
             # "ftrackFamily": "review",
             "extension": ".mp4"
         },
         "audioMain": {
             "family": "audio",
-            "families": ["ftrack"],
+            "families": ["clip", "ftrack"],
             # "ftrackFamily": "audio",
             "extension": ".wav",
             # "version": 1

--- a/pype/plugins/standalonepublisher/publish/collect_instance_data.py
+++ b/pype/plugins/standalonepublisher/publish/collect_instance_data.py
@@ -1,0 +1,29 @@
+"""
+Requires:
+    Nothing
+
+Provides:
+    Instance
+"""
+
+import pyblish.api
+from pprint import pformat
+
+
+class CollectInstanceData(pyblish.api.InstancePlugin):
+    """
+    Collector with only one reason for its existence - remove 'ftrack'
+    family implicitly added by Standalone Publisher
+    """
+
+    label = "Collect instance data"
+    order = pyblish.api.CollectorOrder + 0.49
+    families = ["render", "plate"]
+    hosts = ["standalonepublisher"]
+
+    def process(self, instance):
+        fps = instance.data["assetEntity"]["data"]["fps"]
+        instance.data.update({
+            "fps": fps
+        })
+        self.log.debug(f"instance.data: {pformat(instance.data)}")

--- a/pype/plugins/standalonepublisher/publish/extract_shot_data.py
+++ b/pype/plugins/standalonepublisher/publish/extract_shot_data.py
@@ -10,7 +10,7 @@ class ExtractShotData(pype.api.Extractor):
 
     label = "Extract Shot Data"
     hosts = ["standalonepublisher"]
-    families = ["review", "audio"]
+    families = ["clip"]
 
     # presets
 

--- a/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
+++ b/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
@@ -64,6 +64,7 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
         else:
             # Convert to jpeg if not yet
             full_input_path = os.path.join(thumbnail_repre["stagingDir"], file)
+            full_input_path = '"{}"'.format(full_input_path)
             self.log.info("input {}".format(full_input_path))
 
             full_thumbnail_path = tempfile.mkstemp(suffix=".jpg")[1]

--- a/pype/plugins/standalonepublisher/publish/validate_editorial_resources.py
+++ b/pype/plugins/standalonepublisher/publish/validate_editorial_resources.py
@@ -1,5 +1,3 @@
-import os
-
 import pyblish.api
 import pype.api
 
@@ -9,10 +7,14 @@ class ValidateEditorialResources(pyblish.api.InstancePlugin):
 
     label = "Validate Editorial Resources"
     hosts = ["standalonepublisher"]
-    families = ["audio", "review"]
+    families = ["clip"]
+
     order = pype.api.ValidateContentsOrder
 
     def process(self, instance):
+        self.log.debug(
+            f"Instance: {instance}, Families: "
+            f"{[instance.data['family']] + instance.data['families']}")
         check_file = instance.data["editorialVideoPath"]
         msg = f"Missing \"{check_file}\"."
         assert check_file, msg

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -15,7 +15,7 @@ ffprobe_path = pype.lib.get_ffmpeg_tool_path("ffprobe")
 
 
 FFMPEG = (
-    '{} -loglevel panic -i %(input)s %(filters)s %(args)s%(output)s'
+    '{} -loglevel panic -i "%(input)s" %(filters)s %(args)s%(output)s'
 ).format(ffmpeg_path)
 
 FFPROBE = (

--- a/pype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/pype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -268,9 +268,10 @@ class DropDataFrame(QtWidgets.QFrame):
         args = [
             ffprobe_path,
             '-v', 'quiet',
-            '-print_format', 'json',
+            '-print_format json',
             '-show_format',
-            '-show_streams', filepath
+            '-show_streams',
+            '"{}"'.format(filepath)
         ]
         ffprobe_p = subprocess.Popen(
             ' '.join(args),


### PR DESCRIPTION
- editorial plugins were interfering with other families
- adding "clip" family to better filter editorial instances 

- render/plates workflow fixes including: 
    - space in input path was crashing standalone publisher
    - space in input path was crashing burning ocio script
    - when input resolution was not dividable by two it was crashing ffmpeg (solution was to add pad filter to add half frame pad to both sides)

closes #579 