### PR TITLE
Raw json environment discard fix

### DIFF
--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -2334,6 +2334,18 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
             output.update(item.config_value())
         return output
 
+    def config_value(self):
+        output = self.item_value()
+        if self.value_is_env_group:
+            for key, value in tuple(output.items()):
+                value[METADATA_KEY] = {
+                    "environments": {
+                        key: list(value.keys())
+                    }
+                }
+                output[key] = value
+        return {self.key: output}
+
     def add_row(self, row=None, key=None, value=None, is_empty=False):
         # Create new item
         item_widget = ModifiableDictItem(

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1328,18 +1328,17 @@ class RawJsonWidget(QtWidgets.QWidget, InputObject):
         output = {}
         for key, value in value.items():
             output[key.upper()] = value
-
-        if self.is_environ:
-            output[METADATA_KEY] = {
-                "environments": {
-                    self.env_group_key: list(output.keys())
-                }
-            }
-
         return output
 
     def config_value(self):
-        return {self.key: self.item_value()}
+        value = self.item_value()
+        if self.is_environ:
+            value[METADATA_KEY] = {
+                "environments": {
+                    self.env_group_key: list(value.keys())
+                }
+            }
+        return {self.key: value}
 
 
 class ListItem(QtWidgets.QWidget, SettingObject):


### PR DESCRIPTION
## Issue
- Environment metadata key is part of `item_value` in `raw-json` item which will always result that item is modified not matter what happens

## Changes
- metadata keys is only set in `config_value` which is not used to comparisons but only for storing
- `dict-modifiable` have to handle environment metadata by it's own in his `config_value`