### PR TITLE
Settings function moved out of tool

### DIFF
--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -59,7 +59,7 @@ def default_settings():
     return _DEFAULT_SETTINGS
 
 
-def load_json(fpath):
+def load_json_file(fpath):
     # Load json data
     with open(fpath, "r") as opened_file:
         lines = opened_file.read().splitlines()

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -278,13 +278,13 @@ def apply_overrides(source_data, override_data):
 
 
 def system_settings():
-    default_values = default_settings()[SYSTEM_SETTINGS_KEY]
+    default_values = copy.deepcopy(default_settings()[SYSTEM_SETTINGS_KEY])
     studio_values = studio_system_settings()
     return apply_overrides(default_values, studio_values)
 
 
 def project_settings(project_name):
-    default_values = default_settings()[PROJECT_SETTINGS_KEY]
+    default_values = copy.deepcopy(default_settings()[PROJECT_SETTINGS_KEY])
     studio_values = studio_project_settings()
 
     studio_overrides = apply_overrides(default_values, studio_values)

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -199,7 +199,9 @@ def save_studio_settings(data):
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
 
-    print("Saving studio overrides")
+    print("Saving studio overrides. Output path: {}".format(
+        SYSTEM_SETTINGS_PATH
+    ))
     with open(SYSTEM_SETTINGS_PATH, "w") as file_stream:
         json.dump(data, file_stream, indent=4)
 
@@ -210,7 +212,9 @@ def save_project_settings(project_name, overrides):
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
 
-    print("Saving overrides of project \"{}\"".format(project_name))
+    print("Saving overrides of project \"{}\". Output path: {}".format(
+        project_name, project_overrides_json_path
+    ))
     with open(project_overrides_json_path, "w") as file_stream:
         json.dump(overrides, file_stream, indent=4)
 
@@ -221,7 +225,9 @@ def save_project_anatomy(project_name, anatomy_data):
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
 
-    print("Saving anatomy of project \"{}\"".format(project_name))
+    print("Saving anatomy of project \"{}\". Output path: {}".format(
+        project_name, project_anatomy_json_path
+    ))
     with open(project_anatomy_json_path, "w") as file_stream:
         json.dump(anatomy_data, file_stream, indent=4)
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -74,9 +74,12 @@ def load_json_file(fpath):
 
 
 def load_jsons_from_dir(path, *args, **kwargs):
-    """Load all json files with content from entered path.
+    """Load all .json files with content from entered folder path.
 
-    Enterd path hiearchy:
+    Data are loaded recursively from a directory and recreate the
+    hierarchy as a dictionary.
+
+    Entered path hiearchy:
     |_ folder1
     | |_ data1.json
     |_ folder2
@@ -98,10 +101,10 @@ def load_jsons_from_dir(path, *args, **kwargs):
     ```
 
     Args:
-        path (str): Path to folder where jsons should be.
+        path (str): Path to the root folder where the json hierarchy starts.
 
     Returns:
-        dict: loaded data
+        dict: Loaded data.
     """
     output = {}
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -239,8 +239,9 @@ def path_to_project_anatomy(project_name):
 def save_studio_settings(data):
     """Save studio overrides of system settings.
 
-    Saving must corespond with loading. For loading should be used function
-    `studio_system_settings`.
+    Do not use to store whole system settings data with defaults but only it's
+    overrides with metadata defining how overrides should be applied in load
+    function. For loading should be used function `studio_system_settings`.
 
     Args:
         data(dict): Data of studio overrides with override metadata.
@@ -260,8 +261,12 @@ def save_project_settings(project_name, overrides):
     """Save studio overrides of project settings.
 
     Data are saved for specific project or as defaults for all projects.
-    Saving must corespond with loading. For loading should be used functions
-    `project_settings_overrides` and `studio_project_settings`.
+
+    Do not use to store whole project settings data with defaults but only it's
+    overrides with metadata defining how overrides should be applied in load
+    function. For loading should be used functions `studio_project_settings`
+    for global project settings and `project_settings_overrides` for
+    project specific settings.
 
     Args:
         project_name(str, null): Project name for which overrides are
@@ -283,9 +288,11 @@ def save_project_settings(project_name, overrides):
 def save_project_anatomy(project_name, anatomy_data):
     """Save studio overrides of project anatomy.
 
-    Data are saved for specific project or as defaults for all projects.
-    Saving must corespond with loading. For loading should be used functions
-    `project_anatomy_overrides` and `studio_project_anatomy`.
+    Do not use to store whole project anatomy data with defaults but only it's
+    overrides with metadata defining how overrides should be applied in load
+    function. For loading should be used functions `studio_project_anatomy`
+    for global project settings and `project_anatomy_overrides` for
+    project specific settings.
 
     Args:
         project_name(str, null): Project name for which overrides are

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -13,7 +13,7 @@ M_ENVIRONMENT_KEY = "__environment_keys__"
 M_POP_KEY = "__pop_key__"
 
 # Folder where studio overrides are stored
-STUDIO_OVERRIDES_PATH = os.environ["PYPE_PROJECT_CONFIGS"]
+STUDIO_OVERRIDES_PATH = os.getenv("PYPE_PROJECT_CONFIGS")
 
 # File where studio's system overrides are stored
 SYSTEM_SETTINGS_KEY = "system_settings"
@@ -70,7 +70,6 @@ def load_json_file(fpath):
             "File has invalid json format \"{}\"".format(fpath),
             exc_info=True
         )
-
     return {}
 
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -175,7 +175,9 @@ def studio_project_anatomy():
     return {}
 
 
-def path_to_project_overrides(project_name):
+def path_to_project_settings(project_name):
+    if not project_name:
+        return PROJECT_SETTINGS_PATH
     return os.path.join(
         STUDIO_OVERRIDES_PATH,
         project_name,
@@ -184,6 +186,8 @@ def path_to_project_overrides(project_name):
 
 
 def path_to_project_anatomy(project_name):
+    if not project_name:
+        return PROJECT_ANATOMY_PATH
     return os.path.join(
         STUDIO_OVERRIDES_PATH,
         project_name,
@@ -195,7 +199,7 @@ def project_settings_overrides(project_name):
     if not project_name:
         return {}
 
-    path_to_json = path_to_project_overrides(project_name)
+    path_to_json = path_to_project_settings(project_name)
     if not os.path.exists(path_to_json):
         return {}
     return load_json_file(path_to_json)

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -153,25 +153,25 @@ def load_jsons_from_dir(path, *args, **kwargs):
 
 def studio_system_settings():
     if os.path.exists(SYSTEM_SETTINGS_PATH):
-        return load_json(SYSTEM_SETTINGS_PATH)
+        return load_json_file(SYSTEM_SETTINGS_PATH)
     return {}
 
 
 def studio_environments():
     if os.path.exists(ENVIRONMENTS_PATH):
-        return load_json(ENVIRONMENTS_PATH)
+        return load_json_file(ENVIRONMENTS_PATH)
     return {}
 
 
 def studio_project_settings():
     if os.path.exists(PROJECT_SETTINGS_PATH):
-        return load_json(PROJECT_SETTINGS_PATH)
+        return load_json_file(PROJECT_SETTINGS_PATH)
     return {}
 
 
 def studio_project_anatomy():
     if os.path.exists(PROJECT_ANATOMY_PATH):
-        return load_json(PROJECT_ANATOMY_PATH)
+        return load_json_file(PROJECT_ANATOMY_PATH)
     return {}
 
 
@@ -198,7 +198,7 @@ def project_settings_overrides(project_name):
     path_to_json = path_to_project_overrides(project_name)
     if not os.path.exists(path_to_json):
         return {}
-    return load_json(path_to_json)
+    return load_json_file(path_to_json)
 
 
 def project_anatomy_overrides(project_name):
@@ -208,7 +208,7 @@ def project_anatomy_overrides(project_name):
     path_to_json = path_to_project_anatomy(project_name)
     if not os.path.exists(path_to_json):
         return {}
-    return load_json(path_to_json)
+    return load_json_file(path_to_json)
 
 
 def merge_overrides(global_dict, override_dict):

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -195,6 +195,38 @@ def path_to_project_anatomy(project_name):
     )
 
 
+def save_studio_settings(data):
+    dirpath = os.path.dirname(SYSTEM_SETTINGS_PATH)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
+
+    print("Saving studio overrides")
+    with open(SYSTEM_SETTINGS_PATH, "w") as file_stream:
+        json.dump(data, file_stream, indent=4)
+
+
+def save_project_settings(project_name, overrides):
+    project_overrides_json_path = path_to_project_settings(project_name)
+    dirpath = os.path.dirname(project_overrides_json_path)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
+
+    print("Saving overrides of project \"{}\"".format(project_name))
+    with open(project_overrides_json_path, "w") as file_stream:
+        json.dump(overrides, file_stream, indent=4)
+
+
+def save_project_anatomy(project_name, anatomy_data):
+    project_anatomy_json_path = path_to_project_anatomy(project_name)
+    dirpath = os.path.dirname(project_anatomy_json_path)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
+
+    print("Saving anatomy of project \"{}\"".format(project_name))
+    with open(project_anatomy_json_path, "w") as file_stream:
+        json.dump(anatomy_data, file_stream, indent=4)
+
+
 def project_settings_overrides(project_name):
     if not project_name:
         return {}

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -13,7 +13,7 @@ M_ENVIRONMENT_KEY = "__environment_keys__"
 M_POP_KEY = "__pop_key__"
 
 # Folder where studio overrides are stored
-STUDIO_OVERRIDES_PATH = os.getenv("PYPE_PROJECT_CONFIGS")
+STUDIO_OVERRIDES_PATH = os.getenv("PYPE_PROJECT_CONFIGS") or ""
 
 # File where studio's system overrides are stored
 SYSTEM_SETTINGS_KEY = "system_settings"

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -74,6 +74,44 @@ def load_json_file(fpath):
     return {}
 
 
+def load_jsons_from_dir(path, *args, **kwargs):
+    output = {}
+
+    path = os.path.normpath(path)
+    if not os.path.exists(path):
+        # TODO warning
+        return output
+
+    sub_keys = list(kwargs.pop("subkeys", args))
+    for sub_key in tuple(sub_keys):
+        _path = os.path.join(path, sub_key)
+        if not os.path.exists(_path):
+            break
+
+        path = _path
+        sub_keys.pop(0)
+
+    base_len = len(path) + 1
+    for base, _directories, filenames in os.walk(path):
+        base_items_str = base[base_len:]
+        if not base_items_str:
+            base_items = []
+        else:
+            base_items = base_items_str.split(os.path.sep)
+
+        for filename in filenames:
+            basename, ext = os.path.splitext(filename)
+            if ext == ".json":
+                full_path = os.path.join(base, filename)
+                value = load_json_file(full_path)
+                dict_keys = base_items + [basename]
+                output = subkey_merge(output, value, dict_keys)
+
+    for sub_key in sub_keys:
+        output = output[sub_key]
+    return output
+
+
 def find_environments(data):
     if not data or not isinstance(data, dict):
         return
@@ -111,44 +149,6 @@ def subkey_merge(_dict, value, keys):
     _dict[key] = subkey_merge(_dict[key], value, keys)
 
     return _dict
-
-
-def load_jsons_from_dir(path, *args, **kwargs):
-    output = {}
-
-    path = os.path.normpath(path)
-    if not os.path.exists(path):
-        # TODO warning
-        return output
-
-    sub_keys = list(kwargs.pop("subkeys", args))
-    for sub_key in tuple(sub_keys):
-        _path = os.path.join(path, sub_key)
-        if not os.path.exists(_path):
-            break
-
-        path = _path
-        sub_keys.pop(0)
-
-    base_len = len(path) + 1
-    for base, _directories, filenames in os.walk(path):
-        base_items_str = base[base_len:]
-        if not base_items_str:
-            base_items = []
-        else:
-            base_items = base_items_str.split(os.path.sep)
-
-        for filename in filenames:
-            basename, ext = os.path.splitext(filename)
-            if ext == ".json":
-                full_path = os.path.join(base, filename)
-                value = load_json(full_path)
-                dict_keys = base_items + [basename]
-                output = subkey_merge(output, value, dict_keys)
-
-    for sub_key in sub_keys:
-        output = output[sub_key]
-    return output
 
 
 def studio_system_settings():

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -61,48 +61,9 @@ def default_settings():
 
 def load_json_file(fpath):
     # Load json data
-    with open(fpath, "r") as opened_file:
-        lines = opened_file.read().splitlines()
-
-    # prepare json string
-    standard_json = ""
-    for line in lines:
-        # Remove all whitespace on both sides
-        line = line.strip()
-
-        # Skip blank lines
-        if len(line) == 0:
-            continue
-
-        standard_json += line
-
-    # Check if has extra commas
-    extra_comma = False
-    if ",]" in standard_json or ",}" in standard_json:
-        extra_comma = True
-    standard_json = standard_json.replace(",]", "]")
-    standard_json = standard_json.replace(",}", "}")
-
-    if extra_comma:
-        log.error("Extra comma in json file: \"{}\"".format(fpath))
-
-    # return empty dict if file is empty
-    if standard_json == "":
-        return {}
-
-    # Try to parse string
-    try:
-        return json.loads(standard_json)
-
-    except json.decoder.JSONDecodeError:
-        # Return empty dict if it is first time that decode error happened
-        return {}
-
-    # Repreduce the exact same exception but traceback contains better
-    # information about position of error in the loaded json
     try:
         with open(fpath, "r") as opened_file:
-            json.load(opened_file)
+            return json.load(opened_file)
 
     except json.decoder.JSONDecodeError:
         log.warning(

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -3,11 +3,8 @@ import json
 from Qt import QtWidgets, QtCore, QtGui
 from pype.settings.lib import (
     SYSTEM_SETTINGS_KEY,
-    SYSTEM_SETTINGS_PATH,
     PROJECT_SETTINGS_KEY,
-    PROJECT_SETTINGS_PATH,
     PROJECT_ANATOMY_KEY,
-    PROJECT_ANATOMY_PATH,
 
     DEFAULTS_DIR,
 
@@ -21,8 +18,9 @@ from pype.settings.lib import (
     project_settings_overrides,
     project_anatomy_overrides,
 
-    path_to_project_overrides,
-    path_to_project_anatomy
+    save_studio_settings,
+    save_project_settings,
+    save_project_anatomy
 )
 from .widgets import UnsavedChangesDialog
 from . import lib
@@ -183,13 +181,7 @@ class SystemWidget(QtWidgets.QWidget):
 
         values = lib.convert_gui_data_to_overrides(_data.get("system", {}))
 
-        dirpath = os.path.dirname(SYSTEM_SETTINGS_PATH)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
-
-        print("Saving data to:", SYSTEM_SETTINGS_PATH)
-        with open(SYSTEM_SETTINGS_PATH, "w") as file_stream:
-            json.dump(values, file_stream, indent=4)
+        save_studio_settings(values)
 
         self._update_values()
 
@@ -621,29 +613,25 @@ class ProjectWidget(QtWidgets.QWidget):
             if item.child_invalid:
                 has_invalid = True
 
-        if has_invalid:
-            invalid_items = []
-            for item in self.input_fields:
-                invalid_items.extend(item.get_invalid())
-            msg_box = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Warning,
-                "Invalid input",
-                "There is invalid value in one of inputs."
-                " Please lead red color and fix them."
-            )
-            msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
-            msg_box.exec_()
+        if not has_invalid:
+            return self._save_overrides()
 
-            first_invalid_item = invalid_items[0]
-            self.scroll_widget.ensureWidgetVisible(first_invalid_item)
-            if first_invalid_item.isVisible():
-                first_invalid_item.setFocus(True)
-            return
+        invalid_items = []
+        for item in self.input_fields:
+            invalid_items.extend(item.get_invalid())
+        msg_box = QtWidgets.QMessageBox(
+            QtWidgets.QMessageBox.Warning,
+            "Invalid input",
+            "There is invalid value in one of inputs."
+            " Please lead red color and fix them."
+        )
+        msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
+        msg_box.exec_()
 
-        if self.project_name is None:
-            self._save_studio_overrides()
-        else:
-            self._save_overrides()
+        first_invalid_item = invalid_items[0]
+        self.scroll_widget.ensureWidgetVisible(first_invalid_item)
+        if first_invalid_item.isVisible():
+            first_invalid_item.setFocus(True)
 
     def _on_refresh(self):
         self.reset()
@@ -665,75 +653,19 @@ class ProjectWidget(QtWidgets.QWidget):
         )
 
         # Saving overrides data
-        project_overrides_data = output_data.get(
-            PROJECT_SETTINGS_KEY, {}
-        )
-        project_overrides_json_path = path_to_project_overrides(
-            self.project_name
-        )
-        dirpath = os.path.dirname(project_overrides_json_path)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
-
-        print("Saving data to:", project_overrides_json_path)
-        with open(project_overrides_json_path, "w") as file_stream:
-            json.dump(project_overrides_data, file_stream, indent=4)
+        project_overrides_data = output_data.get(PROJECT_SETTINGS_KEY, {})
+        save_project_settings(self.project_name, project_overrides_data)
 
         # Saving anatomy data
-        project_anatomy_data = output_data.get(
-            PROJECT_ANATOMY_KEY, {}
-        )
-        project_anatomy_json_path = path_to_project_anatomy(
-            self.project_name
-        )
-        dirpath = os.path.dirname(project_anatomy_json_path)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
+        project_anatomy_data = output_data.get(PROJECT_ANATOMY_KEY, {})
+        save_project_anatomy(self.project_name, project_anatomy_data)
 
-        print("Saving data to:", project_anatomy_json_path)
-        with open(project_anatomy_json_path, "w") as file_stream:
-            json.dump(project_anatomy_data, file_stream, indent=4)
-
-        # Refill values with overrides
-        self._on_project_change()
-
-    def _save_studio_overrides(self):
-        data = {}
-        for input_field in self.input_fields:
-            value, is_group = input_field.studio_overrides()
-            if value is not lib.NOT_SET:
-                data.update(value)
-
-        output_data = lib.convert_gui_data_to_overrides(
-            data.get("project", {})
-        )
-
-        # Project overrides data
-        project_overrides_data = output_data.get(
-            PROJECT_SETTINGS_KEY, {}
-        )
-        dirpath = os.path.dirname(PROJECT_SETTINGS_PATH)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
-
-        print("Saving data to:", PROJECT_SETTINGS_PATH)
-        with open(PROJECT_SETTINGS_PATH, "w") as file_stream:
-            json.dump(project_overrides_data, file_stream, indent=4)
-
-        # Project Anatomy data
-        project_anatomy_data = output_data.get(
-            PROJECT_ANATOMY_KEY, {}
-        )
-        dirpath = os.path.dirname(PROJECT_ANATOMY_PATH)
-        if not os.path.exists(dirpath):
-            os.makedirs(dirpath)
-
-        print("Saving data to:", PROJECT_ANATOMY_PATH)
-        with open(PROJECT_ANATOMY_PATH, "w") as file_stream:
-            json.dump(project_anatomy_data, file_stream, indent=4)
-
-        # Update saved values
-        self._update_values()
+        if self.project_name:
+            # Refill values with overrides
+            self._on_project_change()
+        else:
+            # Update saved values
+            self._update_values()
 
     def _update_values(self):
         self.ignore_value_changes = True

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -643,8 +643,12 @@ class ProjectWidget(QtWidgets.QWidget):
 
     def _save_overrides(self):
         data = {}
+        studio_overrides = bool(self.project_name is None)
         for item in self.input_fields:
-            value, is_group = item.overrides()
+            if studio_overrides:
+                value, is_group = item.studio_overrides()
+            else:
+                value, is_group = item.overrides()
             if value is not lib.NOT_SET:
                 data.update(value)
 
@@ -670,7 +674,7 @@ class ProjectWidget(QtWidgets.QWidget):
     def _update_values(self):
         self.ignore_value_changes = True
 
-        default_values = default_values = lib.convert_data_to_gui_data(
+        default_values = lib.convert_data_to_gui_data(
             {"project": default_settings()}
         )
         for input_field in self.input_fields:


### PR DESCRIPTION
## Changes
- environ is get in safer way until mongo saving is implemented
- saving functions are in `pype/settings` not in settings tool and tool is using that (with this should be easier to switch to save to mongo)