### PR TITLE
TVPaint store context to workfile metadata (764)

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -1,6 +1,8 @@
+import os
 import json
 
 import pyblish.api
+import avalon.api
 from avalon.tvpaint import pipeline, lib
 
 
@@ -10,26 +12,58 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
     hosts = ["tvpaint"]
 
     def process(self, context):
+        # Collect and store current context to have reference
+        current_context = {
+            "project": avalon.api.Session["AVALON_PROJECT"],
+            "asset": avalon.api.Session["AVALON_ASSET"],
+            "task": avalon.api.Session["AVALON_TASK"]
+        }
+        context.data["previous_context"] = current_context
+        self.log.debug("Current context is: {}".format(current_context))
+
+        # Collect context from workfile metadata
+        self.log.info("Collecting workfile context")
+        workfile_context = pipeline.get_current_workfile_context()
+        if workfile_context:
+            # Change current context with context from workfile
+            key_map = (("AVALON_ASSET", "asset"), ("AVALON_TASK", "task"))
+            for env_key, key in key_map:
+                avalon.api.Session[env_key] = workfile_context[key]
+                os.environ[env_key] = workfile_context[key]
+        else:
+            # Handle older workfiles or workfiles without metadata
+            self.log.warning(
+                "Workfile does not contain information about context."
+                " Using current Session context."
+            )
+            workfile_context = current_context.copy()
+
+        context.data["workfile_context"] = workfile_context
+        self.log.info("Context changed to: {}".format(workfile_context))
+
+        # Collect instances
         self.log.info("Collecting instance data from workfile")
         instance_data = pipeline.list_instances()
+        context.data["workfileInstances"] = instance_data
         self.log.debug(
             "Instance data:\"{}".format(json.dumps(instance_data, indent=4))
         )
-        context.data["workfileInstances"] = instance_data
 
+        # Collect information about layers
         self.log.info("Collecting layers data from workfile")
         layers_data = lib.layers_data()
+        context.data["layersData"] = layers_data
         self.log.debug(
             "Layers data:\"{}".format(json.dumps(layers_data, indent=4))
         )
-        context.data["layersData"] = layers_data
 
+        # Collect information about groups
         self.log.info("Collecting groups data from workfile")
         group_data = lib.groups_data()
+        context.data["groupsData"] = group_data
         self.log.debug(
             "Group data:\"{}".format(json.dumps(group_data, indent=4))
         )
-        context.data["groupsData"] = group_data
 
         self.log.info("Collecting scene data from workfile")
         workfile_info_parts = lib.execute_george("tv_projectinfo").split(" ")

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -26,7 +26,10 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         workfile_context = pipeline.get_current_workfile_context()
         if workfile_context:
             # Change current context with context from workfile
-            key_map = (("AVALON_ASSET", "asset"), ("AVALON_TASK", "task"))
+            key_map = (
+                ("AVALON_ASSET", "asset"),
+                ("AVALON_TASK", "task")
+            )
             for env_key, key in key_map:
                 avalon.api.Session[env_key] = workfile_context[key]
                 os.environ[env_key] = workfile_context[key]

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -12,6 +12,9 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
     hosts = ["tvpaint"]
 
     def process(self, context):
+        current_project_id = lib.execute_george("tv_projectcurrentid")
+        lib.execute_george("tv_projectselect {}".format(current_project_id))
+
         # Collect and store current context to have reference
         current_context = {
             "project": avalon.api.Session["AVALON_PROJECT"],

--- a/pype/plugins/tvpaint/publish/validate_workfile_project_name.py
+++ b/pype/plugins/tvpaint/publish/validate_workfile_project_name.py
@@ -1,0 +1,37 @@
+import os
+import pyblish.api
+
+
+class ValidateWorkfileProjectName(pyblish.api.ContextPlugin):
+    """Validate project name stored in workfile metadata.
+
+    It is not possible to publish from different project than is set in
+    environment variable "AVALON_PROJECT".
+    """
+
+    label = "Validate Workfile Project Name"
+    order = pyblish.api.ValidatorOrder
+
+    def process(self, context):
+        workfile_context = context.data["workfile_context"]
+        workfile_project_name = workfile_context["project"]
+        env_project_name = os.environ["AVALON_PROJECT"]
+        if workfile_project_name == env_project_name:
+            self.log.info((
+                "Both workfile project and environment project are same. {}"
+            ).format(env_project_name))
+            return
+
+        # Raise an error
+        raise AssertionError((
+            # Short message
+            "Workfile from different Project ({})."
+            # Description what's wrong
+            " It is not possible to publish when TVPaint was launched in"
+            "context of different project. Current context project is \"{}\"."
+            " Launch TVPaint in context of project \"{}\" and then publish."
+        ).format(
+            workfile_project_name,
+            env_project_name,
+            workfile_project_name,
+        ))


### PR DESCRIPTION
## Issue
It is possible to have opened multiple workfiles at the same time from different contexts. Which is not an issue for most of avalon workflow but is issue for publishing.

## Changes
- each workfile contain metadata with "project", "asset" and "task" to keep context in which were workfiles created.
- these metadata are loaded in first TVPaint's collector and current context is modified by them
    - if workfile does not contain these metadata current context from `api.Session` is used
- added validator for comparing project name (it is not allowed to publish in different project)

## Possible issues
- manually copy-pasted workfile (out of workfile tool) may contain metadata from different context
    - this can be fixed with resave
- workfile change is not "Super Responsive" TVPaint won't change workfile context at the moment of tab change (it is required to click somwhere in gui).

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/233|

Resolves https://github.com/pypeclub/pype/issues/764