### PR TITLE
Maya: allow renders to have version synced with workfile

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -740,6 +740,11 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
                 "family": "prerender",
                 "families": []})
 
+        # skip locking version if we are creating v01
+        instance_version = instance.data.get("version")
+        if instance_version != 1:
+            instance_skeleton_data["version"] = instance_version
+
         # transfer specific families from original instance to new render
         for item in self.families_transfer:
             if item in instance.data.get("families", []):

--- a/pype/plugins/maya/publish/collect_render.py
+++ b/pype/plugins/maya/publish/collect_render.py
@@ -59,6 +59,7 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder + 0.01
     hosts = ["maya"]
     label = "Collect Render Layers"
+    sync_workfile_version = False
 
     def process(self, context):
         """Entry point to collector."""
@@ -249,6 +250,9 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "priority": render_instance.data.get("priority"),
                 "convertToScanline": render_instance.data.get("convertToScanline") or False  # noqa: E501
             }
+
+            if self.sync_workfile_version:
+                data["version"] = context.data["version"]
 
             # Apply each user defined attribute as data
             for attr in cmds.listAttr(layer, userDefined=True) or list():


### PR DESCRIPTION
This adds `sync_workfile_version` option to maya render collection. When set to True, the final render output will have the same version number as the source workfile in maya at the time of publish