### PR TITLE
Nuke: prevent crash if we only have single frame in sequence

### DIFF
--- a/pype/plugins/nuke/load/load_sequence.py
+++ b/pype/plugins/nuke/load/load_sequence.py
@@ -119,13 +119,14 @@ class LoadSequence(api.Loader):
         repr_cont = context["representation"]["context"]
         if "#" not in file:
             frame = repr_cont.get("frame")
-            padding = len(frame)
-            file = file.replace(frame, "#" * padding)
+            if frame:
+                padding = len(frame)
+                file = file.replace(frame, "#" * padding)
 
         read_name = "Read_{0}_{1}_{2}".format(
             repr_cont["asset"],
             repr_cont["subset"],
-            repr_cont["representation"])
+            context["representation"]["name"])
 
         # Create the Loader with the filename path set
         with viewer_update_and_undo_stop():
@@ -249,8 +250,9 @@ class LoadSequence(api.Loader):
 
         if "#" not in file:
             frame = repr_cont.get("frame")
-            padding = len(frame)
-            file = file.replace(frame, "#" * padding)
+            if frame:
+                padding = len(frame)
+                file = file.replace(frame, "#" * padding)
 
         # Get start frame from version data
         version = io.find_one({


### PR DESCRIPTION
If a render only had a single frame it couldn't be loaded with the default nuke loader. Also if importing a lot of representations, their read nodes weren't named correctly based on representation name