### PR TITLE
Pyblish-pype spacer in terminal wasn't transparent

### DIFF
--- a/pype/tools/pyblish_pype/widgets.py
+++ b/pype/tools/pyblish_pype/widgets.py
@@ -543,7 +543,9 @@ class TerminalFilterWidget(QtWidgets.QWidget):
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         # Add spacers
-        layout.addWidget(QtWidgets.QWidget(), 1)
+        spacer = QtWidgets.QWidget()
+        spacer.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        layout.addWidget(spacer, 1)
 
         for btn in filter_buttons:
             layout.addWidget(btn)


### PR DESCRIPTION
## Issue
- spacer for filter buttons may not be transparent for few Qt bindings
![image](https://user-images.githubusercontent.com/43494761/96241294-3bf59180-0fa2-11eb-85ef-f707d570a9a0.png)


## Changes
- added transparency attribute