### PR TITLE
Feature AE load background

### DIFF
--- a/pype/lib/abstract_collect_render.py
+++ b/pype/lib/abstract_collect_render.py
@@ -73,14 +73,14 @@ class RenderInstance(object):
     @frameStart.validator
     def check_frame_start(self, _, value):
         """Validate if frame start is not larger then end."""
-        if value >= self.frameEnd:
+        if value > self.frameEnd:
             raise ValueError("frameStart must be smaller "
                              "or equal then frameEnd")
 
     @frameEnd.validator
     def check_frame_end(self, _, value):
         """Validate if frame end is not less then start."""
-        if value <= self.frameStart:
+        if value < self.frameStart:
             raise ValueError("frameEnd must be smaller "
                              "or equal then frameStart")
 

--- a/pype/plugins/aftereffects/load/load_background.py
+++ b/pype/plugins/aftereffects/load/load_background.py
@@ -24,7 +24,8 @@ class BackgroundLoader(api.Loader):
         items = stub.get_items(comps=True)
         existing_items = [layer.name for layer in items]
 
-        comp_name = get_unique_layer_name(existing_items,
+        comp_name = get_unique_layer_name(
+            existing_items,
             "{}_{}".format(context["asset"]["name"], name))
 
         layers = get_background_layers(self.fname)
@@ -60,7 +61,8 @@ class BackgroundLoader(api.Loader):
         if namespace_from_container != comp_name:
             items = stub.get_items(comps=True)
             existing_items = [layer.name for layer in items]
-            comp_name = get_unique_layer_name(existing_items,
+            comp_name = get_unique_layer_name(
+                existing_items,
                 "{}_{}".format(context["asset"], context["subset"]))
         else:  # switching version - keep same name
             comp_name = container["namespace"]

--- a/pype/plugins/aftereffects/load/load_background.py
+++ b/pype/plugins/aftereffects/load/load_background.py
@@ -1,0 +1,96 @@
+import re
+
+from avalon import api, aftereffects
+
+from pype.plugins.lib import get_background_layers, get_unique_layer_name
+
+stub = aftereffects.stub()
+
+
+class BackgroundLoader(api.Loader):
+    """
+        Load images from Background family
+        Creates for each background separate folder with all imported images
+        from background json AND automatically created composition with layers,
+        each layer for separate image.
+
+        For each load container is created and stored in project (.aep)
+        metadata
+    """
+    families = ["background"]
+    representations = ["json"]
+
+    def load(self, context, name=None, namespace=None, data=None):
+        items = stub.get_items(comps=True)
+        existing_items = [layer.name for layer in items]
+
+        comp_name = get_unique_layer_name(existing_items,
+            "{}_{}".format(context["asset"]["name"], name))
+
+        layers = get_background_layers(self.fname)
+        comp = stub.import_background(None, comp_name, layers)
+
+        if not comp:
+            self.log.warning(
+                "Import background failed.")
+            self.log.warning("Check host app for alert error.")
+            return
+
+        self[:] = [comp]
+        namespace = namespace or comp_name
+
+        return aftereffects.containerise(
+            name,
+            namespace,
+            comp,
+            context,
+            self.__class__.__name__
+        )
+
+    def update(self, container, representation):
+        """ Switch asset or change version """
+        context = representation.get("context", {})
+
+        # without iterator number (_001, 002...)
+        namespace_from_container = re.sub(r'_\d{3}$', '',
+                                          container["namespace"])
+        comp_name = "{}_{}".format(context["asset"], context["subset"])
+
+        # switching assets
+        if namespace_from_container != comp_name:
+            items = stub.get_items(comps=True)
+            existing_items = [layer.name for layer in items]
+            comp_name = get_unique_layer_name(existing_items,
+                "{}_{}".format(context["asset"], context["subset"]))
+        else:  # switching version - keep same name
+            comp_name = container["namespace"]
+
+        path = api.get_representation_path(representation)
+
+        layers = get_background_layers(path)
+        comp = stub.reload_background(container["members"][1],
+                                      comp_name,
+                                      layers)
+
+        # update container
+        container["representation"] = str(representation["_id"])
+        container["name"] = context["subset"]
+        container["namespace"] = comp_name
+        container["members"] = comp.members
+
+        stub.imprint(comp, container)
+
+    def remove(self, container):
+        """
+            Removes element from scene: deletes layer + removes from file
+            metadata.
+        Args:
+            container (dict): container to be removed - used to get layer_id
+        """
+        print("!!!! container:: {}".format(container))
+        layer = container.pop("layer")
+        stub.imprint(layer, {})
+        stub.delete_item(layer.id)
+
+    def switch(self, container, representation):
+        self.update(container, representation)

--- a/pype/plugins/aftereffects/load/load_file.py
+++ b/pype/plugins/aftereffects/load/load_file.py
@@ -23,8 +23,8 @@ class FileLoader(api.Loader):
     def load(self, context, name=None, namespace=None, data=None):
         layers = stub.get_items(comps=True, folders=True, footages=True)
         existing_layers = [layer.name for layer in layers]
-        comp_name = lib.get_unique_layer_name(existing_layers,
-            "{}_{}".format(context["asset"]["name"], name))
+        comp_name = lib.get_unique_layer_name(
+            existing_layers, "{}_{}".format(context["asset"]["name"], name))
 
         import_options = {}
 
@@ -80,9 +80,9 @@ class FileLoader(api.Loader):
         if namespace_from_container != layer_name:
             layers = stub.get_items(comps=True)
             existing_layers = [layer.name for layer in layers]
-            layer_name = lib.get_unique_layer_name(existing_layers,
-                "{}_{}".format(context["asset"],
-                               context["subset"]))
+            layer_name = lib.get_unique_layer_name(
+                existing_layers,
+                "{}_{}".format(context["asset"], context["subset"]))
         else:  # switching version - keep same name
             layer_name = container["namespace"]
         path = api.get_representation_path(representation)

--- a/pype/plugins/aftereffects/load/load_file.py
+++ b/pype/plugins/aftereffects/load/load_file.py
@@ -21,9 +21,10 @@ class FileLoader(api.Loader):
     representations = ["*"]
 
     def load(self, context, name=None, namespace=None, data=None):
-        comp_name = lib.get_unique_layer_name(stub.get_items(comps=True),
-                                              context["asset"]["name"],
-                                              name)
+        layers = stub.get_items(comps=True, folders=True, footages=True)
+        existing_layers = [layer.name for layer in layers]
+        comp_name = lib.get_unique_layer_name(existing_layers,
+            "{}_{}".format(context["asset"]["name"], name))
 
         import_options = {}
 
@@ -77,9 +78,11 @@ class FileLoader(api.Loader):
         layer_name = "{}_{}".format(context["asset"], context["subset"])
         # switching assets
         if namespace_from_container != layer_name:
-            layer_name = lib.get_unique_layer_name(stub.get_items(comps=True),
-                                                   context["asset"],
-                                                   context["subset"])
+            layers = stub.get_items(comps=True)
+            existing_layers = [layer.name for layer in layers]
+            layer_name = lib.get_unique_layer_name(existing_layers,
+                "{}_{}".format(context["asset"],
+                               context["subset"]))
         else:  # switching version - keep same name
             layer_name = container["namespace"]
         path = api.get_representation_path(representation)

--- a/pype/plugins/aftereffects/publish/collect_render.py
+++ b/pype/plugins/aftereffects/publish/collect_render.py
@@ -110,7 +110,10 @@ class CollectAERender(abstract_collect_render.AbstractCollectRender):
 
         # pull file name from Render Queue Output module
         render_q = aftereffects.stub().get_render_info()
+        if not render_q:
+            raise ValueError("No file extension set in Render Queue")
         _, ext = os.path.splitext(os.path.basename(render_q.file_name))
+
         base_dir = self._get_output_dir(render_instance)
         expected_files = []
         if "#" not in render_q.file_name:  # single frame (mov)W

--- a/pype/plugins/lib.py
+++ b/pype/plugins/lib.py
@@ -1,22 +1,22 @@
 import re
+import json
+import os
 
 
-def get_unique_layer_name(layers, asset_name, subset_name):
+def get_unique_layer_name(layers, name):
     """
         Gets all layer names and if 'name' is present in them, increases
         suffix by 1 (eg. creates unique layer name - for Loader)
     Args:
-        layers (list): of namedtuples, expects 'name' field present
-        asset_name (string):  in format asset_subset (Hero)
-        subset_name (string): (LOD)
+        layers (list): of strings, names only
+        name (string):  checked value
 
     Returns:
         (string): name_00X (without version)
     """
-    name = "{}_{}".format(asset_name, subset_name)
     names = {}
     for layer in layers:
-        layer_name = re.sub(r'_\d{3}$', '', layer.name)
+        layer_name = re.sub(r'_\d{3}$', '', layer)
         if layer_name in names.keys():
             names[layer_name] = names[layer_name] + 1
         else:
@@ -24,3 +24,34 @@ def get_unique_layer_name(layers, asset_name, subset_name):
     occurrences = names.get(name, 0)
 
     return "{}_{:0>3d}".format(name, occurrences + 1)
+
+
+def get_background_layers(file_url):
+    """
+        Pulls file name from background json file, enrich with folder url for
+        AE to be able import files.
+
+        Order is important, follows order in json.
+
+        Args:
+            file_url (str): abs url of background json
+
+        Returns:
+            (list): of abs paths to images
+    """
+    with open(file_url) as json_file:
+        data = json.load(json_file)
+
+    layers = list()
+    bg_folder = os.path.dirname(file_url)
+    for child in data['children']:
+        if child.get("filename"):
+            layers.append(os.path.join(bg_folder, child.get("filename")).
+                          replace("\\", "/"))
+        else:
+            for layer in child['children']:
+                if layer.get("filename"):
+                    layers.append(os.path.join(bg_folder,
+                                               layer.get("filename")).
+                                  replace("\\", "/"))
+    return layers


### PR DESCRIPTION
Implemented new loader for 'background' family.

Reworked structure of json metadata to follow existing implementations more closely. (Currently contains list of container or instances. Containers have 'members' array to list all imported files from loader.)

Requires:
pypeclub/avalon-core#237