### PR TITLE
#688 - Fix publishing hidden layers

### DIFF
--- a/pype/plugins/photoshop/publish/extract_image.py
+++ b/pype/plugins/photoshop/publish/extract_image.py
@@ -34,8 +34,6 @@ class ExtractImage(pype.api.Extractor):
                     # limit unnecessary calls to client
                     if layer.visible and layer.id not in extract_ids:
                         stub.set_visible(layer.id, False)
-                    if not layer.visible and layer.id in extract_ids:
-                        stub.set_visible(layer.id, True)
 
                 save_options = []
                 if "png" in self.formats:

--- a/pype/plugins/photoshop/publish/extract_review.py
+++ b/pype/plugins/photoshop/publish/extract_review.py
@@ -38,8 +38,6 @@ class ExtractReview(pype.api.Extractor):
                 # limit unnecessary calls to client
                 if layer.visible and layer.id not in extract_ids:
                     stub.set_visible(layer.id, False)
-                if not layer.visible and layer.id in extract_ids:
-                    stub.set_visible(layer.id, True)
 
             stub.saveAs(output_image_path, 'jpg', True)
 


### PR DESCRIPTION
Hidden layers in published group stay hidden and not shown in a published review.

Closes pype:pypeclub/pype#688

Requires:
avalon-core:pypeclub/avalon-core#216