### PR TITLE
Maya: disable legacy override check for cameras

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -378,14 +378,8 @@ class AExpectedFiles:
             renderable = False
             if self.maya_is_true(cmds.getAttr("{}.renderable".format(cam))):
                 renderable = True
-
-            for override in self.get_layer_overrides(
-                "{}.renderable".format(cam), self.layer
-            ):
-                renderable = self.maya_is_true(override)
-
-            if renderable:
                 renderable_cameras.append(cam)
+
         return renderable_cameras
 
     def maya_is_true(self, attr_val):


### PR DESCRIPTION
## Problem

Legacy overrides doesn't work with render setup and make renderable cameras not renderable. This is removing this check for overrides.

❕ **this will make it incompatible with legacy rende layers system**