### PR TITLE
Hotfix: Maya: multiple renderable cameras in layer

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -266,8 +266,8 @@ class AExpectedFiles:
 
     def _generate_single_file_sequence(self, layer_data):
         expected_files = []
-        file_prefix = layer_data["filePrefix"]
         for cam in layer_data["cameras"]:
+            file_prefix = layer_data["filePrefix"]
             mappings = (
                 (R_SUBSTITUTE_SCENE_TOKEN, layer_data["sceneName"]),
                 (R_SUBSTITUTE_LAYER_TOKEN, layer_data["layerName"]),
@@ -299,9 +299,9 @@ class AExpectedFiles:
     def _generate_aov_file_sequences(self, layer_data):
         expected_files = []
         aov_file_list = {}
-        file_prefix = layer_data["filePrefix"]
         for aov in layer_data["enabledAOVs"]:
             for cam in layer_data["cameras"]:
+                file_prefix = layer_data["filePrefix"]
 
                 mappings = (
                     (R_SUBSTITUTE_SCENE_TOKEN, layer_data["sceneName"]),


### PR DESCRIPTION
## Problem

There is a bug when trying to render and publish multiple renderable cameras in one render layer. Expected files are generated only for one of those cameras. Render on farm will be ok, but publish will work for only one.

```python
['maya/render_test_v007/MainCamA/MainCamA_cam2.0991.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam2.0992.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam2.0991.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam2.0992.exr']
```
this fix will produce correct output:

```python
['maya/render_test_v007/MainCamA/MainCamA_cam2.0991.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam2.0992.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam1.0991.exr',
 'maya/render_test_v007/MainCamA/MainCamA_cam1.0992.exr']
```

🏴 **freshdesk ticket**: [#406](https://pype.freshdesk.com/a/tickets/406)
|---|