### PR TITLE
Deadline user defaults to pype username if present

### DIFF
--- a/pype/plugins/global/publish/collect_current_pype_user.py
+++ b/pype/plugins/global/publish/collect_current_pype_user.py
@@ -13,7 +13,7 @@ class CollectCurrentUserPype(pyblish.api.ContextPlugin):
     def process(self, context):
         user = os.getenv("PYPE_USERNAME", "").strip()
         if not user:
-            return
+            user = context.data.get("user", getpass.getuser())
 
         context.data["user"] = user
-        self.log.debug("Pype user is \"{}\"".format(user))
+        self.log.debug("Colected user \"{}\"".format(user))

--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -174,7 +174,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         "FTRACK_SERVER",
         "PYPE_METADATA_FILE",
         "AVALON_PROJECT",
-        "PYPE_LOG_NO_COLORS"
+        "PYPE_LOG_NO_COLORS",
+        "PYPE_USERNAME"
     ]
 
     # custom deadline atributes
@@ -297,6 +298,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
         environment["PYPE_METADATA_FILE"] = roothless_metadata_path
         environment["AVALON_PROJECT"] = io.Session["AVALON_PROJECT"]
         environment["PYPE_LOG_NO_COLORS"] = "1"
+        environment["PYPE_USERNAME"] = instance.context.data["user"]
         try:
             environment["PYPE_PYTHON_EXE"] = os.environ["PYPE_PYTHON_EXE"]
         except KeyError:

--- a/pype/plugins/maya/publish/submit_maya_deadline.py
+++ b/pype/plugins/maya/publish/submit_maya_deadline.py
@@ -348,7 +348,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         comment = context.data.get("comment", "")
         dirname = os.path.join(workspace, "renders")
         renderlayer = instance.data['setMembers']       # rs_beauty
-        deadline_user = context.data.get("deadlineUser", getpass.getuser())
+        deadline_user = context.data.get("user", getpass.getuser())
         jobname = "%s - %s" % (filename, instance.name)
 
         # Get the variables depending on the renderer
@@ -418,7 +418,7 @@ class MayaSubmitDeadline(pyblish.api.InstancePlugin):
         # Adding file dependencies.
         dependencies = instance.context.data["fileDependencies"]
         dependencies.append(filepath)
-        if self.assembly_files:
+        if self.asset_dependencies:
             for dependency in dependencies:
                 key = "AssetDependency" + str(dependencies.index(dependency))
                 payload_skeleton["JobInfo"][key] = dependency


### PR DESCRIPTION
## Changes
- deadline publish should publish with right user on deadline
    - `PYPE_USERNAME` variable is filled on deadline submit

## Note
- not tested as don't have deadline setup