### PR TITLE
Asset fetch second fix

### DIFF
--- a/pype/tools/launcher/widgets.py
+++ b/pype/tools/launcher/widgets.py
@@ -49,6 +49,14 @@ class ProjectBar(QtWidgets.QWidget):
 
     def set_project(self, project_name):
         index = self.project_combobox.findText(project_name)
+        if index < 0:
+            # Try refresh combobox model
+            self.project_combobox.blockSignals(True)
+            self.model.refresh()
+            self.project_combobox.blockSignals(False)
+
+            index = self.project_combobox.findText(project_name)
+
         if index >= 0:
             self.project_combobox.setCurrentIndex(index)
 

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -207,7 +207,7 @@ class AssetsPanel(QtWidgets.QWidget):
         self.assets_widget.refresh()
 
         # Force asset change callback to ensure tasks are correctly reset
-        tools_lib.schedule(self.on_asset_changed, 0.05, channel="assets")
+        self.assets_widget.refreshed.connect(self.on_asset_changed)
 
     def on_asset_changed(self):
         """Callback on asset selection changed

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -375,7 +375,6 @@ class LauncherWindow(QtWidgets.QDialog):
     def on_project_clicked(self, project_name):
         self.dbcon.Session["AVALON_PROJECT"] = project_name
         # Refresh projects
-        self.asset_panel.project_bar.refresh()
         self.asset_panel.set_project(project_name)
         self.set_page(1)
         self.refresh_actions()


### PR DESCRIPTION
## Issue
- project change does not affect refresh of assets in launcher because refresh first set project to previous and then to new one

## Changes
- do not call refresh of projects on project change, but call model refresh if project was not found in project's combobox

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/222|