### PR TITLE
Ftrack integrate custom attributes fix

### DIFF
--- a/pype/plugins/ftrack/publish/collect_ftrack_api.py
+++ b/pype/plugins/ftrack/publish/collect_ftrack_api.py
@@ -96,6 +96,7 @@ class CollectFtrackApi(pyblish.api.ContextPlugin):
             task_entity = None
             self.log.warning("Task name is not set.")
 
+        context.data["ftrackPythonModule"] = ftrack_api
         context.data["ftrackProject"] = project_entity
         context.data["ftrackEntity"] = asset_entity
         context.data["ftrackTask"] = task_entity

--- a/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
+++ b/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
@@ -3,10 +3,10 @@ import six
 import pyblish.api
 from avalon import io
 
-try:
-    from pype.modules.ftrack.lib.avalon_sync import CUST_ATTR_AUTO_SYNC
-except Exception:
-    CUST_ATTR_AUTO_SYNC = "avalon_auto_sync"
+from pype.modules.ftrack.lib.avalon_sync import (
+    CUST_ATTR_AUTO_SYNC,
+    get_pype_attr
+)
 
 
 class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):

--- a/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
+++ b/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
@@ -73,6 +73,15 @@ class IntegrateHierarchyToFtrack(pyblish.api.ContextPlugin):
                 self.auto_sync_on(project)
 
     def import_to_ftrack(self, input_data, parent=None):
+        # Prequery hiearchical custom attributes
+        hier_custom_attributes = get_pype_attr(self.session)[1]
+        hier_attr_by_key = {
+            attr["key"]: attr
+            for attr in hier_custom_attributes
+        }
+        # Get ftrack api module (as they are different per python version)
+        ftrack_api = self.context.data["ftrackPythonModule"]
+
         for entity_name in input_data:
             entity_data = input_data[entity_name]
             entity_type = entity_data['entity_type']


### PR DESCRIPTION
## Issue
- integrate ftrack hiearchy is using native ftrack_api way of settings custom attribute values (`entity["custom_attributes"]["{key}"] = value`) which will not wok when custom attribute key has both hierarchical and non hiearchical version

## Changes
- hieararchical attributes are prepared before import to ftrack
- removed backwards compatibility of ftrack custom attributes group (`"avalon"` -> `"pype"`)
    - this should be already fixed and new import is required
- modified custom attribute value setter to use specific attribute id and entity id to set the value with ftrack operations

## TODO
- test in Nukestudio/Hiero as `IntegrateHierarchyToFtrack` may not work as expected in Python 2 host