### PR TITLE
Maya: Vray handling of default aov

### DIFF
--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -583,7 +583,7 @@ class ExpectedFilesVray(AExpectedFiles):
 
             expected_files[0].update(update)
         return expected_files
-    
+
     def get_aovs(self):
         """Get all AOVs.
 
@@ -669,10 +669,11 @@ class ExpectedFilesVray(AExpectedFiles):
                 final_name = vray_name
             else:
                 continue
-            # special case for Material Select elements - these are named based on the material
-            # they are connected to.
+            # special case for Material Select elements - these are named
+            # based on the materia they are connected to.
             if "vray_mtl_mtlselect" in cmds.listAttr(node):
-                connections = cmds.listConnections("{}.vray_mtl_mtlselect".format(node))
+                connections = cmds.listConnections(
+                    "{}.vray_mtl_mtlselect".format(node))
                 if connections:
                     final_name += '_{}'.format(str(connections[0]))
 

--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -418,13 +418,12 @@ class AExpectedFiles:
         if connections:
             for connection in connections:
                 if connection:
-                    node_name = connection.split(".")[0]
-                    if cmds.nodeType(node_name) == "renderLayer":
-                        attr_name = "%s.value" % ".".join(
-                            connection.split(".")[:-1]
-                        )
-                        if node_name == layer:
-                            yield cmds.getAttr(attr_name)
+                    # node_name = connection.split(".")[0]
+
+                    attr_name = "%s.value" % ".".join(
+                        connection.split(".")[:-1]
+                    )
+                    yield cmds.getAttr(attr_name)
 
     def get_render_attribute(self, attr):
         """Get attribute from render options.
@@ -642,25 +641,42 @@ class ExpectedFilesVray(AExpectedFiles):
         return enabled_aovs
 
     def _get_vray_aov_name(self, node):
+        """Get AOVs name from Vray.
 
-        # Get render element pass type
-        vray_node_attr = next(
-            attr
-            for attr in cmds.listAttr(node)
-            if attr.startswith("vray_name")
-        )
-        pass_type = vray_node_attr.rsplit("_", 1)[-1]
+        Args:
+            node (str): aov node name.
 
-        # Support V-Ray extratex explicit name (if set by user)
-        if pass_type == "extratex":
-            explicit_attr = "{}.vray_explicit_name_extratex".format(node)
-            explicit_name = cmds.getAttr(explicit_attr)
-            if explicit_name:
-                return explicit_name
+        Returns:
+            str: aov name.
 
-        # Node type is in the attribute name but we need to check if value
-        # of the attribute as it can be changed
-        return cmds.getAttr("{}.{}".format(node, vray_node_attr))
+        """
+        vray_name = None
+        vray_explicit_name = None
+        vray_file_name = None
+        for attr in cmds.listAttr(node):
+            if attr.startswith("vray_filename"):
+                vray_file_name = cmds.getAttr("{}.{}".format(node, attr))
+            elif attr.startswith("vray_name"):
+                vray_name = cmds.getAttr("{}.{}".format(node, attr))
+            elif attr.startswith("vray_explicit_name"):
+                vray_explicit_name = cmds.getAttr("{}.{}".format(node, attr))
+
+            if vray_file_name is not None and vray_file_name != "":
+                final_name = vray_file_name
+            elif vray_explicit_name is not None and vray_explicit_name != "":
+                final_name = vray_explicit_name
+            elif vray_name is not None and vray_name != "":
+                final_name = vray_name
+            else:
+                continue
+            # special case for Material Select elements - these are named based on the material
+            # they are connected to.
+            if "vray_mtl_mtlselect" in cmds.listAttr(node):
+                connections = cmds.listConnections("{}.vray_mtl_mtlselect".format(node))
+                if connections:
+                    final_name += '_{}'.format(str(connections[0]))
+
+            return final_name
 
 
 class ExpectedFilesRedshift(AExpectedFiles):

--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -561,24 +561,6 @@ class ExpectedFilesVray(AExpectedFiles):
         layer_data["padding"] = cmds.getAttr("vraySettings.fileNamePadding")
         return layer_data
 
-    def get_files(self):
-        """Get expected files.
-
-        This overrides :func:`AExpectedFiles.get_files()` as we
-        we need to add one sequence for plain beauty if AOVs are enabled
-        as vray output beauty without 'beauty' in filename.
-
-        """
-        expected_files = super(ExpectedFilesVray, self).get_files()
-
-        layer_data = self._get_layer_data()
-        if layer_data.get("enabledAOVs"):
-            expected_files[0][u"beauty"] = self._generate_single_file_sequence(
-                layer_data
-            )  # noqa: E501
-
-        return expected_files
-
     def get_aovs(self):
         """Get all AOVs.
 
@@ -630,6 +612,9 @@ class ExpectedFilesVray(AExpectedFiles):
                 # todo: find how vray set format for AOVs
                 enabled_aovs.append(
                     (self._get_vray_aov_name(aov), default_ext))
+        enabled_aovs.append(
+            (u"beauty", default_ext)
+        )
         return enabled_aovs
 
     def _get_vray_aov_name(self, node):

--- a/pype/hosts/maya/expected_files.py
+++ b/pype/hosts/maya/expected_files.py
@@ -561,6 +561,30 @@ class ExpectedFilesVray(AExpectedFiles):
         layer_data["padding"] = cmds.getAttr("vraySettings.fileNamePadding")
         return layer_data
 
+    def get_files(self):
+        """Get expected files.
+
+        This overrides :func:`AExpectedFiles.get_files()` as we
+        we need to add one sequence for plain beauty if AOVs are enabled
+        as vray output beauty without 'beauty' in filename.
+
+        """
+        expected_files = super(ExpectedFilesVray, self).get_files()
+
+        layer_data = self._get_layer_data()
+        # remove 'beauty' from filenames as vray doesn't output it
+        update = {}
+        if layer_data.get("enabledAOVs"):
+            for aov, seq in expected_files[0].items():
+                if aov.startswith("beauty"):
+                    new_list = []
+                    for f in seq:
+                        new_list.append(f.replace("_beauty", ""))
+                    update[aov] = new_list
+
+            expected_files[0].update(update)
+        return expected_files
+    
     def get_aovs(self):
         """Get all AOVs.
 

--- a/pype/plugins/maya/publish/extract_look.py
+++ b/pype/plugins/maya/publish/extract_look.py
@@ -350,7 +350,7 @@ class ExtractLook(pype.api.Extractor):
         if existing and not force:
             self.log.info("Found hash in database, preparing hardlink..")
             source = next((p for p in existing if os.path.exists(p)), None)
-            if filepath:
+            if source:
                 return source, HARDLINK, texture_hash
             else:
                 self.log.warning(


### PR DESCRIPTION
## Bug

There was a bug when Vray default "beauty" AOV was not handle properly, resulting in invalid publishes of multiple cameras.

This PR is handling this and is adding support for more esoteric vray aovs that were crashing Pype - like `materialID`. Finally it is fixing issue determining overridden values in Render Setup.

### Testing:

Create few AOVs in Vray - Diffuse and Material ID. They should be collected in `Collect Render Layers`.

Resolves #755 