### PR TITLE
Maya: Vray expected file fixes

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -564,6 +564,7 @@ class ExpectedFilesVray(AExpectedFiles):
         if default_ext == "exr (multichannel)" or default_ext == "exr (deep)":
             default_ext = "exr"
         layer_data["defaultExt"] = default_ext
+        layer_data["padding"] = cmds.getAttr("vraySettings.fileNamePadding")
         return layer_data
 
     def get_files(self):
@@ -614,11 +615,14 @@ class ExpectedFilesVray(AExpectedFiles):
         if default_ext == "exr (multichannel)" or default_ext == "exr (deep)":
             default_ext = "exr"
 
+        # filter all namespace prefixed AOVs - they are pulled in from
+        # references and are not rendered.
         vr_aovs = [
             n
             for n in cmds.ls(
                 type=["VRayRenderElement", "VRayRenderElementSet"]
             )
+            if len(n.split(":")) == 1
         ]
 
         for aov in vr_aovs:


### PR DESCRIPTION
## Change

this adds two fixes - one for getting frame padding directly from vray settings (and not render globals) and one for filtering aovs coming from refereces (prefixed with namespaces). So AOVs named like `foo:bar` will be skipped but `baz` wil not.