### PR TITLE
Improved publishing of multiple representation from SP

### DIFF
--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -69,9 +69,15 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                     "name": "thumbnail"  # Default component name is "main".
                 }
                 comp['thumbnail'] = True
-                if not comp.get("published_path"):
-                    comp['published_path'] = os.path.join(comp['stagingDir'],
-                                                        comp["files"])
+                comp_files = comp["files"]
+                if isinstance(comp_files, (tuple, list, set)):
+                    filename = comp_files[0]
+                else:
+                    filename = comp_files
+
+                comp['published_path'] = os.path.join(
+                    comp['stagingDir'], filename
+)
 
             elif comp.get('ftrackreview') or ("ftrackreview" in comp.get('tags', [])):
                 '''

--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -1,5 +1,6 @@
 import pyblish.api
 import json
+import os
 
 
 class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
@@ -68,6 +69,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                     "name": "thumbnail"  # Default component name is "main".
                 }
                 comp['thumbnail'] = True
+                if not comp.get("published_path"):
+                    comp['published_path'] = os.path.join(comp['stagingDir'],
+                                                        comp["files"])
+
             elif comp.get('ftrackreview') or ("ftrackreview" in comp.get('tags', [])):
                 '''
                 Ftrack bug requirement:

--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -77,7 +77,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
                 comp['published_path'] = os.path.join(
                     comp['stagingDir'], filename
-)
+                    )
 
             elif comp.get('ftrackreview') or ("ftrackreview" in comp.get('tags', [])):
                 '''

--- a/pype/plugins/global/publish/cleanup.py
+++ b/pype/plugins/global/publish/cleanup.py
@@ -21,6 +21,7 @@ class CleanUp(pyblish.api.InstancePlugin):
 
     # Presets
     paterns = None  # list of regex paterns
+    remove_temp_renders = True
 
     def process(self, instance):
         """Plugin entry point."""
@@ -36,8 +37,9 @@ class CleanUp(pyblish.api.InstancePlugin):
             )
         )
 
-        self.log.info("Cleaning renders new...")
-        self.clean_renders(instance)
+        if self.remove_temp_renders:
+            self.log.info("Cleaning renders new...")
+            self.clean_renders(instance)
 
         if [ef for ef in self.exclude_families
                 if instance.data["family"] in ef]:
@@ -85,7 +87,11 @@ class CleanUp(pyblish.api.InstancePlugin):
             if os.path.normpath(src) != os.path.normpath(dest):
                 if instance_family == 'render' or 'render' in current_families:
                     self.log.info("Removing src: `{}`...".format(src))
-                    os.remove(src)
+                    try:
+                        os.remove(src)
+                    except PermissionError:
+                        self.log.warning("Insufficient permission to delete {}".format(src))
+                        continue
 
                     # add dir for cleanup
                     dirnames.append(os.path.dirname(src))

--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -74,11 +74,9 @@ class ExtractBurnin(pype.api.Extractor):
         # Remove any representations tagged for deletion.
         # QUESTION Is possible to have representation with "delete" tag?
         for repre in tuple(instance.data["representations"]):
-            if "delete" in repre.get("tags", []):
+            if all(x in repre.get("tags", []) for x in ['delete', 'burnin']):
                 self.log.debug("Removing representation: {}".format(repre))
                 instance.data["representations"].remove(repre)
-
-        self.log.debug(instance.data["representations"])
 
     def use_legacy_code(self, instance):
         presets = instance.context.data.get("presets")

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -51,6 +51,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
     to_height = 1080
 
     def process(self, instance):
+        self.log.debug(instance.data["representations"])
         # Skip review when requested.
         if not instance.data.get("review", True):
             return
@@ -77,7 +78,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
         # Make sure cleanup happens and pop representations with "delete" tag.
         for repre in tuple(instance.data["representations"]):
             tags = repre.get("tags") or []
-            if "delete" in tags:
+            if "delete" in tags and "thumbnail" not in tags:
                 instance.data["representations"].remove(repre)
 
     def main_process(self, instance):

--- a/pype/plugins/standalonepublisher/publish/collect_representation_names.py
+++ b/pype/plugins/standalonepublisher/publish/collect_representation_names.py
@@ -1,0 +1,40 @@
+"""
+Requires:
+    Nothing
+
+Provides:
+    Instance
+"""
+
+import pyblish.api
+from pprint import pformat
+import re
+import os
+
+class CollecRepresentationNames(pyblish.api.InstancePlugin):
+    """
+    Sets the representation names for given families based on RegEx filter
+    """
+
+    label = "Collect Representaion Names"
+    order = pyblish.api.CollectorOrder
+    families = []
+    hosts = ["standalonepublisher"]
+    name_filter = ""
+
+    def process(self, instance):
+        self.log.debug(f"instance.data: {pformat(instance.data['representations'])}")
+        for repre in instance.data['representations']:
+            self.log.debug(repre['files'])
+            if isinstance(repre['files'], list):
+                shortened_name = os.path.splitext(repre['files'][0])[0]
+                new_repre_name = re.search(self.name_filter, shortened_name)
+            else:
+                new_repre_name = re.search(self.name_filter, repre['files'])
+
+
+            self.log.debug(new_repre_name.group())
+            repre['name'] = new_repre_name.group()
+            repre['outputName'] = new_repre_name.group()
+
+        self.log.debug(f"instance.data: {pformat(instance.data['representations'])}")

--- a/pype/plugins/standalonepublisher/publish/collect_representation_names.py
+++ b/pype/plugins/standalonepublisher/publish/collect_representation_names.py
@@ -1,17 +1,9 @@
-"""
-Requires:
-    Nothing
-
-Provides:
-    Instance
-"""
-
-import pyblish.api
-from pprint import pformat
 import re
 import os
+import pyblish.api
 
-class CollecRepresentationNames(pyblish.api.InstancePlugin):
+
+class CollectRepresentationNames(pyblish.api.InstancePlugin):
     """
     Sets the representation names for given families based on RegEx filter
     """
@@ -23,18 +15,17 @@ class CollecRepresentationNames(pyblish.api.InstancePlugin):
     name_filter = ""
 
     def process(self, instance):
-        self.log.debug(f"instance.data: {pformat(instance.data['representations'])}")
         for repre in instance.data['representations']:
-            self.log.debug(repre['files'])
+            new_repre_name = None
             if isinstance(repre['files'], list):
                 shortened_name = os.path.splitext(repre['files'][0])[0]
-                new_repre_name = re.search(self.name_filter, shortened_name)
+                new_repre_name = re.search(self.name_filter,
+                                           shortened_name).group()
             else:
-                new_repre_name = re.search(self.name_filter, repre['files'])
+                new_repre_name = re.search(self.name_filter,
+                                           repre['files']).group()
 
+            if new_repre_name:
+                repre['name'] = new_repre_name
 
-            self.log.debug(new_repre_name.group())
-            repre['name'] = new_repre_name.group()
-            repre['outputName'] = new_repre_name.group()
-
-        self.log.debug(f"instance.data: {pformat(instance.data['representations'])}")
+            repre['outputName'] = repre['name']

--- a/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
+++ b/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
@@ -112,12 +112,11 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
             'ext': 'jpg',
             'files': filename,
             "stagingDir": staging_dir,
-            "thumbnail": True,
-            "tags": []
+            "tags": ["thumbnail"],
         }
 
         # # add Delete tag when temp file was rendered
-        # if not is_jpeg:
-        #     representation["tags"].append("delete")
+        if not is_jpeg:
+            representation["tags"].append("delete")
 
         instance.data["representations"].append(representation)


### PR DESCRIPTION
This makes it possible to name multiple representation in standalone publisher using regex and filename. This allows publishing for example multiple render AOVs from standalone publisher while keeping their correct naming.

With that it was neccessary to tweak a few other places to amke sure we dont' throw away more data than needed. Especially burning and review plugins were deleting anything with 'delete' tag, even though they were representations that should not be processed by review at all. 

To use and test this, correct preset needs to be added to `presets/plugins/standalonepublisher/publish.json`
```json
    "CollecRepresentationNames": {
      "families": ["render"],
      "name_filter": "([^_]+_[^_]+(?=\\.))"
    }
```