### PR TITLE
Harmony: template extraction and palettes thumbnails on mac

### DIFF
--- a/pype/hosts/harmony/js/PypeHarmony.js
+++ b/pype/hosts/harmony/js/PypeHarmony.js
@@ -183,11 +183,11 @@ PypeHarmony.color = function(rgba) {
 /**
  * get all dependencies for given node.
  * @function
- * @param   {string}  node node path.
+ * @param   {string}  _node node path.
  * @return  {array}   List of dependent nodes.
  */
-PypeHarmony.getDependencies = function(node) {
-    var target_node = node;
+PypeHarmony.getDependencies = function(_node) {
+    var target_node = _node;
     var numInput = node.numberOfInputPorts(target_node);
     var dependencies = [];
     for (var i = 0 ; i < numInput; i++) {

--- a/pype/plugins/harmony/publish/extract_palette.py
+++ b/pype/plugins/harmony/publish/extract_palette.py
@@ -38,7 +38,7 @@ class ExtractPalette(pype.api.Extractor):
                                       os.path.basename(palette_file)
                                       .split(".plt")[0] + "_swatches.png"
                                       )
-        self.log.info(f"Temporary humbnail path {tmp_thumb_path}")
+        self.log.info(f"Temporary thumbnail path {tmp_thumb_path}")
 
         palette_version = str(instance.data.get("version")).zfill(3)
 
@@ -52,6 +52,11 @@ class ExtractPalette(pype.api.Extractor):
                                                            palette_version,
                                                            palette_file,
                                                            tmp_thumb_path)
+        except OSError as e:
+            # FIXME: this happens on Mac where PIL cannot access fonts
+            # for some reason.
+            self.log.warning("Thumbnail generation failed")
+            self.log.warning(e)
         except ValueError:
             self.log.error("Unsupported palette type for thumbnail.")
 

--- a/pype/plugins/harmony/publish/extract_template.py
+++ b/pype/plugins/harmony/publish/extract_template.py
@@ -31,7 +31,11 @@ class ExtractTemplate(pype.api.Extractor):
             for backdrop in self.get_backdrops(dependency):
                 backdrops[backdrop["title"]["text"]] = backdrop
         unique_backdrops = [backdrops[x] for x in set(backdrops.keys())]
-
+        if not unique_backdrops:
+            self.log.error(("No backdrops detected for template. "
+                            "Please move template instance node onto "
+                            "some backdrop and try again."))
+            raise AssertionError("No backdrop detected")
         # Get non-connected nodes within backdrops.
         all_nodes = instance.context.data.get("allNodes")
         for node in [x for x in all_nodes if x not in dependencies]:


### PR DESCRIPTION
## Bugs

### Extract Templates

There was a bug where local function argument was shadowing Harmony object name `node` in `PypeHarmony.getDependencies()` crashing template extraction process.

### Palettes thumbnails on Mac

Creating thumbnail for Harmony palettes is failing on Mac due **PIL** inability to access fonts. This is temporary solution disabling thumbnail creation when this error happens.