### PR TITLE
Extract review audio cut fix

### DIFF
--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -387,7 +387,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
             ffmpeg_output_args.append("-t {:0.2f}".format(duration_sec))
 
         # Set frame range of output when input or output is sequence
-        elif temp_data["input_is_sequence"] or temp_data["output_is_sequence"]:
+        elif temp_data["output_is_sequence"]:
             ffmpeg_output_args.append("-frames:v {}".format(output_frames_len))
 
         # Add video/image input path

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -406,9 +406,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
             "-i \"{}\"".format(temp_data["full_input_path"])
         )
 
-        # Use shortest input
-        ffmpeg_output_args.append("-shortest")
-
         # Add audio arguments if there are any. Skipped when output are images.
         if not temp_data["output_ext_is_image"] and temp_data["with_audio"]:
             audio_in_args, audio_filters, audio_out_args = self.audio_args(


### PR DESCRIPTION
## Issue
- ExtractReview cut audio if input is sequence because will set `frames:v ...`

## Changes
- argument `frames:v ...` for output is used only if output is sequence
- audio inputs have set duration with help of `-to` argument where duration in seconds is filled
- same is applied for input if input **is** image sequence and output **is not** image sequence
    - this is to specify how many frames should be used from input
- `shortest` argument was removed (as all inputs have defined duration)