### PR TITLE
TVPaint update fix

### DIFF
--- a/pype/plugins/tvpaint/load/load_reference_image.py
+++ b/pype/plugins/tvpaint/load/load_reference_image.py
@@ -162,6 +162,9 @@ class LoadImage(pipeline.Loader):
         """
         # Create new containers first
         context = get_representation_context(representation)
+        # Change `fname` to new representation
+        self.fname = self.filepath_from_context(context)
+
         name = container["name"]
         namespace = container["namespace"]
         new_container = self.load(context, name, namespace, {})


### PR DESCRIPTION
## Issue
- update of TVPaint loader does not work because `fname` attribute cotain path to "loaded" representation, not to "loading" representation

## Changes
- change `fname` attribute to "loading" representation path from "loaded" path on update

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/227|