### PR TITLE
Fix: Burnin data pass and FFmpeg tool check

### DIFF
--- a/pype/plugins/global/publish/extract_burnin.py
+++ b/pype/plugins/global/publish/extract_burnin.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import copy
+import tempfile
 
 import pype.api
 import pyblish
@@ -222,12 +223,30 @@ class ExtractBurnin(pype.api.Extractor):
                 # Dump data to string
                 dumped_script_data = json.dumps(script_data)
 
+                # Store dumped json to temporary file
+                temporary_json_file = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".json", delete=False
+                )
+                temporary_json_file.write(dumped_script_data)
+                temporary_json_file.close()
+                temporary_json_filepath = temporary_json_file.name.replace(
+                    "\\", "/"
+                )
+
                 # Prepare subprocess arguments
-                args = [executable, scriptpath, dumped_script_data]
-                self.log.debug("Executing: {}".format(args))
+                args = [
+                    "\"{}\"".format(executable),
+                    "\"{}\"".format(scriptpath),
+                    "\"{}\"".format(temporary_json_filepath)
+                ]
+                subprcs_cmd = " ".join(args)
+                self.log.debug("Executing: {}".format(subprcs_cmd))
 
                 # Run burnin script
-                pype.api.subprocess(args, shell=True, logger=self.log)
+                pype.api.subprocess(subprcs_cmd, shell=True, logger=self.log)
+
+                # Remove the temporary json
+                os.remove(temporary_json_filepath)
 
                 for filepath in temp_data["full_input_paths"]:
                     filepath = filepath.replace("\\", "/")

--- a/pype/plugins/global/publish/validate_ffmpeg_installed.py
+++ b/pype/plugins/global/publish/validate_ffmpeg_installed.py
@@ -29,6 +29,6 @@ class ValidateFFmpegInstalled(pyblish.api.ContextPlugin):
     def process(self, context):
         ffmpeg_path = pype.lib.get_ffmpeg_tool_path("ffmpeg")
         self.log.info("ffmpeg path: `{}`".format(ffmpeg_path))
-        if self.is_tool("\"{}\"".format(ffmpeg_path)) is False:
+        if self.is_tool("{}".format(ffmpeg_path)) is False:
             self.log.error("ffmpeg not found in PATH")
             raise RuntimeError('ffmpeg not installed.')

--- a/pype/plugins/photoshop/publish/extract_review.py
+++ b/pype/plugins/photoshop/publish/extract_review.py
@@ -54,7 +54,7 @@ class ExtractReview(pype.api.Extractor):
         # Generate thumbnail.
         thumbnail_path = os.path.join(staging_dir, "thumbnail.jpg")
         args = [
-            "\"{}\"".format(ffmpeg_path), "-y",
+            "{}".format(ffmpeg_path), "-y",
             "-i", output_image_path,
             "-vf", "scale=300:-1",
             "-vframes", "1",

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -578,7 +578,10 @@ def burnins_from_data(
 
 if __name__ == "__main__":
     print("* Burnin script started")
-    in_data = json.loads(sys.argv[-1])
+    in_data_json_path = sys.argv[-1]
+    with open(in_data_json_path, "r") as file_stream:
+        in_data = json.load(file_stream)
+
     burnins_from_data(
         in_data["input"],
         in_data["output"],

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -326,11 +326,13 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
 
         _stdout, _stderr = proc.communicate()
         if _stdout:
-            print(_stdout.decode("utf-8"))
+            for line in _stdout.split(b"\r\n"):
+                print(line.decode("utf-8"))
 
         # This will probably never happen as ffmpeg use stdout
         if _stderr:
-            print(_stderr.decode("utf-8"))
+            for line in _stderr.split(b"\r\n"):
+                print(line.decode("utf-8"))
 
         if proc.returncode != 0:
             raise RuntimeError(

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -213,9 +213,7 @@ class ModifiedBurnins(ffmpeg_burnins.Burnins):
             if frame_start is None:
                 replacement_final = replacement_size = str(MISSING_KEY_VALUE)
             else:
-                replacement_final = "\\'{}\\'".format(
-                    r'%%{eif\:n+%d\:d}' % frame_start
-                )
+                replacement_final = "%{eif:n+" + str(frame_start) + ":d}"
                 replacement_size = str(frame_end)
 
             final_text = final_text.replace(


### PR DESCRIPTION
## Changes
- data for burnin script are not passed in arguments but are stored to temporary json and path to temporary file is passed as arugment
- do not put ffmpeg path to quotes for `is_tool` check