### PR TITLE
Remove avalon io from pype lib

### DIFF
--- a/pype/lib.py
+++ b/pype/lib.py
@@ -538,19 +538,6 @@ def get_last_version_from_path(path_dir, filter):
         return None
 
 
-def get_avalon_database():
-    if io._database is None:
-        set_io_database()
-    return io._database
-
-
-def set_io_database():
-    required_keys = ["AVALON_PROJECT", "AVALON_ASSET", "AVALON_SILO"]
-    for key in required_keys:
-        os.environ[key] = os.environ.get(key, "")
-    io.install()
-
-
 def filter_pyblish_plugins(plugins):
     """
     This servers as plugin filter / modifier for pyblish. It will load plugin

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1511,12 +1511,18 @@ class ApplicationLaunchFailed(Exception):
 
 
 def launch_application(project_name, asset_name, task_name, app_name):
-    database = get_avalon_database()
-    project_document = database[project_name].find_one({"type": "project"})
-    asset_document = database[project_name].find_one({
+    # Prepare mongo connection for query of project and asset documents.
+    dbcon = avalon.api.AvalonMongoDB()
+    dbcon.install()
+    dbcon.Session["AVALON_PROJECT"] = project_name
+
+    project_document = dbcon.find_one({"type": "project"})
+    asset_document = dbcon.find_one({
         "type": "asset",
         "name": asset_name
     })
+    # Uninstall Mongo connection as is not needed anymore.
+    dbcon.uninstall()
 
     asset_doc_parents = asset_document["data"].get("parents")
     hierarchy = "/".join(asset_doc_parents)

--- a/pype/modules/ftrack/actions/action_application_loader.py
+++ b/pype/modules/ftrack/actions/action_application_loader.py
@@ -2,13 +2,13 @@ import os
 import toml
 import time
 from pype.modules.ftrack.lib import AppAction
-from avalon import lib
+from avalon import lib, api
 from pype.api import Logger, config
 
 log = Logger().get_logger(__name__)
 
 
-def registerApp(app, session, plugins_presets):
+def register_app(app, dbcon, session, plugins_presets):
     name = app['name']
     variant = ""
     try:
@@ -39,7 +39,7 @@ def registerApp(app, session, plugins_presets):
 
     # register action
     AppAction(
-        session, label, name, executable, variant,
+        session, dbcon, label, name, executable, variant,
         icon, description, preactions, plugins_presets
     ).register()
 
@@ -85,11 +85,12 @@ def register(session, plugins_presets={}):
             )
         )
 
+    dbcon = api.AvalonMongoDB()
     apps = sorted(apps, key=lambda app: app["name"])
     app_counter = 0
     for app in apps:
         try:
-            registerApp(app, session, plugins_presets)
+            register_app(app, dbcon, session, plugins_presets)
             if app_counter % 5 == 0:
                 time.sleep(0.1)
             app_counter += 1

--- a/pype/modules/ftrack/lib/ftrack_app_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_app_handler.py
@@ -20,7 +20,7 @@ class AppAction(BaseAction):
     preactions = ["start.timer"]
 
     def __init__(
-        self, session, label, name, executable, variant=None,
+        self, session, dbcon, label, name, executable, variant=None,
         icon=None, description=None, preactions=[], plugins_presets={}
     ):
         self.label = label
@@ -30,6 +30,8 @@ class AppAction(BaseAction):
         self.icon = icon
         self.description = description
         self.preactions.extend(preactions)
+
+        self.dbcon = dbcon
 
         super().__init__(session, plugins_presets)
         if label is None:
@@ -89,8 +91,10 @@ class AppAction(BaseAction):
         if avalon_project_apps is None:
             if avalon_project_doc is None:
                 ft_project = self.get_project_from_entity(entity)
-                database = pypelib.get_avalon_database()
                 project_name = ft_project["full_name"]
+
+                self.dbcon.install()
+                database = self.dbcon.database
                 avalon_project_doc = database[project_name].find_one({
                     "type": "project"
                 }) or False


### PR DESCRIPTION
## Changes
- removed functions from `pype.lib` using and modifying `avalon.io` (functions: `get_avalon_database` and `set_io_database`)
- their usage was replaced with using `AvalonMongoDB` object
    - was used in ftrack application action and on application launch from launcher tool