### PR TITLE
Settings get anatomy data

### DIFF
--- a/pype/api.py
+++ b/pype/api.py
@@ -1,7 +1,8 @@
 from .settings import (
     get_system_settings,
     get_project_settings,
-    environments
+    get_anatomy_data,
+    get_environments
 )
 from pypeapp import (
     Logger,
@@ -52,7 +53,8 @@ from .lib import _subprocess as subprocess
 __all__ = [
     "get_system_settings",
     "get_project_settings",
-    "environments",
+    "get_anatomy_data",
+    "get_environments",
 
     "Logger",
     "Anatomy",

--- a/pype/api.py
+++ b/pype/api.py
@@ -1,6 +1,7 @@
 from .settings import (
     get_system_settings,
     get_project_settings,
+    get_current_project_settings,
     get_anatomy_data,
     get_environments
 )
@@ -53,6 +54,7 @@ from .lib import _subprocess as subprocess
 __all__ = [
     "get_system_settings",
     "get_project_settings",
+    "get_current_project_settings",
     "get_anatomy_data",
     "get_environments",
 

--- a/pype/api.py
+++ b/pype/api.py
@@ -1,6 +1,6 @@
 from .settings import (
-    system_settings,
-    project_settings,
+    get_system_settings,
+    get_project_settings,
     environments
 )
 from pypeapp import (
@@ -50,8 +50,8 @@ from .lib import (
 from .lib import _subprocess as subprocess
 
 __all__ = [
-    "system_settings",
-    "project_settings",
+    "get_system_settings",
+    "get_project_settings",
     "environments",
 
     "Logger",

--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -19,8 +19,8 @@ from ..api import (
     Anatomy,
     Logger,
     config,
-    system_settings,
-    environments
+    get_system_settings,
+    get_environments
 )
 from .python_module_tools import (
     modules_from_path,
@@ -526,7 +526,7 @@ class ApplicationManager:
 
     def refresh(self):
         """Refresh applications from settings."""
-        settings = system_settings()
+        settings = get_system_settings()
 
         hosts_definitions = settings["applications"]
         for app_group, variant_definitions in hosts_definitions.items():
@@ -905,7 +905,7 @@ class ApplicationLaunchContext:
         # Load settings if were not passed in data
         settings_env = self.data.get("settings_env")
         if settings_env is None:
-            settings_env = environments()
+            settings_env = get_environments()
             self.data["settings_env"] = settings_env
 
         # subprocess.Popen launch arguments (first argument in constructor)

--- a/pype/modules_manager.py
+++ b/pype/modules_manager.py
@@ -3,7 +3,7 @@ import inspect
 
 import pype.modules
 from pype.modules import PypeModule
-from pype.settings import system_settings
+from pype.settings import get_system_settings
 from pype.api import Logger
 
 
@@ -24,7 +24,7 @@ class PypeModuleManager:
         return environments
 
     def find_pype_modules(self):
-        settings = system_settings()
+        settings = get_system_settings()
         modules = []
         dirpath = os.path.dirname(pype.modules.__file__)
         for module_name in os.listdir(dirpath):

--- a/pype/settings/__init__.py
+++ b/pype/settings/__init__.py
@@ -1,11 +1,13 @@
 from .lib import (
     get_system_settings,
     get_project_settings,
+    get_anatomy_data,
     get_environments
 )
 
 __all__ = (
     "get_system_settings",
     "get_project_settings",
+    "get_anatomy_data",
     "get_environments"
 )

--- a/pype/settings/__init__.py
+++ b/pype/settings/__init__.py
@@ -1,6 +1,7 @@
 from .lib import (
     get_system_settings,
     get_project_settings,
+    get_current_project_settings,
     get_anatomy_data,
     get_environments
 )
@@ -8,6 +9,7 @@ from .lib import (
 __all__ = (
     "get_system_settings",
     "get_project_settings",
+    "get_current_project_settings",
     "get_anatomy_data",
     "get_environments"
 )

--- a/pype/settings/__init__.py
+++ b/pype/settings/__init__.py
@@ -1,11 +1,11 @@
 from .lib import (
-    system_settings,
-    project_settings,
-    environments
+    get_system_settings,
+    get_project_settings,
+    get_environments
 )
 
 __all__ = (
-    "system_settings",
-    "project_settings",
-    "environments"
+    "get_system_settings",
+    "get_project_settings",
+    "get_environments"
 )

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -367,7 +367,7 @@ def get_project_settings_overrides(project_name):
     return load_json_file(path_to_json)
 
 
-def project_anatomy_overrides(project_name):
+def get_project_anatomy_overrides(project_name):
     """Studio overrides of project anatomy for specific project.
 
     Args:
@@ -430,6 +430,18 @@ def get_project_settings(project_name):
     studio_overrides = apply_overrides(default_values, studio_values)
 
     project_overrides = get_project_settings_overrides(project_name)
+
+    return apply_overrides(studio_overrides, project_overrides)
+
+
+def get_anatomy_data(project_name):
+    """Project anatomy data with applied studio and project overrides."""
+    default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
+    studio_values = get_studio_project_anatomy()
+
+    studio_overrides = apply_overrides(default_values, studio_values)
+
+    project_overrides = get_project_anatomy_overrides(project_name)
 
     return apply_overrides(studio_overrides, project_overrides)
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -418,30 +418,50 @@ def apply_overrides(source_data, override_data):
 def get_system_settings():
     """System settings with applied studio overrides."""
     default_values = get_default_settings()[SYSTEM_SETTINGS_KEY]
-    studio_values = get_studio_system_settings()
+    studio_values = get_studio_overrides_system_settings()
     return apply_overrides(default_values, studio_values)
 
 
-def get_project_settings(project_name):
-    """Project settings with applied studio and project overrides."""
+def get_default_project_settings():
+    """Project settings with applied studio's default project overrides."""
     default_values = get_default_settings()[PROJECT_SETTINGS_KEY]
-    studio_values = get_studio_project_settings()
+    studio_values = get_studio_overrides_default_project_settings()
 
-    studio_overrides = apply_overrides(default_values, studio_values)
+    return apply_overrides(default_values, studio_values)
 
-    project_overrides = get_project_settings_overrides(project_name)
 
-    return apply_overrides(studio_overrides, project_overrides)
+def get_default_project_anatomy_data():
+    """Project anatomy data with applied studio's default project overrides."""
+    default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
+    studio_values = get_studio_overrides_default_project_anatomy()
+
+    return apply_overrides(default_values, studio_values)
 
 
 def get_anatomy_data(project_name):
     """Project anatomy data with applied studio and project overrides."""
-    default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
-    studio_values = get_studio_project_anatomy()
+    if not project_name:
+        raise ValueError(
+            "Must enter project name."
+            " Call `get_default_project_anatomy_data` to get project defaults."
+        )
 
-    studio_overrides = apply_overrides(default_values, studio_values)
-
+    studio_overrides = get_default_project_anatomy_data()
     project_overrides = get_project_anatomy_overrides(project_name)
+
+    return apply_overrides(studio_overrides, project_overrides)
+
+
+def get_project_settings(project_name):
+    """Project settings with applied studio and project overrides."""
+    if not project_name:
+        raise ValueError(
+            "Must enter project name."
+            " Call `get_default_project_settings` to get project defaults."
+        )
+
+    studio_overrides = get_default_project_settings()
+    project_overrides = get_project_settings_overrides(project_name)
 
     return apply_overrides(studio_overrides, project_overrides)
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -287,9 +287,9 @@ def save_project_settings(project_name, overrides):
 
     Do not use to store whole project settings data with defaults but only it's
     overrides with metadata defining how overrides should be applied in load
-    function. For loading should be used function `get_studio_project_settings`
-    for global project settings and `get_project_settings_overrides` for
-    project specific settings.
+    function. For loading should be used function
+    `get_studio_overrides_default_project_settings` for global project settings
+    and `get_project_settings_overrides` for project specific settings.
 
     Args:
         project_name(str, null): Project name for which overrides are
@@ -358,8 +358,6 @@ def get_project_settings_overrides(project_name):
     Returns:
         dict: Only overrides for entered project, may be empty dictionary.
     """
-    if not project_name:
-        return {}
 
     path_to_json = path_to_project_settings(project_name)
     if not os.path.exists(path_to_json):

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -69,7 +69,7 @@ def reset_default_settings():
     _DEFAULT_SETTINGS = None
 
 
-def default_settings():
+def get_default_settings():
     global _DEFAULT_SETTINGS
     if _DEFAULT_SETTINGS is None:
         _DEFAULT_SETTINGS = load_jsons_from_dir(DEFAULTS_DIR)
@@ -236,21 +236,21 @@ def subkey_merge(_dict, value, keys):
     return _dict
 
 
-def studio_system_settings():
+def get_studio_system_settings():
     """Studio overrides of system settings."""
     if os.path.exists(SYSTEM_SETTINGS_PATH):
         return load_json_file(SYSTEM_SETTINGS_PATH)
     return {}
 
 
-def studio_project_settings():
+def get_studio_project_settings():
     """Studio overrides of default project settings."""
     if os.path.exists(PROJECT_SETTINGS_PATH):
         return load_json_file(PROJECT_SETTINGS_PATH)
     return {}
 
 
-def studio_project_anatomy():
+def get_studio_project_anatomy():
     """Studio overrides of default project anatomy data."""
     if os.path.exists(PROJECT_ANATOMY_PATH):
         return load_json_file(PROJECT_ANATOMY_PATH)
@@ -305,8 +305,8 @@ def save_project_settings(project_name, overrides):
 
     Do not use to store whole project settings data with defaults but only it's
     overrides with metadata defining how overrides should be applied in load
-    function. For loading should be used functions `studio_project_settings`
-    for global project settings and `project_settings_overrides` for
+    function. For loading should be used function `get_studio_project_settings`
+    for global project settings and `get_project_settings_overrides` for
     project specific settings.
 
     Args:
@@ -346,7 +346,7 @@ def save_project_anatomy(project_name, anatomy_data):
         json.dump(anatomy_data, file_stream, indent=4)
 
 
-def project_settings_overrides(project_name):
+def get_project_settings_overrides(project_name):
     """Studio overrides of project settings for specific project.
 
     Args:
@@ -412,26 +412,26 @@ def apply_overrides(source_data, override_data):
     return merge_overrides(_source_data, override_data)
 
 
-def system_settings():
+def get_system_settings():
     """System settings with applied studio overrides."""
-    default_values = default_settings()[SYSTEM_SETTINGS_KEY]
-    studio_values = studio_system_settings()
+    default_values = get_default_settings()[SYSTEM_SETTINGS_KEY]
+    studio_values = get_studio_system_settings()
     return apply_overrides(default_values, studio_values)
 
 
-def project_settings(project_name):
+def get_project_settings(project_name):
     """Project settings with applied studio and project overrides."""
-    default_values = default_settings()[PROJECT_SETTINGS_KEY]
-    studio_values = studio_project_settings()
+    default_values = get_default_settings()[PROJECT_SETTINGS_KEY]
+    studio_values = get_studio_project_settings()
 
     studio_overrides = apply_overrides(default_values, studio_values)
 
-    project_overrides = project_settings_overrides(project_name)
+    project_overrides = get_project_settings_overrides(project_name)
 
     return apply_overrides(studio_overrides, project_overrides)
 
 
-def environments():
+def get_environments():
     """Calculated environment based on defaults and system settings.
 
     Any default environment also found in the system settings will be fully

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -443,11 +443,5 @@ def get_environments():
     Returns:
         dict: Output should be ready for `acre` module.
     """
-    # TODO remove these defaults (All should be set with system settings)
-    envs = copy.deepcopy(default_settings()[ENVIRONMENTS_KEY])
-    # This is part of loading environments from settings
-    envs_from_system_settings = find_environments(system_settings())
 
-    for env_group_key, values in envs_from_system_settings.items():
-        envs[env_group_key] = values
-    return envs
+    return find_environments(get_system_settings())

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -288,7 +288,7 @@ def save_project_settings(project_name, overrides):
     Do not use to store whole project settings data with defaults but only it's
     overrides with metadata defining how overrides should be applied in load
     function. For loading should be used function
-    `get_studio_overrides_default_project_settings` for global project settings
+    `get_studio_project_settings_overrides` for global project settings
     and `get_project_settings_overrides` for project specific settings.
 
     Args:
@@ -328,21 +328,21 @@ def save_project_anatomy(project_name, anatomy_data):
         json.dump(anatomy_data, file_stream, indent=4)
 
 
-def get_studio_overrides_system_settings():
+def get_studio_system_settings_overrides():
     """Studio overrides of system settings."""
     if os.path.exists(SYSTEM_SETTINGS_PATH):
         return load_json_file(SYSTEM_SETTINGS_PATH)
     return {}
 
 
-def get_studio_overrides_default_project_settings():
+def get_studio_project_settings_overrides():
     """Studio overrides of default project settings."""
     if os.path.exists(PROJECT_SETTINGS_PATH):
         return load_json_file(PROJECT_SETTINGS_PATH)
     return {}
 
 
-def get_studio_overrides_default_project_anatomy():
+def get_studio_project_anatomy_overrides():
     """Studio overrides of default project anatomy data."""
     if os.path.exists(PROJECT_ANATOMY_PATH):
         return load_json_file(PROJECT_ANATOMY_PATH)
@@ -416,14 +416,14 @@ def apply_overrides(source_data, override_data):
 def get_system_settings():
     """System settings with applied studio overrides."""
     default_values = get_default_settings()[SYSTEM_SETTINGS_KEY]
-    studio_values = get_studio_overrides_system_settings()
+    studio_values = get_studio_system_settings_overrides()
     return apply_overrides(default_values, studio_values)
 
 
 def get_default_project_settings():
     """Project settings with applied studio's default project overrides."""
     default_values = get_default_settings()[PROJECT_SETTINGS_KEY]
-    studio_values = get_studio_overrides_default_project_settings()
+    studio_values = get_studio_project_settings_overrides()
 
     return apply_overrides(default_values, studio_values)
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -431,7 +431,7 @@ def get_default_project_settings():
 def get_default_project_anatomy_data():
     """Project anatomy data with applied studio's default project overrides."""
     default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
-    studio_values = get_studio_overrides_default_project_anatomy()
+    studio_values = get_studio_project_anatomy_overrides()
 
     return apply_overrides(default_values, studio_values)
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -239,27 +239,6 @@ def subkey_merge(_dict, value, keys):
     return _dict
 
 
-def get_studio_system_settings():
-    """Studio overrides of system settings."""
-    if os.path.exists(SYSTEM_SETTINGS_PATH):
-        return load_json_file(SYSTEM_SETTINGS_PATH)
-    return {}
-
-
-def get_studio_project_settings():
-    """Studio overrides of default project settings."""
-    if os.path.exists(PROJECT_SETTINGS_PATH):
-        return load_json_file(PROJECT_SETTINGS_PATH)
-    return {}
-
-
-def get_studio_project_anatomy():
-    """Studio overrides of default project anatomy data."""
-    if os.path.exists(PROJECT_ANATOMY_PATH):
-        return load_json_file(PROJECT_ANATOMY_PATH)
-    return {}
-
-
 def path_to_project_settings(project_name):
     if not project_name:
         return PROJECT_SETTINGS_PATH
@@ -347,6 +326,27 @@ def save_project_anatomy(project_name, anatomy_data):
     ))
     with open(project_anatomy_json_path, "w") as file_stream:
         json.dump(anatomy_data, file_stream, indent=4)
+
+
+def get_studio_overrides_system_settings():
+    """Studio overrides of system settings."""
+    if os.path.exists(SYSTEM_SETTINGS_PATH):
+        return load_json_file(SYSTEM_SETTINGS_PATH)
+    return {}
+
+
+def get_studio_overrides_default_project_settings():
+    """Studio overrides of default project settings."""
+    if os.path.exists(PROJECT_SETTINGS_PATH):
+        return load_json_file(PROJECT_SETTINGS_PATH)
+    return {}
+
+
+def get_studio_overrides_default_project_anatomy():
+    """Studio overrides of default project anatomy data."""
+    if os.path.exists(PROJECT_ANATOMY_PATH):
+        return load_json_file(PROJECT_ANATOMY_PATH)
+    return {}
 
 
 def get_project_settings_overrides(project_name):

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -5,6 +5,9 @@ import copy
 
 log = logging.getLogger(__name__)
 
+# Py2 + Py3 json decode exception
+JSON_EXC = getattr(json.decoder, "JSONDecodeError", ValueError)
+
 # Metadata keys for work with studio and project overrides
 M_OVERRIDEN_KEY = "__overriden_keys__"
 # Metadata key for storing information about environments
@@ -82,7 +85,7 @@ def load_json_file(fpath):
         with open(fpath, "r") as opened_file:
             return json.load(opened_file)
 
-    except json.decoder.JSONDecodeError:
+    except JSON_EXC:
         log.warning(
             "File has invalid json format \"{}\"".format(fpath),
             exc_info=True

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -464,6 +464,22 @@ def get_project_settings(project_name):
     return apply_overrides(studio_overrides, project_overrides)
 
 
+def get_current_project_settings():
+    """Project settings for current context project.
+
+    Project name should be stored in environment variable `AVALON_PROJECT`.
+    This function should be used only in host context where environment
+    variable must be set and should not happen that any part of process will
+    change the value of the enviornment variable.
+    """
+    project_name = os.environ.get("AVALON_PROJECT")
+    if not project_name:
+        raise ValueError(
+            "Missing context project in environemt variable `AVALON_PROJECT`."
+        )
+    return get_project_settings(project_name)
+
+
 def get_environments():
     """Calculated environment based on defaults and system settings.
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -12,9 +12,9 @@ from pype.settings.lib import (
     reset_default_settings,
     get_default_settings,
 
-    get_studio_system_settings,
-    get_studio_project_settings,
-    get_studio_project_anatomy,
+    get_studio_overrides_system_settings,
+    get_studio_overrides_default_project_settings,
+    get_studio_overrides_default_project_anatomy,
 
     get_project_settings_overrides,
     get_project_anatomy_overrides,
@@ -384,7 +384,7 @@ class SystemWidget(SettingsCategoryWidget):
             system_values = lib.NOT_SET
         else:
             system_values = lib.convert_overrides_to_gui_data(
-                {self.main_schema_key: get_studio_system_settings()}
+                {self.main_schema_key: get_studio_overrides_system_settings()}
             )
 
         for input_field in self.input_fields:
@@ -609,8 +609,12 @@ class ProjectWidget(SettingsCategoryWidget):
         else:
             studio_values = lib.convert_overrides_to_gui_data({
                 self.main_schema_key: {
-                    PROJECT_SETTINGS_KEY: get_studio_project_settings(),
-                    PROJECT_ANATOMY_KEY: get_studio_project_anatomy()
+                    PROJECT_SETTINGS_KEY: (
+                        get_studio_overrides_default_project_settings()
+                    ),
+                    PROJECT_ANATOMY_KEY: (
+                        get_studio_overrides_default_project_anatomy()
+                    )
                 }
             })
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -12,8 +12,8 @@ from pype.settings.lib import (
     reset_default_settings,
     get_default_settings,
 
-    get_studio_overrides_system_settings,
-    get_studio_overrides_default_project_settings,
+    get_studio_system_settings_overrides,
+    get_studio_project_settings_overrides,
     get_studio_overrides_default_project_anatomy,
 
     get_project_settings_overrides,
@@ -384,7 +384,7 @@ class SystemWidget(SettingsCategoryWidget):
             system_values = lib.NOT_SET
         else:
             system_values = lib.convert_overrides_to_gui_data(
-                {self.main_schema_key: get_studio_overrides_system_settings()}
+                {self.main_schema_key: get_studio_system_settings_overrides()}
             )
 
         for input_field in self.input_fields:
@@ -610,7 +610,7 @@ class ProjectWidget(SettingsCategoryWidget):
             studio_values = lib.convert_overrides_to_gui_data({
                 self.main_schema_key: {
                     PROJECT_SETTINGS_KEY: (
-                        get_studio_overrides_default_project_settings()
+                        get_studio_project_settings_overrides()
                     ),
                     PROJECT_ANATOMY_KEY: (
                         get_studio_overrides_default_project_anatomy()

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -10,14 +10,14 @@ from pype.settings.lib import (
     DEFAULTS_DIR,
 
     reset_default_settings,
-    default_settings,
+    get_default_settings,
 
-    studio_system_settings,
-    studio_project_settings,
-    studio_project_anatomy,
+    get_studio_system_settings,
+    get_studio_project_settings,
+    get_studio_project_anatomy,
 
-    project_settings_overrides,
-    project_anatomy_overrides,
+    get_project_settings_overrides,
+    get_project_anatomy_overrides,
 
     save_studio_settings,
     save_project_settings,
@@ -322,7 +322,7 @@ class SystemWidget(SettingsCategoryWidget):
     def duplicated_env_group_validation(self, values=None, overrides=None):
         try:
             if overrides is not None:
-                default_values = default_settings()[SYSTEM_SETTINGS_KEY]
+                default_values = get_default_settings()[SYSTEM_SETTINGS_KEY]
                 values = apply_overrides(default_values, overrides)
             else:
                 values = copy.deepcopy(values)
@@ -375,7 +375,7 @@ class SystemWidget(SettingsCategoryWidget):
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data({
-            self.main_schema_key: default_settings()[SYSTEM_SETTINGS_KEY]
+            self.main_schema_key: get_default_settings()[SYSTEM_SETTINGS_KEY]
         })
         for input_field in self.input_fields:
             input_field.update_default_values(default_values)
@@ -384,7 +384,7 @@ class SystemWidget(SettingsCategoryWidget):
             system_values = lib.NOT_SET
         else:
             system_values = lib.convert_overrides_to_gui_data(
-                {self.main_schema_key: studio_system_settings()}
+                {self.main_schema_key: get_studio_system_settings()}
             )
 
         for input_field in self.input_fields:
@@ -549,8 +549,8 @@ class ProjectWidget(SettingsCategoryWidget):
             _project_anatomy = lib.NOT_SET
             self.is_overidable = False
         else:
-            _project_overrides = project_settings_overrides(project_name)
-            _project_anatomy = project_anatomy_overrides(project_name)
+            _project_overrides = get_project_settings_overrides(project_name)
+            _project_anatomy = get_project_anatomy_overrides(project_name)
             self.is_overidable = True
 
         overrides = {self.main_schema_key: {
@@ -590,16 +590,16 @@ class ProjectWidget(SettingsCategoryWidget):
         project_anatomy_data = output_data.get(PROJECT_ANATOMY_KEY, {})
         save_project_anatomy(self.project_name, project_anatomy_data)
 
-        if self.project_name:
-            # Refill values with overrides
-            self._on_project_change()
-        else:
+        if studio_overrides:
             # Update saved values
             self._update_values()
+        else:
+            # Refill values with overrides
+            self._on_project_change()
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data(
-            {self.main_schema_key: default_settings()}
+            {self.main_schema_key: get_default_settings()}
         )
         for input_field in self.input_fields:
             input_field.update_default_values(default_values)
@@ -609,8 +609,8 @@ class ProjectWidget(SettingsCategoryWidget):
         else:
             studio_values = lib.convert_overrides_to_gui_data({
                 self.main_schema_key: {
-                    PROJECT_SETTINGS_KEY: studio_project_settings(),
-                    PROJECT_ANATOMY_KEY: studio_project_anatomy()
+                    PROJECT_SETTINGS_KEY: get_studio_project_settings(),
+                    PROJECT_ANATOMY_KEY: get_studio_project_anatomy()
                 }
             })
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -14,7 +14,7 @@ from pype.settings.lib import (
 
     get_studio_system_settings_overrides,
     get_studio_project_settings_overrides,
-    get_studio_overrides_default_project_anatomy,
+    get_studio_project_anatomy_overrides,
 
     get_project_settings_overrides,
     get_project_anatomy_overrides,
@@ -613,7 +613,7 @@ class ProjectWidget(SettingsCategoryWidget):
                         get_studio_project_settings_overrides()
                     ),
                     PROJECT_ANATOMY_KEY: (
-                        get_studio_overrides_default_project_anatomy()
+                        get_studio_project_anatomy_overrides()
                     )
                 }
             })


### PR DESCRIPTION
## Changes
- added verb `get` to settings getter functions
    - at the same time "get overrides" functions were renamed to make more sence (these return only override data which should be applied to existing settings)
          - `studio_system_settings` -> `get_studio_overrides_system_settings`
          - `studio_project_settings` -> `get_studio_overrides_default_project_settings`
          - `studio_project_anatomy` -> `get_studio_overrides_default_project_anatomy`

- implemented functions:
    - `get_default_project_settings` - return studio's default project settings
    - `get_default_project_anatomy_data` - return studio's default project anatomy data
    - `get_anatomy_data` - return anatomy data(not `Anatomy` object) for specific project 
    - `get_current_project_settings` - return project settings for current project set in env variable `AVALON_PROJECT`
- `get_environments` do not use deprecated loading of environments from json (they are already deleted)
- fixed missing json exception (for Python 2 hosts)