### PR TITLE
Project overrides fix

### DIFF
--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -236,15 +236,12 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
 
         self.save()
 
-        self._update_values()
-
     def _on_refresh(self):
         self.reset()
 
     def _on_hide_studio_overrides(self, state):
         self._hide_studio_overrides = (state == QtCore.Qt.Checked)
         self._update_values()
-        self.hierarchical_style_update()
 
     def _save_as_defaults(self):
         if not self.items_are_valid():
@@ -288,7 +285,6 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         reset_default_settings()
 
         self._update_values()
-        self.hierarchical_style_update()
 
     def _update_values(self):
         self.ignore_value_changes = True
@@ -372,6 +368,8 @@ class SystemWidget(SettingsCategoryWidget):
             return
 
         save_studio_settings(values)
+
+        self._update_values()
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data({

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -236,6 +236,8 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
 
         self.save()
 
+        self._update_values()
+
     def _on_refresh(self):
         self.reset()
 
@@ -368,8 +370,6 @@ class SystemWidget(SettingsCategoryWidget):
             return
 
         save_studio_settings(values)
-
-        self._update_values()
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data({
@@ -588,14 +588,10 @@ class ProjectWidget(SettingsCategoryWidget):
         project_anatomy_data = output_data.get(PROJECT_ANATOMY_KEY, {})
         save_project_anatomy(self.project_name, project_anatomy_data)
 
-        if studio_overrides:
-            # Update saved values
-            self._update_values()
-        else:
-            # Refill values with overrides
-            self._on_project_change()
-
     def update_values(self):
+        if not self.project_name is None:
+            self._on_project_change()
+            return
         default_values = lib.convert_data_to_gui_data(
             {self.main_schema_key: get_default_settings()}
         )

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -589,9 +589,10 @@ class ProjectWidget(SettingsCategoryWidget):
         save_project_anatomy(self.project_name, project_anatomy_data)
 
     def update_values(self):
-        if not self.project_name is None:
+        if self.project_name is not None:
             self._on_project_change()
             return
+
         default_values = lib.convert_data_to_gui_data(
             {self.main_schema_key: get_default_settings()}
         )

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -326,9 +326,11 @@ class SettingObject:
             return True
 
         if self.is_overidable:
+            if self.as_widget:
+                return self._was_overriden != self.is_overriden
             return self.was_overriden != self.is_overriden
-        else:
-            return self.has_studio_override != self.had_studio_override
+
+        return self.has_studio_override != self.had_studio_override
 
     @property
     def is_overriden(self):

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -2347,9 +2347,9 @@ class ModifiableDictItem(QtWidgets.QWidget, SettingObject):
         if self._is_empty:
             return False
         return (
-            self.is_value_modified()
-            or self.is_key_modified()
+            self.is_key_modified()
             or self.is_key_label_modified()
+            or self.is_value_modified()
         )
 
     def hierarchical_style_update(self):

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1744,7 +1744,9 @@ class ListWidget(QtWidgets.QWidget, InputObject):
 
     def apply_overrides(self, parent_values):
         self._is_modified = False
-        if parent_values is NOT_SET or self.key not in parent_values:
+        if self.as_widget:
+            override_value = parent_values
+        elif parent_values is NOT_SET or self.key not in parent_values:
             override_value = NOT_SET
         else:
             override_value = parent_values[self.key]


### PR DESCRIPTION
## Issue
- seems like project overrides are not applied on save
    - they are filled right but when they are applied they are overriden with default project overrides

## Changes
- make sure `_update_values` won't apply default project if any project is selected in project's view