### PR TITLE
Pull file extension from Render Queue

### DIFF
--- a/pype/modules/websocket_server/stubs/aftereffects_server_stub.py
+++ b/pype/modules/websocket_server/stubs/aftereffects_server_stub.py
@@ -305,6 +305,18 @@ class AfterEffectsServerStub():
                                    image_path=project_path,
                                    as_copy=as_copy))
 
+    def get_render_info(self):
+        """ Get render queue info for render purposes
+        """
+        res = self.websocketserver.call(self.client.call
+                                        ('AfterEffects.get_render_info'))
+
+        records = self._to_records(res)
+        if records:
+            return records.pop()
+
+        log.debug("Couldn't get render queue info")
+
     def close(self):
         self.client.close()
 

--- a/pype/modules/websocket_server/stubs/aftereffects_server_stub.py
+++ b/pype/modules/websocket_server/stubs/aftereffects_server_stub.py
@@ -252,6 +252,9 @@ class AfterEffectsServerStub():
             Args:
                 item_id (int):
 
+            Returns:
+                (namedtuple)
+
         """
         res = self.websocketserver.call(self.client.call
                                         ('AfterEffects.get_work_area',
@@ -307,6 +310,9 @@ class AfterEffectsServerStub():
 
     def get_render_info(self):
         """ Get render queue info for render purposes
+
+            Returns:
+                (namedtuple): with 'file_name' field
         """
         res = self.websocketserver.call(self.client.call
                                         ('AfterEffects.get_render_info'))
@@ -316,6 +322,20 @@ class AfterEffectsServerStub():
             return records.pop()
 
         log.debug("Couldn't get render queue info")
+
+    def get_audio_url(self, item_id):
+        """ Get audio layer absolute url for comp
+
+            Args:
+                item_id (int): composition id
+            Returns:
+                (str): absolute path url
+        """
+        res = self.websocketserver.call(self.client.call
+                                        ('AfterEffects.get_audio_url',
+                                         item_id=item_id))
+
+        return res
 
     def close(self):
         self.client.close()

--- a/pype/plugins/aftereffects/publish/collect_audio.py
+++ b/pype/plugins/aftereffects/publish/collect_audio.py
@@ -1,0 +1,27 @@
+import os
+
+import pyblish.api
+
+from avalon import aftereffects
+
+
+class CollectAudio(pyblish.api.ContextPlugin):
+    """Inject audio file url for rendered composition into context.
+        Needs to run AFTER 'collect_render'. Use collected comp_id to check
+        if there is an AVLayer in this composition
+    """
+
+    order = pyblish.api.CollectorOrder + 0.499
+    label = "Collect Audio"
+    hosts = ["aftereffects"]
+
+    def process(self, context):
+        for instance in context:
+            if instance.data["family"] == 'render.farm':
+                comp_id = instance.data["comp_id"]
+                if not comp_id:
+                    self.log.debug("No comp_id filled in instance")
+                    return
+                context.data["audioFile"] = os.path.normpath(
+                    aftereffects.stub().get_audio_url(comp_id)
+                ).replace("\\", "/")

--- a/pype/plugins/aftereffects/publish/collect_render.py
+++ b/pype/plugins/aftereffects/publish/collect_render.py
@@ -108,18 +108,29 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
         start = render_instance.frameStart
         end = render_instance.frameEnd
 
+        # pull file name from Render Queue Output module
+        render_q = aftereffects.stub().get_render_info()
+        _, ext = os.path.splitext(os.path.basename(render_q.file_name))
         base_dir = self._get_output_dir(render_instance)
         expected_files = []
-        for frame in range(start, end + 1):
-            path = os.path.join(base_dir, "{}_{}_{}.{}.{}".format(
-                        render_instance.asset,
-                        render_instance.subset,
-                        "v{:03d}".format(render_instance.version),
-                        str(frame).zfill(self.padding_width),
-                        self.rendered_extension
-                    ))
+        if "#" not in render_q.file_name:  # single frame (mov)W
+            path = os.path.join(base_dir, "{}_{}_{}.{}".format(
+                render_instance.asset,
+                render_instance.subset,
+                "v{:03d}".format(render_instance.version),
+                ext.replace('.', '')
+            ))
             expected_files.append(path)
-
+        else:
+            for frame in range(start, end + 1):
+                path = os.path.join(base_dir, "{}_{}_{}.{}.{}".format(
+                            render_instance.asset,
+                            render_instance.subset,
+                            "v{:03d}".format(render_instance.version),
+                            str(frame).zfill(self.padding_width),
+                            ext.replace('.', '')
+                        ))
+                expected_files.append(path)
         return expected_files
 
     def _get_output_dir(self, render_instance):

--- a/pype/plugins/aftereffects/publish/collect_render.py
+++ b/pype/plugins/aftereffects/publish/collect_render.py
@@ -124,12 +124,12 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
         else:
             for frame in range(start, end + 1):
                 path = os.path.join(base_dir, "{}_{}_{}.{}.{}".format(
-                            render_instance.asset,
-                            render_instance.subset,
-                            "v{:03d}".format(render_instance.version),
-                            str(frame).zfill(self.padding_width),
-                            ext.replace('.', '')
-                        ))
+                    render_instance.asset,
+                    render_instance.subset,
+                    "v{:03d}".format(render_instance.version),
+                    str(frame).zfill(self.padding_width),
+                    ext.replace('.', '')
+                ))
                 expected_files.append(path)
         return expected_files
 

--- a/pype/plugins/aftereffects/publish/collect_render.py
+++ b/pype/plugins/aftereffects/publish/collect_render.py
@@ -11,6 +11,7 @@ from avalon import aftereffects
 class AERenderInstance(RenderInstance):
     # extend generic, composition name is needed
     comp_name = attr.ib(default=None)
+    comp_id = attr.ib(default=None)
 
 
 class CollectAERender(abstract_collect_render.AbstractCollectRender):
@@ -83,6 +84,7 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
                     raise ValueError("There is no composition for item {}".
                                      format(item_id))
                 instance.comp_name = comp.name
+                instance.comp_id = item_id
                 instance._anatomy = context.data["anatomy"]
                 instance.anatomyData = context.data["anatomyData"]
 

--- a/pype/plugins/aftereffects/publish/submit_aftereffects_deadline.py
+++ b/pype/plugins/aftereffects/publish/submit_aftereffects_deadline.py
@@ -18,6 +18,7 @@ class DeadlinePluginInfo():
     ProjectPath = attr.ib(default=None)
     AWSAssetFile0 = attr.ib(default=None)
     Version = attr.ib(default=None)
+    MultiProcess = attr.ib(default=None)
 
 
 class AfterEffectsSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline):
@@ -39,9 +40,14 @@ class AfterEffectsSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
         dln_job_info.Plugin = "AfterEffects"
         dln_job_info.UserName = context.data.get(
             "deadlineUser", getpass.getuser())
-        frame_range = "{}-{}".format(self._instance.data["frameStart"],
-                                     self._instance.data["frameEnd"])
-        dln_job_info.Frames = frame_range
+        if self._instance.data["frameEnd"] > self._instance.data["frameStart"]:
+            frame_range = "{}-{}".format(self._instance.data["frameStart"],
+                                         self._instance.data["frameEnd"])
+            dln_job_info.Frames = frame_range
+
+        if len(self._instance.data["expectedFiles"]) == 1:
+            dln_job_info.ChunkSize = 1000000
+
         dln_job_info.OutputFilename = \
             os.path.basename(self._instance.data["expectedFiles"][0])
         dln_job_info.OutputDirectory = \
@@ -77,17 +83,23 @@ class AfterEffectsSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline
         script_path = context.data["currentFile"]
 
         render_path = self._instance.data["expectedFiles"][0]
-        # replace frame info ('000001') with Deadline's required '[#######]'
-        # expects filename in format project_asset_subset_version.FRAME.ext
-        render_dir = os.path.dirname(render_path)
-        file_name = os.path.basename(render_path)
-        arr = file_name.split('.')
-        assert len(arr) == 3, \
-            "Unable to parse frames from {}".format(file_name)
-        hashed = '[{}]'.format(len(arr[1]) * "#")
 
-        render_path = os.path.join(render_dir,
-                                   '{}.{}.{}'.format(arr[0], hashed, arr[2]))
+        if len(self._instance.data["expectedFiles"]) > 1:
+            # replace frame ('000001') with Deadline's required '[#######]'
+            # expects filename in format project_asset_subset_version.FRAME.ext
+            render_dir = os.path.dirname(render_path)
+            file_name = os.path.basename(render_path)
+            arr = file_name.split('.')
+            assert len(arr) == 3, \
+                "Unable to parse frames from {}".format(file_name)
+            hashed = '[{}]'.format(len(arr[1]) * "#")
+
+            render_path = os.path.join(render_dir,
+                                       '{}.{}.{}'.format(arr[0], hashed,
+                                                         arr[2]))
+            deadline_plugin_info.MultiProcess = True
+        else:
+            deadline_plugin_info.MultiProcess = False
 
         deadline_plugin_info.Comp = self._instance.data["comp_name"]
         deadline_plugin_info.Version = "17.5"


### PR DESCRIPTION
Use extension configured in Render Queue.

If extension is not a sequence (mov, avi), only single rendering task is created.

Requires:
pypeclub/avalon-core#229