### PR TITLE
Harmony: Disable application launch logic

### DIFF
--- a/pype/hosts/harmony/__init__.py
+++ b/pype/hosts/harmony/__init__.py
@@ -155,8 +155,10 @@ def check_inventory():
 
 
 def application_launch():
-    ensure_scene_settings()
-    check_inventory()
+    # FIXME: manually invoked because of server <-> client problems.
+    # ensure_scene_settings()
+    # check_inventory()
+    pass
 
 
 def export_template(backdrops, nodes, filepath):


### PR DESCRIPTION
## Fix

This PR is disabling `application.launched` logic that is breaking harmony client <-> server communication for some yet unknown reason. `pype.hosts.harmony.ensure_scene_settings()` should be called manually using Toobar button in Harmony.

![harmony_scripting](https://user-images.githubusercontent.com/33513211/95994759-f8c7e100-0e30-11eb-87ab-128475301b47.gif)

🏴 **depends on hotfix to pypeclub/avalon-core**
|---|