### PR TITLE
#731 - better handling of missing presets

### DIFF
--- a/pype/modules/sync_server/providers/gdrive.py
+++ b/pype/modules/sync_server/providers/gdrive.py
@@ -6,8 +6,8 @@ from googleapiclient import errors
 from .abstract_provider import AbstractProvider
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from pype.api import Logger
-from pype.lib import timeit
 from pype.api import config
+from ..utils import time_function
 
 SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly',
           'https://www.googleapis.com/auth/drive.file',
@@ -119,7 +119,7 @@ class GDriveHandler(AbstractProvider):
 
         return roots
 
-    @timeit
+    @time_function
     def _build_tree(self, folders):
         """
             Create in-memory structure resolving paths to folder id as
@@ -467,7 +467,7 @@ class GDriveHandler(AbstractProvider):
         """
         pass
 
-    @timeit
+    @time_function
     def list_folders(self):
         """ Lists all folders in GDrive.
             Used to build in-memory structure of path to folder ids model.

--- a/pype/modules/sync_server/utils.py
+++ b/pype/modules/sync_server/utils.py
@@ -1,0 +1,24 @@
+import time
+from pype.api import  Logger
+log = Logger().get_logger("SyncServer")
+
+
+def time_function(method):
+    """ Decorator to print how much time function took.
+        For debugging.
+        Depends on presence of 'log' object
+    """
+
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method.__name__.upper())
+            kw['log_time'][name] = int((te - ts) * 1000)
+        else:
+            log.debug('%r  %2.2f ms' % (method.__name__, (te - ts) * 1000))
+            print('%r  %2.2f ms' % (method.__name__, (te - ts) * 1000))
+        return result
+
+    return timed


### PR DESCRIPTION
Moved rest of init under try part as if no presets present, no syncing is possible.

Moved timeit decorator to utils, renamed as it was shadowing python core library.

Requires:
pypeclub/pype-config#94