### PR TITLE
Get latest version in lib

### DIFF
--- a/pype/hosts/harmony/__init__.py
+++ b/pype/hosts/harmony/__init__.py
@@ -155,8 +155,11 @@ def check_inventory():
 
 
 def application_launch():
-    ensure_scene_settings()
-    check_inventory()
+    # FIXME: This is breaking server <-> client communication.
+    # It is now moved so it it manually called.
+    # ensure_scene_settings()
+    # check_inventory()
+    pass
 
 
 def export_template(backdrops, nodes, filepath):

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1422,6 +1422,14 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
 
     # Check if subsets actually exists.
     assert subset, "No subsets found."
+    if project_name and project_name != dbcon.Session.get("AVALON_PROJECT"):
+        # `avalon.io` has only `_database` attribute
+        # but `AvalonMongoDB` has `database`
+        database = getattr(dbcon, "database", dbcon._database)
+        collection = database[project_name]
+    else:
+        project_name = dbcon.Session.get("AVALON_PROJECT")
+        collection = dbcon
 
     # Get version
     version_projection = {

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1430,6 +1430,8 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     if not dbcon:
         log.debug("Using `avalon.io` for query.")
         dbcon = io
+        # Make sure is installed
+        io.install()
 
     if project_name and project_name != dbcon.Session.get("AVALON_PROJECT"):
         # `avalon.io` has only `_database` attribute

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1408,7 +1408,7 @@ def source_hash(filepath, *args):
     return "|".join([file_name, time, size] + list(args)).replace(".", ",")
 
 
-def get_latest_version(asset_name, subset_name):
+def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     """Retrieve latest version from `asset_name`, and `subset_name`.
 
     Args:

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1415,15 +1415,10 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         asset_name (str): Name of asset.
         subset_name (str): Name of subset.
     """
-    # Get asset
-    asset_name = io.find_one(
-        {"type": "asset", "name": asset_name}, projection={"name": True}
-    )
 
-    subset = io.find_one(
-        {"type": "subset", "name": subset_name, "parent": asset_name["_id"]},
-        projection={"_id": True, "name": True},
-    )
+    if not dbcon:
+        log.debug("Using `avalon.io` for query.")
+        dbcon = io
 
     # Check if subsets actually exists.
     assert subset, "No subsets found."

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1429,12 +1429,20 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         project_name = dbcon.Session.get("AVALON_PROJECT")
         collection = dbcon
 
+    log.debug((
+        "Getting latest version for Project: \"{}\" Asset: \"{}\""
+        " and Subset: \"{}\""
+    ).format(project_name, asset_name, subset_name))
+
     # Query asset document id by asset name
     asset_doc = collection.find_one(
         {"type": "asset", "name": asset_name},
         {"_id": True}
     )
     if not asset_doc:
+        log.info(
+            "Asset \"{}\" was not found in Database.".format(asset_name)
+        )
         return None
 
     subset_doc = collection.find_one(
@@ -1442,6 +1450,9 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         {"_id": True}
     )
     if not subset_doc:
+        log.info(
+            "Subset \"{}\" was not found in Database.".format(subset_name)
+        )
         return None
 
     version_doc = collection.find_one(
@@ -1449,6 +1460,9 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         sort=[("name", -1)],
     )
     if not version_doc:
+        log.info(
+            "Subset \"{}\" does not have any version yet.".format(subset_name)
+        )
         return None
     return version_doc
 

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1429,9 +1429,28 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         project_name = dbcon.Session.get("AVALON_PROJECT")
         collection = dbcon
 
+    # Query asset document id by asset name
+    asset_doc = collection.find_one(
+        {"type": "asset", "name": asset_name},
+        {"_id": True}
     )
+    if not asset_doc:
+        return None
 
+    subset_doc = collection.find_one(
+        {"type": "subset", "name": subset_name, "parent": asset_doc["_id"]},
+        {"_id": True}
+    )
+    if not subset_doc:
+        return None
 
+    version_doc = collection.find_one(
+        {"type": "version", "parent": subset_doc["_id"]},
+        sort=[("name", -1)],
+    )
+    if not version_doc:
+        return None
+    return version_doc
 
 
 class ApplicationLaunchFailed(Exception):

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1411,6 +1411,10 @@ def source_hash(filepath, *args):
 def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     """Retrieve latest version from `asset_name`, and `subset_name`.
 
+    Do not use if you want to query more than 5 latest versions as this method
+    query 3 times to mongo for each call. For those cases is better to use
+    more efficient way, e.g. with help of aggregations.
+
     Args:
         asset_name (str): Name of asset.
         subset_name (str): Name of subset.

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1420,8 +1420,6 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         log.debug("Using `avalon.io` for query.")
         dbcon = io
 
-    # Check if subsets actually exists.
-    assert subset, "No subsets found."
     if project_name and project_name != dbcon.Session.get("AVALON_PROJECT"):
         # `avalon.io` has only `_database` attribute
         # but `AvalonMongoDB` has `database`
@@ -1431,21 +1429,9 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
         project_name = dbcon.Session.get("AVALON_PROJECT")
         collection = dbcon
 
-    # Get version
-    version_projection = {
-        "name": True,
-        "parent": True,
-    }
-
-    version = io.find_one(
-        {"type": "version", "parent": subset["_id"]},
-        projection=version_projection,
-        sort=[("name", -1)],
     )
 
-    assert version, "No version found, this is a bug"
 
-    return version
 
 
 class ApplicationLaunchFailed(Exception):

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1414,6 +1414,13 @@ def get_latest_version(asset_name, subset_name, dbcon=None, project_name=None):
     Args:
         asset_name (str): Name of asset.
         subset_name (str): Name of subset.
+        dbcon (avalon.mongodb.AvalonMongoDB, optional): Avalon Mongo connection
+            with Session.
+        project_name (str, optional): Find latest version in specific project.
+
+    Returns:
+        None: If asset, subset or version were not found.
+        dict: Last version document for entered .
     """
 
     if not dbcon:

--- a/pype/plugins/nuke/publish/collect_review.py
+++ b/pype/plugins/nuke/publish/collect_review.py
@@ -1,4 +1,3 @@
-import os
 import pyblish.api
 import pype.api
 from avalon import io, api

--- a/pype/plugins/nuke/publish/collect_review.py
+++ b/pype/plugins/nuke/publish/collect_review.py
@@ -1,3 +1,4 @@
+import os
 import pyblish.api
 import pype.api
 from avalon import io, api
@@ -26,20 +27,24 @@ class CollectReview(pyblish.api.InstancePlugin):
         if not node["review"].value():
             return
 
-        # Add audio to instance if it exists.
-        try:
-            version = pype.api.get_latest_version(
-                instance.context.data["assetEntity"]["name"], "audioMain"
+        # * Add audio to instance if exists.
+        # Find latest versions document
+        version_doc = pype.api.get_latest_version(
+            instance.context.data["assetEntity"]["name"], "audioMain"
+        )
+        repre_doc = None
+        if version_doc:
+            # Try to find it's representation (Expected there is only one)
+            repre_doc = io.find_one(
+                {"type": "representation", "parent": version_doc["_id"]}
             )
-            representation = io.find_one(
-                {"type": "representation", "parent": version["_id"]}
-            )
+
+        # Add audio to instance if representation was found
+        if repre_doc:
             instance.data["audio"] = [{
                 "offset": 0,
-                "filename": api.get_representation_path(representation)
+                "filename": api.get_representation_path(repre_doc)
             }]
-        except AssertionError:
-            pass
 
         instance.data["families"].append("review")
         instance.data['families'].append('ftrack')


### PR DESCRIPTION
## Changes in `get_latest_version` from `pype.lib`
- method do not raise `AssertionError` if any document was not found but returns `None`
- has additional `dbcon` keyword argument to have ability to use different avalon mongo connection than `avalon.io` (optional)
- it is possible to enter `project_name`

- changed way how `get_latest_version` it is used in `CollectReview` plugin in Nuke as it does not raise `AssertionErro`r now