### PR TITLE
TVPaint extract review fix

### DIFF
--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -122,11 +122,24 @@ class ExtractReview(pyblish.api.InstancePlugin):
 
         # Loop through representations
         for repre in tuple(instance.data["representations"]):
+            repre_name = str(repre.get("name"))
             tags = repre.get("tags") or []
-            if "review" not in tags or "thumbnail" in tags:
+            if "review" not in tags:
+                self.log.debug((
+                    "Repre: {} - Didn't found \"review\" in tags. Skipping"
+                ).format(repre_name))
+                continue
+
+            if "thumbnail" in tags:
+                self.log.debug((
+                    "Repre: {} - Found \"thumbnail\" in tags. Skipping"
+                ).format(repre_name))
                 continue
 
             if "passing" in tags:
+                self.log.debug((
+                    "Repre: {} - Found \"passing\" in tags. Skipping"
+                ).format(repre_name))
                 continue
 
             input_ext = repre["ext"]

--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -67,6 +67,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
                     )
                 )
 
+            if instance is None:
+                continue
+
             frame_start = context.data["frameStart"]
             frame_end = frame_start
             for layer in instance.data["layers"]:

--- a/pype/plugins/tvpaint/publish/extract_sequence.py
+++ b/pype/plugins/tvpaint/publish/extract_sequence.py
@@ -137,8 +137,7 @@ class ExtractSequence(pyblish.api.Extractor):
         # Fill tags and new families
         tags = []
         if family_lowered in ("review", "renderlayer"):
-            # Add `ftrackreview` tag
-            tags.append("ftrackreview")
+            tags.append("review")
 
         repre_files = [
             os.path.basename(filepath)


### PR DESCRIPTION
## Changes
- not created instance in TVPaint collector is skipped
- added `review` tag to review instances instead of `ftrackreview`
- added few debug logs to extract review filtering