### PR TITLE
Maya: Look - respect original texture colorspace when not using maketx

### DIFF
--- a/pype/plugins/maya/publish/extract_look.py
+++ b/pype/plugins/maya/publish/extract_look.py
@@ -172,10 +172,11 @@ class ExtractLook(pype.api.Extractor):
 
             cspace = files_metadata[filepath]["color_space"]
             linearise = False
-            if cspace == "sRGB":
-                linearise = True
-                # set its file node to 'raw' as tx will be linearized
-                files_metadata[filepath]["color_space"] = "raw"
+            if do_maketx:
+                if cspace == "sRGB":
+                    linearise = True
+                    # set its file node to 'raw' as tx will be linearized
+                    files_metadata[filepath]["color_space"] = "raw"
 
             source, mode, hash = self._process_texture(
                 filepath,


### PR DESCRIPTION
## Bug
when extracting and applying looks Pype wasn't respecting texture color space when *make tx* function was unchecked.

🎫 **ticket:** [#442](https://pype.freshdesk.com/a/tickets/442)
|---|