### PR TITLE
Deadline publish job shows publishing output folder

### DIFF
--- a/pype/hosts/harmony/__init__.py
+++ b/pype/hosts/harmony/__init__.py
@@ -155,8 +155,11 @@ def check_inventory():
 
 
 def application_launch():
-    ensure_scene_settings()
-    check_inventory()
+    # FIXME: This is breaking server <-> client communication.
+    # It is now moved so it it manually called.
+    # ensure_scene_settings()
+    # check_inventory()
+    pass
 
 
 def export_template(backdrops, nodes, filepath):


### PR DESCRIPTION
Pre-calculate final publish folder to add it to right mouse click option 
![636deadline](https://user-images.githubusercontent.com/4457962/96245415-9b09d500-0fa7-11eb-8e53-5966df8577fa.png)
for easier checking in Deadline Monitor.

Previously value for rendered files on Deadline was used.

Solves #636
Depends on #642