### PR TITLE
Render publish plugins abstraction

### DIFF
--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+"""Collect render template.
+
+TODO: use @dataclass when times come.
+
+"""
+from abc import ABCMeta, abstractmethod
+
+import six
+import attr
+
+from avalon import api
+import pyblish.api
+
+from expected_files import ExpectedFiles
+
+
+@attr.s
+class RenderInstance(object):
+    """Data collected by collectors.
+
+    This data class later on passed to collected instances.
+    Those attributes are required later on.
+
+    """
+
+    # metadata
+    version = attr.ib()
+    time = attr.ib()
+    source = attr.ib()
+    label = attr.ib()
+    subset = attr.ib()
+    asset = attr.ib(init=False)
+    attachTo = attr.ib(init=False)
+    setMembers = attr.ib()
+    publish = attr.ib()
+    review = attr.ib(default=False)
+    renderer = attr.ib()
+    priority = attr.ib(default=50)
+    name = attr.ib()
+
+    family = attr.ib(default="renderlayer")
+    families = attr.ib(default=["renderlayer"])
+
+    # format settings
+    resolutionWidth = attr.ib()
+    resolutionHeight = attr.ib()
+    pixelAspect = attr.ib()
+    multipartExr = attr.ib(default=False)
+    tileRendering = attr.ib()
+    tilesX = attr.ib()
+    tilesY = attr.ib()
+    convertToScanline = attr.ib(default=False)
+
+    # time settings
+    frameStart = attr.ib()
+    frameEnd = attr.ib()
+    frameStep = attr.ib()
+
+    @frameStart.validator
+    def check_frame_start(self, attribute, value):
+        """Validate if frame start is not larger then end."""
+        if value >= self.frameEnd:
+            raise ValueError("frameStart must be smaller "
+                             "or equal then frameEnd")
+
+    @frameEnd.validator
+    def check_frame_end(self, attribute, value):
+        """Validate if frame end is not less then start."""
+        if value <= self.frameStart:
+            raise ValueError("frameEnd must be smaller "
+                             "or equal then frameStart")
+
+    @tilesX.validator
+    def check_tiles_x(self, attribute, value):
+        """Validate if tile x isn't less then 1."""
+        if not self.tileRendering:
+            return
+        if value < 1:
+            raise ValueError("tile X size cannot be less then 1")
+
+        if value == 1 and self.tilesY == 1:
+            raise ValueError("both tiles X a Y sizes are set to 1")
+
+    @tilesY.validator
+    def check_tiles_y(self, attribute, value):
+        """Validate if tile y isn't less then 1."""
+        if not self.tileRendering:
+            return
+        if value < 1:
+            raise ValueError("tile Y size cannot be less then 1")
+
+        if value == 1 and self.tilesX == 1:
+            raise ValueError("both tiles X a Y sizes are set to 1")
+
+
+@six.add_metaclass(ABCMeta)
+class CollectRender(pyblish.api.ContextPlugin):
+    """Gather all publishable render layers from renderSetup."""
+
+    order = pyblish.api.CollectorOrder + 0.01
+    label = "Collect Render"
+    sync_workfile_version = False
+
+    def process(self, context):
+        """Entry point to collector."""
+        rendering_instance = None
+        for instance in context:
+            if "rendering" in instance.data["families"]:
+                rendering_instance = instance
+                rendering_instance.data["remove"] = True
+
+            # make sure workfile instance publishing is enabled
+            if "workfile" in instance.data["families"]:
+                instance.data["publish"] = True
+
+        if not rendering_instance:
+            self.log.info(
+                "No rendering instance found, skipping render "
+                "layer collection."
+            )
+            return
+
+        self._filepath = context.data["currentFile"].replace("\\", "/")
+        self._asset = api.Session["AVALON_ASSET"]
+
+        render_instances = self.get_instances()
+        for render_instance in render_instances:
+            exp_files = self._get_expected_files(render_instance)
+
+            frame_start_render = int(render_instance.frameStart)
+            frame_end_render = int(render_instance.frameEnd)
+
+            if (int(context.data['frameStartHandle']) == frame_start_render
+                    and int(context.data['frameEndHandle']) == frame_end_render):  # noqa: W503, E501
+
+                handle_start = context.data['handleStart']
+                handle_end = context.data['handleEnd']
+                frame_start = context.data['frameStart']
+                frame_end = context.data['frameEnd']
+                frame_start_handle = context.data['frameStartHandle']
+                frame_end_handle = context.data['frameEndHandle']
+            else:
+                handle_start = 0
+                handle_end = 0
+                frame_start = frame_start_render
+                frame_end = frame_end_render
+                frame_start_handle = frame_start_render
+                frame_end_handle = frame_end_render
+
+            data = {
+                "subset": render_instance.subset,
+                "attachTo": render_instance.attachTo,
+                "setMembers": render_instance.setMembers,
+                "multipartExr": exp_files.multipart,
+                "review": render_instance.review or False,
+                "publish": True,
+
+                "handleStart": handle_start,
+                "handleEnd": handle_end,
+                "frameStart": frame_start,
+                "frameEnd": frame_end,
+                "frameStartHandle": frame_start_handle,
+                "frameEndHandle": frame_end_handle,
+                "byFrameStep": int(render_instance.frameStep),
+                "renderer": render_instance.renderer,
+                # instance subset
+                "family": render_instance.family,
+                "families": render_instance.families,
+                "asset": render_instance.asset,
+                "time": render_instance.time,
+                "author": context.data["user"],
+                # Add source to allow tracing back to the scene from
+                # which was submitted originally
+                "source": render_instance.source,
+                "expectedFiles": exp_files,
+                "resolutionWidth": render_instance.resolutionWidth,
+                "resolutionHeight": render_instance.resolutionHeight,
+                "pixelAspect": render_instance.pixelAspect,
+                "tileRendering": render_instance.tileRendering or False,
+                "tilesX": render_instance.tilesX or 2,
+                "tilesY": render_instance.tilesY or 2,
+                "priority": render_instance.priority,
+                "convertToScanline": render_instance.convertToScanline or False
+            }
+            if self.sync_workfile_version:
+                data["version"] = context.data["version"]
+
+            # add additional data
+            data = self.add_additional_data(data)
+
+            instance = context.create_instance(render_instance.name)
+            instance.data["label"] = render_instance.label
+            instance.data.update(data)
+
+        self.post_collecting_action()
+
+    @abstractmethod
+    def get_instances(self):
+        """Get all renderable instances and their data.
+
+        Returns:
+            list of :class:`RenderInstance`: All collected renderable instances
+                (like render layers, write nodes, etc.)
+
+        """
+        pass
+
+    def _get_expected_files(self, render_instance):
+        """Get list of expected files."""
+        # return all expected files for all cameras and aovs in given
+        # frame range
+        ef = ExpectedFiles()
+        exp_files = ef.get(render_instance)
+        self.log.info("multipart: {}".format(ef.multipart))
+        assert exp_files, "no file names were generated, this is bug"
+
+        # if we want to attach render to subset, check if we have AOV's
+        # in expectedFiles. If so, raise error as we cannot attach AOV
+        # (considered to be subset on its own) to another subset
+        if render_instance.attachTo:
+            assert isinstance(exp_files, list), (
+                "attaching multiple AOVs or renderable cameras to "
+                "subset is not supported"
+            )
+
+    def add_additional_data(self, data):
+        """Add additional data to collected instance.
+
+        This can be overridden by host implementation to add custom
+        additional data.
+
+        """
+        return data
+
+    def post_collecting_action(self):
+        """Execute some code after collection is done.
+
+        This is useful for example for restoring current render layer.
+
+        """
+        pass

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -115,7 +115,6 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
         self._file_path = None
         self._asset = api.Session["AVALON_ASSET"]
 
-
     def process(self, context):
         """Entry point to collector."""
         rendering_instance = None

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -117,22 +117,10 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
 
     def process(self, context):
         """Entry point to collector."""
-        rendering_instance = None
         for instance in context:
-            if "rendering" in instance.data["families"]:
-                rendering_instance = instance
-                rendering_instance.data["remove"] = True
-
             # make sure workfile instance publishing is enabled
             if "workfile" in instance.data["families"]:
                 instance.data["publish"] = True
-
-        if not rendering_instance:
-            self.log.info(
-                "No rendering instance found, skipping render "
-                "layer collection."
-            )
-            return
 
         self._file_path = context.data["currentFile"].replace("\\", "/")
 

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -124,6 +124,8 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
             try:
                 if "workfile" in instance.data["families"]:
                     instance.data["publish"] = True
+                if "renderFarm" in instance.data["families"]:
+                    instance.data["remove"] = True
             except KeyError:
                 # be tolerant if 'families' is missing.
                 pass
@@ -165,13 +167,6 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
                 frame_end_handle = frame_end_render
 
             data = {
-                "subset": render_instance.subset,
-                "attachTo": render_instance.attachTo,
-                "setMembers": render_instance.setMembers,
-                "multipartExr": render_instance.multipartExr,
-                "review": render_instance.review or False,
-                "publish": True,
-
                 "handleStart": handle_start,
                 "handleEnd": handle_end,
                 "frameStart": frame_start,
@@ -179,34 +174,22 @@ class AbstractCollectRender(pyblish.api.ContextPlugin):
                 "frameStartHandle": frame_start_handle,
                 "frameEndHandle": frame_end_handle,
                 "byFrameStep": int(render_instance.frameStep),
-                "renderer": render_instance.renderer,
-                # instance subset
-                "family": render_instance.family,
-                "families": render_instance.families,
-                "asset": render_instance.asset,
-                "time": render_instance.time,
+
                 "author": context.data["user"],
                 # Add source to allow tracing back to the scene from
                 # which was submitted originally
-                "source": render_instance.source,
                 "expectedFiles": exp_files,
-                "resolutionWidth": render_instance.resolutionWidth,
-                "resolutionHeight": render_instance.resolutionHeight,
-                "pixelAspect": render_instance.pixelAspect,
-                "tileRendering": render_instance.tileRendering or False,
-                "tilesX": render_instance.tilesX or 2,
-                "tilesY": render_instance.tilesY or 2,
-                "priority": render_instance.priority,
-                "convertToScanline": render_instance.convertToScanline or False
             }
             if self.sync_workfile_version:
                 data["version"] = context.data["version"]
 
             # add additional data
             data = self.add_additional_data(data)
+            render_instance_dict = attr.asdict(render_instance)
 
             instance = context.create_instance(render_instance.name)
             instance.data["label"] = render_instance.label
+            instance.data.update(render_instance_dict)
             instance.data.update(data)
 
         self.post_collecting_action()

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -12,7 +12,7 @@ import attr
 from avalon import api
 import pyblish.api
 
-from expected_files import ExpectedFiles
+from .abstract_expected_files import ExpectedFiles
 
 
 @attr.s
@@ -95,7 +95,7 @@ class RenderInstance(object):
 
 
 @six.add_metaclass(ABCMeta)
-class CollectRender(pyblish.api.ContextPlugin):
+class AbstractCollectRender(pyblish.api.ContextPlugin):
     """Gather all publishable render layers from renderSetup."""
 
     order = pyblish.api.CollectorOrder + 0.01

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -4,10 +4,10 @@
 TODO: use @dataclass when times come.
 
 """
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
-import six
 import attr
+import six
 
 from avalon import api
 import pyblish.api
@@ -102,7 +102,8 @@ class RenderInstance(object):
             raise ValueError("both tiles X a Y sizes are set to 1")
 
 
-class AbstractCollectRender(AbstractMetaContextPlugin):
+@six.add_metaclass(AbstractMetaContextPlugin)
+class AbstractCollectRender(pyblish.api.ContextPlugin):
     """Gather all publishable render layers from renderSetup."""
 
     order = pyblish.api.CollectorOrder + 0.01
@@ -196,8 +197,11 @@ class AbstractCollectRender(AbstractMetaContextPlugin):
         self.post_collecting_action()
 
     @abstractmethod
-    def get_instances(self):
+    def get_instances(self, context):
         """Get all renderable instances and their data.
+
+        Args:
+            context (pyblish.api.Context): Context object.
 
         Returns:
             list of :class:`RenderInstance`: All collected renderable instances

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -64,6 +64,12 @@ class RenderInstance(object):
     tilesX = attr.ib(default=0)  # number of tiles in X
     tilesY = attr.ib(default=0)  # number of tiles in Y
 
+    # submit_publish_job
+    toBeRenderedOn = attr.ib(default=None)
+    deadlineSubmissionJob = attr.ib(default=None)
+    anatomyData = attr.ib(default=None)
+    outputDir = attr.ib(default=None)
+
     @frameStart.validator
     def check_frame_start(self, _, value):
         """Validate if frame start is not larger then end."""

--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -13,6 +13,7 @@ from avalon import api
 import pyblish.api
 
 from .abstract_expected_files import ExpectedFiles
+from .abstract_metaplugins import AbstractMetaContextPlugin
 
 
 @attr.s
@@ -101,8 +102,7 @@ class RenderInstance(object):
             raise ValueError("both tiles X a Y sizes are set to 1")
 
 
-@six.add_metaclass(ABCMeta)
-class AbstractCollectRender(pyblish.api.ContextPlugin):
+class AbstractCollectRender(AbstractMetaContextPlugin):
     """Gather all publishable render layers from renderSetup."""
 
     order = pyblish.api.CollectorOrder + 0.01

--- a/pype/lib/abstract_expected_files.py
+++ b/pype/lib/abstract_expected_files.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Abstract ExpectedFile class definition."""
+from abc import ABCMeta, abstractmethod
+import six
+
+
+@six.add_metaclass(ABCMeta)
+class ExpectedFiles:
+    """Class grouping functionality for all supported renderers.
+
+    Attributes:
+        multipart (bool): Flag if multipart exrs are used.
+
+    """
+
+    multipart = False
+
+    @abstractmethod
+    def get(self, render_instance):
+        """Get expected files for given renderer and render layer.
+
+        This method should return dictionary of all files we are expecting
+        to be rendered from the host. Usually `render_instance` corresponds
+        to *render layer*. Result can be either flat list with the file
+        paths or it can be list of dictionaries. Each key corresponds to
+        for example AOV name or channel, etc.
+
+        Example::
+
+            ['/path/to/file.001.exr', '/path/to/file.002.exr']
+
+            or as dictionary:
+
+            [
+                {
+                    "beauty": ['/path/to/beauty.001.exr', ...],
+                    "mask": ['/path/to/mask.001.exr']
+                }
+            ]
+
+
+        Args:
+            renderer_instance (:class:`RenderInstance`): Data passed from
+                collector to determine files. This should be instance of
+                :class:`abstract_collect_render.RenderInstance`
+
+        Returns:
+            list: Full paths to expected rendered files.
+            list of dict: Path to expected rendered files categorized by
+                AOVs, etc.
+
+        """
+        raise NotImplementedError()

--- a/pype/lib/abstract_expected_files.py
+++ b/pype/lib/abstract_expected_files.py
@@ -40,7 +40,7 @@ class ExpectedFiles:
 
 
         Args:
-            renderer_instance (:class:`RenderInstance`): Data passed from
+            render_instance (:class:`RenderInstance`): Data passed from
                 collector to determine files. This should be instance of
                 :class:`abstract_collect_render.RenderInstance`
 

--- a/pype/lib/abstract_metaplugins.py
+++ b/pype/lib/abstract_metaplugins.py
@@ -1,0 +1,10 @@
+from abc import ABCMeta
+from pyblish.api import InstancePlugin, ContextPlugin
+
+
+class AbstractMetaInstancePlugin(ABCMeta, InstancePlugin):
+    pass
+
+
+class AbstractMetaContextPlugin(ABCMeta, ContextPlugin):
+    pass

--- a/pype/lib/abstract_metaplugins.py
+++ b/pype/lib/abstract_metaplugins.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta
-from pyblish.api import InstancePlugin, ContextPlugin
+from pyblish.plugin import MetaPlugin, ExplicitMetaPlugin
 
 
-class AbstractMetaInstancePlugin(ABCMeta, InstancePlugin):
+class AbstractMetaInstancePlugin(ABCMeta, MetaPlugin):
     pass
 
 
-class AbstractMetaContextPlugin(ABCMeta, ContextPlugin):
+class AbstractMetaContextPlugin(ABCMeta, ExplicitMetaPlugin):
     pass

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -2,6 +2,8 @@
 """Abstract class for submitting jobs to Deadline."""
 import os
 from abc import ABCMeta, abstractmethod
+import platform
+import getpass
 
 import six
 import attr
@@ -12,7 +14,324 @@ import pyblish.api
 
 @attr.s
 class DeadlineJobInfo:
-    BatchName = attr.ib()
+    """Mapping of all Deadline *JobInfo* attributes.
+
+    This contains all JobInfo attributes plus their default values.
+    Those attributes set to `None` shouldn't be posted to Deadline as
+    the only required one is `Plugin`. Their default values used by Deadline
+    are stated in
+    comments.
+
+    ..seealso:
+        https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/manual-submission.html
+
+    """
+
+    # Required
+    # ----------------------------------------------
+    Plugin = attr.ib()
+
+    # General
+    Frames = attr.ib(default=None)  # default: 0
+    Name = attr.ib(default="Untitled")
+    Comment = attr.ib(default=None)  # default: empty
+    Department = attr.ib(default=None)  # default: empty
+    BatchName = attr.ib(default=None)  # default: empty
+    UserName = attr.ib(default=getpass.getuser())
+    MachineName = attr.ib(default=platform.node())
+    Pool = attr.ib(default=None)  # default: "none"
+    SecondaryPool = attr.ib(default=None)
+    Group = attr.ib(default=None)  # default: "none"
+    Priority = attr.ib(default=50)
+    ChunkSize = attr.ib(default=1)
+    ConcurrentTasks = attr.ib(default=1)
+    LimitConcurrentTasksToNumberOfCpus = attr.ib(
+        default=None)  # default: "true"
+    OnJobComplete = attr.ib(default="Nothing")
+    SynchronizeAllAuxiliaryFiles = attr.ib(default=None)  # default: false
+    ForceReloadPlugin = attr.ib(default=None)  # default: false
+    Sequential = attr.ib(default=None)  # default: false
+    SuppressEvents = attr.ib(default=None)  # default: false
+    Protected = attr.ib(default=None)  # default: false
+    InitialStatus = attr.ib(default="Active")
+    NetworkRoot = attr.ib(default=None)
+
+    # Timeouts
+    # ----------------------------------------------
+    MinRenderTimeSeconds = attr.ib(default=None)  # Default: 0
+    MinRenderTimeMinutes = attr.ib(default=None)  # Default: 0
+    TaskTimeoutSeconds = attr.ib(default=None)  # Default: 0
+    TaskTimeoutMinutes = attr.ib(default=None)  # Default: 0
+    StartJobTimeoutSeconds = attr.ib(default=None)  # Default: 0
+    StartJobTimeoutMinutes = attr.ib(default=None)  # Default: 0
+    InitializePluginTimeoutSeconds = attr.ib(default=None)  # Default: 0
+    # can be one of <Error/Notify/ErrorAndNotify/Complete>
+    OnTaskTimeout = attr.ib(default=None)  # Default: Error
+    EnableTimeoutsForScriptTasks = attr.ib(default=None)  # Default: false
+    EnableFrameTimeouts = attr.ib(default=None)  # Default: false
+    EnableAutoTimeout = attr.ib(default=None)  # Default: false
+
+    # Interruptible
+    # ----------------------------------------------
+    Interruptible = attr.ib(default=None)  # Default: false
+    InterruptiblePercentage = attr.ib(default=None)
+    RemTimeThreshold = attr.ib(default=None)
+
+    # Notifications
+    # ----------------------------------------------
+    # can be comma separated list of users
+    NotificationTargets = attr.ib(default=None)  # Default: blank
+    ClearNotificationTargets = attr.ib(default=None)  # Default: false
+    # A comma separated list of additional email addresses
+    NotificationEmails = attr.ib(default=None)  # Default: blank
+    OverrideNotificationMethod = attr.ib(default=None)  # Default: false
+    EmailNotification = attr.ib(default=None)  # Default: false
+    PopupNotification = attr.ib(default=None)  # Default: false
+    # String with `[EOL]` used for end of line
+    NotificationNote = attr.ib(default=None)  # Default: blank
+
+    # Machine Limit
+    # ----------------------------------------------
+    MachineLimit = attr.ib(default=None)  # Default: 0
+    MachineLimitProgress = attr.ib(default=None)  # Default: -1.0
+    Whitelist = attr.ib(default=None)  # Default: blank
+    Blacklist = attr.ib(default=None)  # Default: blank
+
+    # Limits
+    # ----------------------------------------------
+    # comma separated list of limit groups
+    LimitGroups = attr.ib(default=None)  # Default: blank
+
+    # Dependencies
+    # ----------------------------------------------
+    # comma separated list of job IDs
+    JobDependencies = attr.ib(default=None)  # Default: blank
+    JobDependencyPercentage = attr.ib(default=None)  # Default: -1
+    IsFrameDependent = attr.ib(default=None)  # Default: false
+    FrameDependencyOffsetStart = attr.ib(default=None)  # Default: 0
+    FrameDependencyOffsetEnd = attr.ib(default=None)  # Default: 0
+    ResumeOnCompleteDependencies = attr.ib(default=None)  # Default: true
+    ResumeOnDeletedDependencies = attr.ib(default=None)  # Default: false
+    ResumeOnFailedDependencies = attr.ib(default=None)  # Default: false
+    # comma separated list of asset paths
+    RequiredAssets = attr.ib(default=None)  # Default: blank
+    # comma separated list of script paths
+    ScriptDependencies = attr.ib(default=None)  # Default: blank
+
+    # Failure Detection
+    # ----------------------------------------------
+    OverrideJobFailureDetection = attr.ib(default=None)  # Default: false
+    FailureDetectionJobErrors = attr.ib(default=None)  # 0..x
+    OverrideTaskFailureDetection = attr.ib(default=None)  # Default: false
+    FailureDetectionTaskErrors = attr.ib(default=None)  # 0..x
+    IgnoreBadJobDetection = attr.ib(default=None)  # Default: false
+    SendJobErrorWarning = attr.ib(default=None)  # Default: false
+
+    # Cleanup
+    # ----------------------------------------------
+    DeleteOnComplete = attr.ib(default=None)  # Default: false
+    ArchiveOnComplete = attr.ib(default=None)  # Default: false
+    OverrideAutoJobCleanup = attr.ib(default=None)  # Default: false
+    OverrideJobCleanup = attr.ib(default=None)
+    JobCleanupDays = attr.ib(default=None)  # Default: false
+    # <ArchiveJobs/DeleteJobs>
+    OverrideJobCleanupType = attr.ib(default=None)
+
+    # Scheduling
+    # ----------------------------------------------
+    # <None/Once/Daily/Custom>
+    ScheduledType = attr.ib(default=None)  # Default: None
+    # <dd/MM/yyyy HH:mm>
+    ScheduledStartDateTime = attr.ib(default=None)
+    ScheduledDays = attr.ib(default=None)  # Default: 1
+    # <dd:hh:mm:ss>
+    JobDelay = attr.ib(default=None)
+    # <Day of the Week><Start/Stop>Time=<HH:mm:ss>
+    Scheduled = attr.ib(default=None)
+
+    # Scripts
+    # ----------------------------------------------
+    # all accept path to script
+    PreJobScript = attr.ib(default=None)  # Default: blank
+    PostJobScript = attr.ib(default=None)  # Default: blank
+    PreTaskScript = attr.ib(default=None)  # Default: blank
+    PostTaskScript = attr.ib(default=None)  # Default: blank
+
+    # Event Opt-Ins
+    # ----------------------------------------------
+    # comma separated list of plugins
+    EventOptIns = attr.ib(default=None)  # Default: blank
+
+    # Environment
+    # ----------------------------------------------
+    _environmentKeyValue = attr.ib(factory=list)
+
+    @property
+    def EnvironmentKeyValue(self):  # noqa: N802
+        """Return all environment key values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('EnvironmentKeyValue0', 'key=value')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._environmentKeyValue:
+            out.append(("EnvironmentKeyValue{}".format(index), v))
+            index += 1
+        return out
+
+    @EnvironmentKeyValue.setter
+    def EnvironmentKeyValue(self, val):  # noqa: N802
+        self._environmentKeyValue.append(val)
+
+    IncludeEnvironment = attr.ib(default=None)  # Default: false
+    UseJobEnvironmentOnly = attr.ib(default=None)  # Default: false
+    CustomPluginDirectory = attr.ib(default=None)  # Default: blank
+
+    # Job Extra Info
+    # ----------------------------------------------
+    _extraInfos = attr.ib(factory=list)
+    _extraInfoKeyValues = attr.ib(factory=list)
+
+    @property
+    def ExtraInfo(self):  # noqa: N802
+        """Return all ExtraInfo values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('ExtraInfo0', 'value')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._extraInfos:
+            out.append(("ExtraInfo{}".format(index), v))
+            index += 1
+        return out
+
+    @ExtraInfo.setter
+    def ExtraInfo(self, val):  # noqa: N802
+        self._extraInfos.append(val)
+
+    @property
+    def ExtraInfoKeyValue(self):  # noqa: N802
+        """Return all ExtraInfoKeyValue values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('ExtraInfoKeyValue0', 'key=value')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._extraInfoKeyValues:
+            out.append(("ExtraInfoKeyValue{}".format(index), v))
+            index += 1
+        return out
+
+    @ExtraInfoKeyValue.setter
+    def ExtraInfoKeyValue(self, val):  # noqa: N802
+        self._extraInfoKeyValues.append(val)
+
+    # Task Extra Info Names
+    # ----------------------------------------------
+    OverrideTaskExtraInfoNames = attr.ib(default=None)  # Default: false
+    _taskExtraInfos = attr.ib(factory=list)
+
+    @property
+    def TaskExtraInfoName(self):  # noqa: N802
+        """Return all TaskExtraInfoName values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('TaskExtraInfoName0', 'value')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._taskExtraInfos:
+            out.append(("TaskExtraInfoName{}".format(index), v))
+            index += 1
+        return out
+
+    @TaskExtraInfoName.setter
+    def TaskExtraInfoName(self, val):  # noqa: N802
+        self._taskExtraInfos.append(val)
+
+    # Output
+    # ----------------------------------------------
+    _outputFilename = attr.ib(factory=list)
+    _outputFilenameTile = attr.ib(factory=list)
+    _outputDirectory = attr.ib(factory=list)
+
+    @property
+    def OutputFilename(self):  # noqa: N802
+        """Return all OutputFilename values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('OutputFilename0', 'filename')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._outputFilename:
+            out.append(("OutputFilename{}".format(index), v))
+            index += 1
+        return out
+
+    @OutputFilename.setter
+    def OutputFilename(self, val):  # noqa: N802
+        self._outputFilename.append(val)
+
+    @property
+    def OutputFilenameTile(self):  # noqa: N802
+        """Return all OutputFilename#Tile values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('OutputFilename#Tile', 'tile')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._outputFilenameTile:
+            out.append(("OutputFilename{}Tile".format(index), v))
+            index += 1
+        return out
+
+    @OutputFilenameTile.setter
+    def OutputFilenameTile(self, val):  # noqa: N802
+        self._outputFilenameTile.append(val)
+
+    @property
+    def OutputDirectory(self):  # noqa: N802
+        """Return all OutputDirectory values formatted for Deadline.
+
+        Returns:
+            list of tuples: as `[('OutputDirectory0', 'dir')]`
+
+        """
+        out = []
+        index = 0
+        for v in self._outputDirectory:
+            out.append(("OutputDirectory{}".format(index), v))
+            index += 1
+        return out
+
+    @OutputDirectory.setter
+    def OutputDirectory(self, val):  # noqa: N802
+        self._outputDirectory.append(val)
+
+    # Tile Job
+    # ----------------------------------------------
+    TileJob = attr.ib(default=None)  # Default: false
+    TileJobFrame = attr.ib(default=None)  # Default: 0
+    TileJobTilesInX = attr.ib(default=None)  # Default: 0
+    TileJobTilesInY = attr.ib(default=None)  # Default: 0
+    TileJobTileCount = attr.ib(default=None)  # Default: 0
+
+    # Maintenance Job
+    # ----------------------------------------------
+    MaintenanceJob = attr.ib(default=None)  # Default: false
+    MaintenanceJobStartFrame = attr.ib(default=None)  # Default: 0
+    MaintenanceJobEndFrame = attr.ib(default=None)  # Default: 0
 
 
 @attr.s

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -5,7 +5,7 @@ It provides Deadline JobInfo data class.
 
 """
 import os
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 import platform
 import getpass
 from collections import OrderedDict
@@ -352,7 +352,7 @@ class DeadlineJobInfo:
 
 
 @six.add_metaclass(AbstractMetaInstancePlugin)
-class AbstractSubmitDeadline:
+class AbstractSubmitDeadline(pyblish.api.InstancePlugin):
     """Class abstracting access to Deadline."""
 
     label = "Submit to Deadline"

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Abstract class for submitting jobs to Deadline."""
+import os
+from abc import ABCMeta, abstractmethod
+
+import six
+import attr
+import requests
+
+import pyblish.api
+
+
+@attr.s
+class DeadlineJobInfo:
+    BatchName = attr.ib()
+
+
+@attr.s
+class DeadlinePluginInfo:
+    SceneFile = attr.ib()
+
+
+@six.add_metaclass(ABCMeta)
+class AbstractSubmitDeadline(pyblish.api.InstancePlugin):
+
+    label = "Submit to Deadline"
+    order = pyblish.api.IntegratorOrder + 0.1
+    use_published = True
+    asset_dependencies = False
+
+    def submit(self, payload):
+        url = "{}/api/jobs".format(self._deadline_url)
+        response = self._requests_post(url, json=payload)
+        if not response.ok:
+            self.log.error("Submition failed!")
+            self.log.error(response.status_code)
+            self.log.error(response.content)
+            self.log.debug(payload)
+            raise RuntimeError(response.text)
+
+        dependency = response.json()
+        return dependency["_id"]
+
+    def _requests_post(self, *args, **kwargs):
+        """Wrap request post method.
+
+        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
+        variable is found. This is useful when Deadline or Muster server are
+        running with self-signed certificates and their certificate is not
+        added to trusted certificates on client machines.
+
+        Warning:
+            Disabling SSL certificate validation is defeating one line
+            of defense SSL is providing and it is not recommended.
+
+        """
+        if 'verify' not in kwargs:
+            kwargs['verify'] = False if os.getenv("PYPE_DONT_VERIFY_SSL", True) else True  # noqa
+        # add 10sec timeout before bailing out
+        kwargs['timeout'] = 10
+        return requests.post(*args, **kwargs)
+
+    def _requests_get(self, *args, **kwargs):
+        """Wrap request get method.
+
+        Disabling SSL certificate validation if ``DONT_VERIFY_SSL`` environment
+        variable is found. This is useful when Deadline or Muster server are
+        running with self-signed certificates and their certificate is not
+        added to trusted certificates on client machines.
+
+        Warning:
+            Disabling SSL certificate validation is defeating one line
+            of defense SSL is providing and it is not recommended.
+
+        """
+        if 'verify' not in kwargs:
+            kwargs['verify'] = False if os.getenv("PYPE_DONT_VERIFY_SSL", True) else True  # noqa
+        # add 10sec timeout before bailing out
+        kwargs['timeout'] = 10
+        return requests.get(*args, **kwargs)

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -19,7 +19,7 @@ from .abstract_metaplugins import AbstractMetaInstancePlugin
 
 
 @attr.s
-class DeadlineJobInfo:
+class DeadlineJobInfo(object):
     """Mapping of all Deadline *JobInfo* attributes.
 
     This contains all JobInfo attributes plus their default values.
@@ -474,14 +474,15 @@ class AbstractSubmitDeadline(pyblish.api.InstancePlugin):
         anatomy = self._instance.context.data['anatomy']
         file_path = None
         for i in self._instance.context:
-            if "workfile" in i.data["families"]:
+            if "workfile" in i.data["families"] \
+                    or i.data["family"] == "workfile":
                 # test if there is instance of workfile waiting
                 # to be published.
                 assert i.data["publish"] is True, (
                     "Workfile (scene) must be published along")
                 # determine published path from Anatomy.
                 template_data = i.data.get("anatomyData")
-                rep = i.data.get("representations")[0].get("name")
+                rep = i.data.get("representations")[0].get("ext")
                 template_data["representation"] = rep
                 template_data["ext"] = rep
                 template_data["comment"] = None

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -582,6 +582,9 @@ class AbstractSubmitDeadline(pyblish.api.InstancePlugin):
             raise RuntimeError(response.text)
 
         result = response.json()
+        # for submit publish job
+        self._instance.data["deadlineSubmissionJob"] = result
+
         return result["_id"]
 
     def _requests_post(self, *args, **kwargs):

--- a/pype/lib/abstract_submit_deadline.py
+++ b/pype/lib/abstract_submit_deadline.py
@@ -15,6 +15,7 @@ import attr
 import requests
 
 import pyblish.api
+from .abstract_metaplugins import AbstractMetaInstancePlugin
 
 
 @attr.s
@@ -350,8 +351,8 @@ class DeadlineJobInfo:
         return serialized
 
 
-@six.add_metaclass(ABCMeta)
-class AbstractSubmitDeadline(pyblish.api.InstancePlugin):
+@six.add_metaclass(AbstractMetaInstancePlugin)
+class AbstractSubmitDeadline:
     """Class abstracting access to Deadline."""
 
     label = "Submit to Deadline"


### PR DESCRIPTION
## Feature

This is attempt to abstract how renders are collected, submitted and published on farm. This is useful for uniting most of the code between hosts.

Idea is to inherit from those abstract plugins in host specific one, implement abstract method and/or override those that make sense for current host.

To unify data collected I used data class concept. There is support in python for data classes from 3.7 but we still need to support legacy python 2 hosts, so I opted for using [attrs](https://www.attrs.org/) module we already have in dependecies as it is pulled by something.