### PR TITLE
TVPaint image loader with options

### DIFF
--- a/pype/plugins/tvpaint/load/load_image.py
+++ b/pype/plugins/tvpaint/load/load_image.py
@@ -1,4 +1,5 @@
 from avalon import api
+from avalon.vendor import qargparse
 from avalon.tvpaint import CommunicatorWrapper
 
 
@@ -19,6 +20,27 @@ class ImportImage(api.Loader):
         "tv_loadsequence filepath \"preload\" PARSE layer_id\n"
         "tv_layerrename layer_id layer_name"
     )
+
+    options = [
+        qargparse.Boolean(
+            "stretch",
+            label="Stretch to project size",
+            default=True,
+            help="Stretch loaded image/s to project resolution?"
+        ),
+        qargparse.Boolean(
+            "timestretch",
+            label=" Stretch to timeline length",
+            default=True,
+            help="Clip loaded image/s to timeline length?"
+        ),
+        qargparse.Boolean(
+            "preload",
+            label="Preload loaded image/s",
+            default=True,
+            help="Preload image/s?"
+        )
+    ]
 
     def load(self, context, name, namespace, options):
         # Prepare layer name

--- a/pype/plugins/tvpaint/load/load_image.py
+++ b/pype/plugins/tvpaint/load/load_image.py
@@ -17,7 +17,7 @@ class ImportImage(api.Loader):
     import_script = (
         "filepath = \"{}\"\n"
         "layer_name = \"{}\"\n"
-        "tv_loadsequence filepath \"preload\" PARSE layer_id\n"
+        "tv_loadsequence filepath {}PARSE layer_id\n"
         "tv_layerrename layer_id layer_name"
     )
 
@@ -49,6 +49,22 @@ class ImportImage(api.Loader):
     ]
 
     def load(self, context, name, namespace, options):
+        stretch = options.get("stretch", self.defaults["stretch"])
+        timestretch = options.get("timestretch", self.defaults["timestretch"])
+        preload = options.get("preload", self.defaults["preload"])
+
+        load_options = []
+        if stretch:
+            load_options.append("\"STRETCH\"")
+        if timestretch:
+            load_options.append("\"TIMESTRETCH\"")
+        if preload:
+            load_options.append("\"PRELOAD\"")
+
+        load_options_str = ""
+        for load_option in load_options:
+            load_options_str += (load_option + " ")
+
         # Prepare layer name
         asset_name = context["asset"]["name"]
         version_name = context["version"]["name"]
@@ -61,6 +77,7 @@ class ImportImage(api.Loader):
         # - filename mus not contain backwards slashes
         george_script = self.import_script.format(
             self.fname.replace("\\", "/"),
-            layer_name
+            layer_name,
+            load_options_str
         )
         return CommunicatorWrapper.execute_george_through_file(george_script)

--- a/pype/plugins/tvpaint/load/load_image.py
+++ b/pype/plugins/tvpaint/load/load_image.py
@@ -21,6 +21,12 @@ class ImportImage(api.Loader):
         "tv_layerrename layer_id layer_name"
     )
 
+    defaults = {
+        "stretch": True,
+        "timestretch": True,
+        "preload": True
+    }
+
     options = [
         qargparse.Boolean(
             "stretch",

--- a/pype/plugins/tvpaint/load/load_image.py
+++ b/pype/plugins/tvpaint/load/load_image.py
@@ -36,7 +36,7 @@ class ImportImage(api.Loader):
         ),
         qargparse.Boolean(
             "timestretch",
-            label=" Stretch to timeline length",
+            label="Stretch to timeline length",
             default=True,
             help="Clip loaded image/s to timeline length?"
         ),


### PR DESCRIPTION
## Changes
- TVPaint's Image loader have 3 options
    - stretch to project size
    - stretch to project timeline
    - preload images
- defualt loader settings are all set to True for all options