### PR TITLE
Fix ffmpeg executable path with spaces

### DIFF
--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1391,9 +1391,11 @@ class BuildWorkfile:
         return output
 
 
-def ffprobe_streams(path_to_file):
+def ffprobe_streams(path_to_file, logger=None):
     """Load streams from entered filepath via ffprobe."""
-    log.info(
+    if not logger:
+        logger = log
+    logger.info(
         "Getting information about input \"{}\".".format(path_to_file)
     )
     args = [
@@ -1405,12 +1407,21 @@ def ffprobe_streams(path_to_file):
         "\"{}\"".format(path_to_file)
     ]
     command = " ".join(args)
-    log.debug("FFprobe command: \"{}\"".format(command))
-    popen = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    logger.debug("FFprobe command: \"{}\"".format(command))
+    popen = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
 
-    popen_output = popen.communicate()[0]
-    log.debug("FFprobe output: {}".format(popen_output))
-    return json.loads(popen_output)["streams"]
+    popen_stdout, popen_stderr = popen.communicate()
+    if popen_stdout:
+        logger.debug("ffprobe stdout: {}".format(popen_stdout))
+
+    if popen_stderr:
+        logger.debug("ffprobe stderr: {}".format(popen_stderr))
+    return json.loads(popen_stdout)["streams"]
 
 
 def source_hash(filepath, *args):

--- a/pype/lib.py
+++ b/pype/lib.py
@@ -1397,7 +1397,7 @@ def ffprobe_streams(path_to_file):
         "Getting information about input \"{}\".".format(path_to_file)
     )
     args = [
-        get_ffmpeg_tool_path("ffprobe"),
+        "\"{}\"".format(get_ffmpeg_tool_path("ffprobe")),
         "-v quiet",
         "-print_format json",
         "-show_format",

--- a/pype/plugins/global/publish/extract_jpeg.py
+++ b/pype/plugins/global/publish/extract_jpeg.py
@@ -72,7 +72,7 @@ class ExtractJpegEXR(pyblish.api.InstancePlugin):
             ffmpeg_args = self.ffmpeg_args or {}
 
             jpeg_items = []
-            jpeg_items.append(ffmpeg_path)
+            jpeg_items.append("\"{}\"".format(ffmpeg_path))
             # override file if already exists
             jpeg_items.append("-y")
             # use same input args like with mov

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -633,7 +633,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         # NOTE Skipped using instance's resolution
         full_input_path_single_file = temp_data["full_input_path_single_file"]
-        input_data = pype.lib.ffprobe_streams(full_input_path_single_file)[0]
+        input_data = pype.lib.ffprobe_streams(
+            full_input_path_single_file, self.log
+        )[0]
         input_width = int(input_data["width"])
         input_height = int(input_data["height"])
 

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -449,7 +449,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
                     audio_filters.append(arg)
 
         all_args = []
-        all_args.append(self.ffmpeg_path)
+        all_args.append("\"{}\"".format(self.ffmpeg_path))
         all_args.extend(input_args)
         if video_filters:
             all_args.append("-filter:v {}".format(",".join(video_filters)))
@@ -1526,7 +1526,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
                         os.mkdir(stg_dir)
 
                 mov_args = [
-                    ffmpeg_path,
+                    "\"{}\"".format(ffmpeg_path),
                     " ".join(input_args),
                     " ".join(output_args)
                 ]

--- a/pype/plugins/global/publish/extract_review_slate.py
+++ b/pype/plugins/global/publish/extract_review_slate.py
@@ -26,7 +26,7 @@ class ExtractReviewSlate(pype.api.Extractor):
         slate_path = inst_data.get("slateFrame")
         ffmpeg_path = pype.lib.get_ffmpeg_tool_path("ffmpeg")
 
-        slate_stream = pype.lib.ffprobe_streams(slate_path)[0]
+        slate_stream = pype.lib.ffprobe_streams(slate_path, self.log)[0]
         slate_width = slate_stream["width"]
         slate_height = slate_stream["height"]
 
@@ -299,7 +299,7 @@ class ExtractReviewSlate(pype.api.Extractor):
 
         try:
             # Get information about input file via ffprobe tool
-            streams = pype.lib.ffprobe_streams(full_input_path)
+            streams = pype.lib.ffprobe_streams(full_input_path, self.log)
         except Exception:
             self.log.warning(
                 "Could not get codec data from input.",

--- a/pype/plugins/global/publish/extract_review_slate.py
+++ b/pype/plugins/global/publish/extract_review_slate.py
@@ -178,7 +178,7 @@ class ExtractReviewSlate(pype.api.Extractor):
             _remove_at_end.append(slate_v_path)
 
             slate_args = [
-                ffmpeg_path,
+                "\"{}\"".format(ffmpeg_path),
                 " ".join(input_args),
                 " ".join(output_args)
             ]

--- a/pype/plugins/global/publish/validate_ffmpeg_installed.py
+++ b/pype/plugins/global/publish/validate_ffmpeg_installed.py
@@ -29,6 +29,6 @@ class ValidateFFmpegInstalled(pyblish.api.ContextPlugin):
     def process(self, context):
         ffmpeg_path = pype.lib.get_ffmpeg_tool_path("ffmpeg")
         self.log.info("ffmpeg path: `{}`".format(ffmpeg_path))
-        if self.is_tool(ffmpeg_path) is False:
+        if self.is_tool("\"{}\"".format(ffmpeg_path)) is False:
             self.log.error("ffmpeg not found in PATH")
             raise RuntimeError('ffmpeg not installed.')

--- a/pype/plugins/harmony/publish/extract_render.py
+++ b/pype/plugins/harmony/publish/extract_render.py
@@ -90,7 +90,7 @@ class ExtractRender(pyblish.api.InstancePlugin):
         thumbnail_path = os.path.join(path, "thumbnail.png")
         ffmpeg_path = pype.lib.get_ffmpeg_tool_path("ffmpeg")
         args = [
-            ffmpeg_path, "-y",
+            "\"{}\"".format(ffmpeg_path), "-y",
             "-i", os.path.join(path, list(collections[0])[0]),
             "-vf", "scale=300:-1",
             "-vframes", "1",

--- a/pype/plugins/hiero/publish/extract_review_cutup.py
+++ b/pype/plugins/hiero/publish/extract_review_cutup.py
@@ -130,8 +130,8 @@ class ExtractReviewCutUp(pype.api.Extractor):
 
                 # check if audio stream is in input video file
                 ffprob_cmd = (
-                    "{ffprobe_path} -i \"{full_input_path}\" -show_streams "
-                    "-select_streams a -loglevel error"
+                    "\"{ffprobe_path}\" -i \"{full_input_path}\" -show_streams"
+                    " -select_streams a -loglevel error"
                 ).format(**locals())
 
                 self.log.debug("ffprob_cmd: {}".format(ffprob_cmd))
@@ -171,7 +171,8 @@ class ExtractReviewCutUp(pype.api.Extractor):
                     # try to get video native resolution data
                     try:
                         resolution_output = pype.api.subprocess((
-                            "{ffprobe_path} -i \"{full_input_path}\" -v error "
+                            "\"{ffprobe_path}\" -i \"{full_input_path}\""
+                            " -v error "
                             "-select_streams v:0 -show_entries "
                             "stream=width,height -of csv=s=x:p=0"
                         ).format(**locals()))
@@ -274,7 +275,7 @@ class ExtractReviewCutUp(pype.api.Extractor):
                 output_args.append("-y \"{}\"".format(full_output_path))
 
                 mov_args = [
-                    ffmpeg_path,
+                    "\"{}\"".format(ffmpeg_path),
                     " ".join(input_args),
                     " ".join(output_args)
                 ]

--- a/pype/plugins/photoshop/publish/extract_review.py
+++ b/pype/plugins/photoshop/publish/extract_review.py
@@ -56,7 +56,7 @@ class ExtractReview(pype.api.Extractor):
         # Generate thumbnail.
         thumbnail_path = os.path.join(staging_dir, "thumbnail.jpg")
         args = [
-            ffmpeg_path, "-y",
+            "\"{}\"".format(ffmpeg_path), "-y",
             "-i", output_image_path,
             "-vf", "scale=300:-1",
             "-vframes", "1",

--- a/pype/plugins/standalonepublisher/publish/extract_shot_data.py
+++ b/pype/plugins/standalonepublisher/publish/extract_shot_data.py
@@ -47,7 +47,7 @@ class ExtractShotData(pype.api.Extractor):
             start += 0.5
 
         args = [
-            ffmpeg_path,
+            "\"{}\"".format(ffmpeg_path),
             "-ss", str(start / fps),
             "-i", f"\"{video_file_path}\"",
             "-t", str(dur / fps)

--- a/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
+++ b/pype/plugins/standalonepublisher/publish/extract_thumbnail.py
@@ -75,7 +75,7 @@ class ExtractThumbnailSP(pyblish.api.InstancePlugin):
             ffmpeg_args = self.ffmpeg_args or {}
 
             jpeg_items = []
-            jpeg_items.append(ffmpeg_path)
+            jpeg_items.append("\"{}\"".format(ffmpeg_path))
             # override file if already exists
             jpeg_items.append("-y")
             # add input filters from peresets

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -13,11 +13,11 @@ ffprobe_path = pype.lib.get_ffmpeg_tool_path("ffprobe")
 
 
 FFMPEG = (
-    '\"{}\" -i "%(input)s" %(filters)s %(args)s%(output)s'
+    '"{}" -i "%(input)s" %(filters)s %(args)s%(output)s'
 ).format(ffmpeg_path)
 
 FFPROBE = (
-    '\"{}\" -v quiet -print_format json -show_format -show_streams "%(source)s"'
+    '"{}" -v quiet -print_format json -show_format -show_streams "%(source)s"'
 ).format(ffprobe_path)
 
 DRAWTEXT = (

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -13,11 +13,11 @@ ffprobe_path = pype.lib.get_ffmpeg_tool_path("ffprobe")
 
 
 FFMPEG = (
-    '{} -i "%(input)s" %(filters)s %(args)s%(output)s'
+    '\"{}\" -i "%(input)s" %(filters)s %(args)s%(output)s'
 ).format(ffmpeg_path)
 
 FFPROBE = (
-    '{} -v quiet -print_format json -show_format -show_streams "%(source)s"'
+    '\"{}\" -v quiet -print_format json -show_format -show_streams "%(source)s"'
 ).format(ffprobe_path)
 
 DRAWTEXT = (

--- a/pype/tools/standalonepublish/widgets/widget_drop_frame.py
+++ b/pype/tools/standalonepublish/widgets/widget_drop_frame.py
@@ -266,7 +266,7 @@ class DropDataFrame(QtWidgets.QFrame):
     def load_data_with_probe(self, filepath):
         ffprobe_path = pype.lib.get_ffmpeg_tool_path("ffprobe")
         args = [
-            ffprobe_path,
+            "\"{}\"".format(ffprobe_path),
             '-v', 'quiet',
             '-print_format json',
             '-show_format',


### PR DESCRIPTION
## Issue
- ffmpeg(and other tools) crash in subprocess if path to them contain spaces

## Changes
- path to ffmpeg executables is wrapped with quotes to tell system full path to executable
- function `ffprobe_streams` can accept logger object and log also stderr from executed process, if there is any