### PR TITLE
Hotfix: Added default version number

### DIFF
--- a/pype/plugins/global/publish/submit_publish_job.py
+++ b/pype/plugins/global/publish/submit_publish_job.py
@@ -1024,6 +1024,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin):
             version = pype.api.get_latest_version(asset, subset)
             if version:
                 version = int(version["name"]) + 1
+            else:
+                version = 1
 
         template_data["subset"] = subset
         template_data["family"] = "render"


### PR DESCRIPTION
## Bug description

When publishing initial version of render there is a case when version feeded to `Anatomy` is **None**.

This happens here:

https://github.com/pypeclub/pype/blob/7c87d2c1140b09dbca3f15e4528f687623937788/pype/plugins/global/publish/submit_publish_job.py#L222-L232

in this case `instance.data.get("version")` is `1` but to `_get_publish_folder()` is passed `override_version` that is still **None**.

Inside, version determination can still result in **None**:

https://github.com/pypeclub/pype/blob/7c87d2c1140b09dbca3f15e4528f687623937788/pype/plugins/global/publish/submit_publish_job.py#L1023-L1030

If `get_latest_version` returns **None** (and it will, because nothing is published), **None** will be fed as version to Anatomy and will result in error.