### PR TITLE
Missing audio on farm submission.

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -732,7 +732,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             "resolutionHeight": data.get("resolutionHeight", 1080),
             "multipartExr": data.get("multipartExr", False),
             "jobBatchName": data.get("jobBatchName", ""),
-            "review": data.get("review", True)
+            "review": data.get("review", True),
+            "audio": data.get("audio", [])
         }
 
         if "prerender" in instance.data["families"]:


### PR DESCRIPTION
Case was submitting compositing from Nuke did not have audio on reviews when rendering on the farm, but local rendering does.