### PR TITLE
Maya: Fix for publishing multiple cameras with review from the same scene

### DIFF
--- a/pype/plugins/maya/publish/collect_ftrack_family.py
+++ b/pype/plugins/maya/publish/collect_ftrack_family.py
@@ -20,7 +20,8 @@ class CollectFtrackFamilies(pyblish.api.InstancePlugin):
                 "model",
                 "animation",
                 "look",
-                "rig"
+                "rig",
+                "camera"
                 ]
 
     def process(self, instance):

--- a/pype/plugins/maya/publish/collect_remove_marked.py
+++ b/pype/plugins/maya/publish/collect_remove_marked.py
@@ -18,7 +18,12 @@ class CollectRemoveMarked(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
+        self.log.debug(context)
         # make ftrack publishable
+        instances_to_remove = []
         for instance in context:
             if instance.data.get('remove'):
-                context.remove(instance)
+                instances_to_remove.append(instance)
+
+        for instance in instances_to_remove:
+            context.remove(instance)

--- a/pype/plugins/maya/publish/collect_review.py
+++ b/pype/plugins/maya/publish/collect_review.py
@@ -47,7 +47,8 @@ class CollectReview(pyblish.api.InstancePlugin):
                 data = instance.context[i].data
 
                 if inst.name != reviewable_subset[0]:
-                    self.log.debug('subset name does not match {}'.format(reviewable_subset[0]))
+                    self.log.debug('subset name does not match {}'.format(
+                        reviewable_subset[0]))
                     i += 1
                     continue
 
@@ -55,7 +56,8 @@ class CollectReview(pyblish.api.InstancePlugin):
                     data['families'].append('review')
                 else:
                     data['families'] = ['review']
-                self.log.debug('adding review family to {}'.format(reviewable_subset))
+                self.log.debug('adding review family to {}'.format(
+                    reviewable_subset))
                 data['review_camera'] = camera
                 # data["publish"] = False
                 data['frameStartFtrack'] = instance.data["frameStartHandle"]
@@ -85,8 +87,10 @@ class CollectReview(pyblish.api.InstancePlugin):
                 instance.data['subset'] = subset
 
             instance.data['review_camera'] = camera
-            instance.data['frameStartFtrack'] = instance.data["frameStartHandle"]
-            instance.data['frameEndFtrack'] = instance.data["frameEndHandle"]
+            instance.data['frameStartFtrack'] = \
+                instance.data["frameStartHandle"]
+            instance.data['frameEndFtrack'] = \
+                instance.data["frameEndHandle"]
 
             # make ftrack publishable
             instance.data["families"] = ['ftrack']

--- a/pype/plugins/maya/publish/collect_review.py
+++ b/pype/plugins/maya/publish/collect_review.py
@@ -43,33 +43,36 @@ class CollectReview(pyblish.api.InstancePlugin):
             i = 0
             for inst in instance.context:
 
-                self.log.debug('processing {}'.format(inst))
-                self.log.debug('processing2 {}'.format(instance.context[i]))
+                self.log.debug('filtering {}'.format(inst))
                 data = instance.context[i].data
 
-                if inst.name == reviewable_subset[0]:
-                    if data.get('families'):
-                        data['families'].append('review')
-                    else:
-                        data['families'] = ['review']
-                    self.log.debug('adding review family to {}'.format(reviewable_subset))
-                    data['review_camera'] = camera
-                    # data["publish"] = False
-                    data['frameStartFtrack'] = instance.data["frameStartHandle"]
-                    data['frameEndFtrack'] = instance.data["frameEndHandle"]
-                    data['frameStartHandle'] = instance.data["frameStartHandle"]
-                    data['frameEndHandle'] = instance.data["frameEndHandle"]
-                    data["frameStart"] = instance.data["frameStart"]
-                    data["frameEnd"] = instance.data["frameEnd"]
-                    data['handles'] = instance.data.get('handles', None)
-                    data['step'] = instance.data['step']
-                    data['fps'] = instance.data['fps']
-                    data["isolate"] = instance.data["isolate"]
-                    cmds.setAttr(str(instance) + '.active', 1)
-                    self.log.debug('data {}'.format(instance.context[i].data))
-                    instance.context[i].data.update(data)
-                    instance.data['remove'] = True
-                i += 1
+                if inst.name != reviewable_subset[0]:
+                    self.log.debug('subset name does not match {}'.format(reviewable_subset[0]))
+                    i += 1
+                    continue
+
+                if data.get('families'):
+                    data['families'].append('review')
+                else:
+                    data['families'] = ['review']
+                self.log.debug('adding review family to {}'.format(reviewable_subset))
+                data['review_camera'] = camera
+                # data["publish"] = False
+                data['frameStartFtrack'] = instance.data["frameStartHandle"]
+                data['frameEndFtrack'] = instance.data["frameEndHandle"]
+                data['frameStartHandle'] = instance.data["frameStartHandle"]
+                data['frameEndHandle'] = instance.data["frameEndHandle"]
+                data["frameStart"] = instance.data["frameStart"]
+                data["frameEnd"] = instance.data["frameEnd"]
+                data['handles'] = instance.data.get('handles', None)
+                data['step'] = instance.data['step']
+                data['fps'] = instance.data['fps']
+                data["isolate"] = instance.data["isolate"]
+                cmds.setAttr(str(instance) + '.active', 1)
+                self.log.debug('data {}'.format(instance.context[i].data))
+                instance.context[i].data.update(data)
+                instance.data['remove'] = True
+                self.log.debug('isntance data {}'.format(instance.data))
         else:
             if self.legacy:
                 instance.data['subset'] = task + 'Review'

--- a/pype/plugins/maya/publish/extract_camera_alembic.py
+++ b/pype/plugins/maya/publish/extract_camera_alembic.py
@@ -26,7 +26,15 @@ class ExtractCameraAlembic(pype.api.Extractor):
         # get settings
         framerange = [instance.data.get("frameStart", 1),
                       instance.data.get("frameEnd", 1)]
-        handles = instance.data.get("handles", 0)
+        handle_start = instance.data.get("handleStart", 0)
+        handle_end = instance.data.get("handleEnd", 0)
+
+        # TODO: deprecated attribute "handles"
+
+        if handle_start is None:
+            handle_start = instance.data.get("handles", 0)
+            handle_end = instance.data.get("handles", 0)
+
         step = instance.data.get("step", 1.0)
         bake_to_worldspace = instance.data("bakeToWorldSpace", True)
 
@@ -55,8 +63,8 @@ class ExtractCameraAlembic(pype.api.Extractor):
 
             job_str = ' -selection -dataFormat "ogawa" '
             job_str += ' -attrPrefix cb'
-            job_str += ' -frameRange {0} {1} '.format(framerange[0] - handles,
-                                                      framerange[1] + handles)
+            job_str += ' -frameRange {0} {1} '.format(framerange[0] - handle_start,
+                                                      framerange[1] + handle_end)
             job_str += ' -step {0} '.format(step)
 
             if bake_to_worldspace:

--- a/pype/plugins/maya/publish/extract_camera_alembic.py
+++ b/pype/plugins/maya/publish/extract_camera_alembic.py
@@ -63,8 +63,10 @@ class ExtractCameraAlembic(pype.api.Extractor):
 
             job_str = ' -selection -dataFormat "ogawa" '
             job_str += ' -attrPrefix cb'
-            job_str += ' -frameRange {0} {1} '.format(framerange[0] - handle_start,
-                                                      framerange[1] + handle_end)
+            job_str += ' -frameRange {0} {1} '.format(framerange[0]
+                                                      - handle_start,
+                                                      framerange[1]
+                                                      + handle_end)
             job_str += ' -step {0} '.format(step)
 
             if bake_to_worldspace:

--- a/pype/plugins/maya/publish/extract_camera_mayaScene.py
+++ b/pype/plugins/maya/publish/extract_camera_mayaScene.py
@@ -107,7 +107,18 @@ class ExtractCameraMayaScene(pype.api.Extractor):
 
         framerange = [instance.data.get("frameStart", 1),
                       instance.data.get("frameEnd", 1)]
-        handles = instance.data.get("handles", 0)
+        handle_start = instance.data.get("handleStart", 0)
+        handle_end = instance.data.get("handleEnd", 0)
+
+        # TODO: deprecated attribute "handles"
+
+        if handle_start is None:
+            handle_start = instance.data.get("handles", 0)
+            handle_end = instance.data.get("handles", 0)
+
+        range_with_handles = [framerange[0] - handle_start,
+                              framerange[1] + handle_end]
+
         step = instance.data.get("step", 1.0)
         bake_to_worldspace = instance.data("bakeToWorldSpace", True)
 
@@ -120,9 +131,6 @@ class ExtractCameraMayaScene(pype.api.Extractor):
         members = instance.data['setMembers']
         cameras = cmds.ls(members, leaf=True, shapes=True, long=True,
                           dag=True, type="camera")
-
-        range_with_handles = [framerange[0] - handles,
-                              framerange[1] + handles]
 
         # validate required settings
         assert len(cameras) == 1, "Single camera must be found in extraction"


### PR DESCRIPTION
It was not possible to publish multiple cameras if they all had a review attached to them. This PR fixes the problem and also add camera to ftrack publishable instance