### PR TITLE
Settings required keys in modifiable dict

### DIFF
--- a/pype/tools/settings/settings/README.md
+++ b/pype/tools/settings/settings/README.md
@@ -310,6 +310,9 @@
 - items in this input can be removed and added same way as in `list` input
 - value items in dictionary must be the same type
 - type of items is defined with key `"object_type"`
+- required keys may be defined under `"required_keys"`
+    - required keys must be defined as a list (e.g. `["key_1"]`) and are moved to the top
+    - these keys can't be removed or edited (it is possible to edit label if item is collapsible)
 - there are 2 possible ways how to set the type:
     1.) dictionary with item modifiers (`number` input has `minimum`, `maximum` and `decimals`) in that case item type must be set as value of `"type"` (example below)
     2.) item type name as string without modifiers (e.g. `text`)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -2040,15 +2040,16 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
             key_label_input.focusOutEvent = key_label_input_focused_out
 
         spacer_widget = None
+        add_btn = None
         if not self.collapsable_key:
             spacer_widget = QtWidgets.QWidget(self)
             spacer_widget.setAttribute(QtCore.Qt.WA_TranslucentBackground)
             spacer_widget.setVisible(False)
 
-        add_btn = QtWidgets.QPushButton("+")
-        add_btn.setFocusPolicy(QtCore.Qt.ClickFocus)
-        add_btn.setProperty("btn-type", "tool-item")
-        add_btn.setFixedSize(self._btn_size, self._btn_size)
+            add_btn = QtWidgets.QPushButton("+")
+            add_btn.setFocusPolicy(QtCore.Qt.ClickFocus)
+            add_btn.setProperty("btn-type", "tool-item")
+            add_btn.setFixedSize(self._btn_size, self._btn_size)
 
         edit_btn = None
         if self.collapsable_key:
@@ -2069,7 +2070,6 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         if self.collapsable_key:
             key_input_label_widget = QtWidgets.QLabel("Key:")
             key_label_input_label_widget = QtWidgets.QLabel("Label:")
-            wrapper_widget.add_widget_before_label(add_btn)
             wrapper_widget.add_widget_before_label(edit_btn)
             wrapper_widget.add_widget_after_label(key_input_label_widget)
             wrapper_widget.add_widget_after_label(key_input)
@@ -2093,8 +2093,8 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
             key_label_input.returnPressed.connect(self._on_enter_press)
 
         value_input.value_changed.connect(self._on_value_change)
-
-        add_btn.clicked.connect(self.on_add_clicked)
+        if add_btn:
+            add_btn.clicked.connect(self.on_add_clicked)
         if edit_btn:
             edit_btn.clicked.connect(self.on_edit_pressed)
         remove_btn.clicked.connect(self.on_remove_clicked)
@@ -2283,7 +2283,6 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         self._is_empty = is_empty
 
         self.value_input.setVisible(not is_empty)
-        self.add_btn.setVisible(is_empty)
         if not self.collapsable_key:
             self.key_input.setVisible(not is_empty)
             self.remove_btn.setEnabled(not is_empty)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1988,6 +1988,8 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         self._is_empty = False
         self._is_key_duplicated = False
 
+        self._is_required = False
+
         self.origin_key = NOT_SET
         self.origin_key_label = NOT_SET
 
@@ -2161,6 +2163,24 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
                 self._on_focus_lose()
         self.update_style()
 
+    def set_as_required(self, key):
+        self.key_input.setText(key)
+        self.key_input.setEnabled(False)
+        self._is_required = True
+
+        if self._is_empty:
+            self.set_as_empty(False)
+
+        if self.collapsable_key:
+            self.remove_btn.setVisible(False)
+        else:
+            self.remove_btn.setEnabled(False)
+            self.add_btn.setEnabled(False)
+
+    def set_as_last_required(self):
+        if self.add_btn:
+            self.add_btn.setEnabled(True)
+
     def _on_focus_lose(self):
         if (
             self.edit_btn.hasFocus()
@@ -2272,9 +2292,13 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         self.key_input.setVisible(enabled)
         self.key_input_label_widget.setVisible(enabled)
         self.key_label_input.setVisible(enabled)
-        self.remove_btn.setVisible(enabled)
+        if not self._is_required:
+            self.remove_btn.setVisible(enabled)
         if enabled:
-            self.key_input.setFocus()
+            if self.key_input.isEnabled():
+                self.key_input.setFocus()
+            else:
+                self.key_label_input.setFocus()
 
     def on_remove_clicked(self):
         self._parent.remove_row(self)
@@ -2414,6 +2438,7 @@ class ModifiableDict(QtWidgets.QWidget, InputObject):
         self.initial_attributes(schema_data, parent, as_widget)
 
         self.input_fields = []
+        self.required_inputs_by_key = {}
 
         # Validation of "key" key
         self.key = schema_data["key"]


### PR DESCRIPTION
## Changes
- item `modifiable-dict` may have defined required keys
- required keys must be defined as a list (e.g. `["key_1"]`)
     - they are moved to the top
- these keys can't be removed or edited (even for developer)
    - it is possible to edit label if item is collapsible