### PR TITLE
Hotfix/Extract review can handle resolution with odd numbers

### DIFF
--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -674,6 +674,22 @@ class ExtractReview(pyblish.api.InstancePlugin):
         output_width = int(output_width)
         output_height = int(output_height)
 
+        # Make sure output width and height is not an odd number
+        # When this can happen:
+        # - if output definition has set width and height with odd number
+        # - `instance.data` contain width and height with odd numbeer
+        if output_width % 2 != 0:
+            self.log.warning((
+                "Converting output width from odd to even number. {} -> {}"
+            ).format(output_width, output_width + 1))
+            output_width += 1
+
+        if output_height % 2 != 0:
+            self.log.warning((
+                "Converting output height from odd to even number. {} -> {}"
+            ).format(output_height, output_height + 1))
+            output_height += 1
+
         self.log.debug(
             "Output resolution is {}x{}".format(output_width, output_height)
         )

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -633,6 +633,26 @@ class ExtractReview(pyblish.api.InstancePlugin):
         input_width = int(input_data["width"])
         input_height = int(input_data["height"])
 
+        # Make sure input width and height is not an odd number
+        input_width_is_odd = bool(input_width % 2 != 0)
+        inputh_height_is_odd = bool(input_height % 2 != 0)
+        if input_width_is_odd or inputh_height_is_odd:
+            # Add padding to input and make sure this filter is at first place
+            filters.append("pad=width=ceil(iw/2)*2:height=ceil(ih/2)*2")
+
+            # Change input width or height as first filter will change them
+            if input_width_is_odd:
+                self.log.info((
+                    "Converting input width from odd to even number. {} -> {}"
+                ).format(input_width, input_width + 1))
+                input_width += 1
+
+            if inputh_height_is_odd:
+                self.log.info((
+                    "Converting input height from odd to even number. {} -> {}"
+                ).format(input_height, input_height + 1))
+                input_height += 1
+
         self.log.debug("pixel_aspect: `{}`".format(pixel_aspect))
         self.log.debug("input_width: `{}`".format(input_width))
         self.log.debug("input_height: `{}`".format(input_height))


### PR DESCRIPTION
## Issue
- currect ExtractReview can't handle input or output with width or height as odd numbeer

## Changes
- extract review add padding to input if it's input has odd width or height
    - new width and height are stored as input resolution
        - if input's resolution is 1919x1079 and output's resolution is not defined in output definition or instance.data input won't be rescaled only will have one additional pixel column and row
    - this is done with first ffmpeg video filter which must always stay at first place in video filters
- also added similar conversion for output resolution
    - if output resolution has odd numbers it means somebody set bad resolution on asset or in output definition stored in presets