### PR TITLE
Unreal: add 4.26 support

### DIFF
--- a/pype/hosts/unreal/lib.py
+++ b/pype/hosts/unreal/lib.py
@@ -246,15 +246,18 @@ def create_unreal_project(project_name: str,
     with open(project_file, mode="w") as pf:
         json.dump(data, pf, indent=4)
 
-    # ensure we have PySide installed in engine
-    # TODO: make it work for other platforms 🍎 🐧
-    if platform.system().lower() == "windows":
-        python_path = os.path.join(engine_path, "Engine", "Binaries",
-                                   "ThirdParty", "Python", "Win64",
-                                   "python.exe")
+    # UE < 4.26 have Python2 by default, so we need PySide
+    # but we will not need it in 4.26 and up
+    if int(ue_version.split(".")[1]) < 26:
+        # ensure we have PySide installed in engine
+        # TODO: make it work for other platforms 🍎 🐧
+        if platform.system().lower() == "windows":
+            python_path = os.path.join(engine_path, "Engine", "Binaries",
+                                       "ThirdParty", "Python", "Win64",
+                                       "python.exe")
 
-        subprocess.run([python_path, "-m",
-                        "pip", "install", "pyside"])
+            subprocess.run([python_path, "-m",
+                            "pip", "install", "pyside"])
 
     if dev_mode or preset["dev_mode"]:
         _prepare_cpp_project(project_file, engine_path)

--- a/pype/lib/hooks.py
+++ b/pype/lib/hooks.py
@@ -55,7 +55,7 @@ def execute_hook(hook, *args, **kwargs):
     module.__file__ = abspath
 
     try:
-        with open(abspath) as f:
+        with open(abspath, errors='ignore') as f:
             six.exec_(f.read(), module.__dict__)
 
         sys.modules[abspath] = module


### PR DESCRIPTION
This PR is introducing changes to support **Unreal 4.26**. This version has Python 3 by default so there's no need to manually ensure **PySide** to be installed.

🏴 **Requires:** pypeclub/pype-config#96
|---|