### PR TITLE
Foundry apps launch fix

### DIFF
--- a/pype/hooks/global/pre_with_windows_shell.py
+++ b/pype/hooks/global/pre_with_windows_shell.py
@@ -1,0 +1,25 @@
+import os
+from pype.lib import PreLaunchHook
+
+
+class LaunchWithWindowsShell(PreLaunchHook):
+    """Add shell command before executable.
+
+    Some hosts have issues when are launched directly from python in that case
+    it is possible to prepend shell executable which will trigger process
+    instead.
+    """
+
+    order = 10
+    app_groups = ["nuke", "nukex", "hiero", "nukestudio"]
+    platforms = ["windows"]
+
+    def execute(self):
+        # Get comspec which is cmd.exe in most cases.
+        comspec = os.environ.get("COMSPEC", "cmd.exe")
+        # Add comspec to arguments list and add "/k"
+        title = self.application.full_label
+        new_args = [comspec, "/c"]
+        new_args.extend(self.launch_context.launch_args)
+        # Replace launch args with new one
+        self.launch_context.launch_args = new_args

--- a/pype/hooks/global/pre_with_windows_shell.py
+++ b/pype/hooks/global/pre_with_windows_shell.py
@@ -18,7 +18,6 @@ class LaunchWithWindowsShell(PreLaunchHook):
         # Get comspec which is cmd.exe in most cases.
         comspec = os.environ.get("COMSPEC", "cmd.exe")
         # Add comspec to arguments list and add "/k"
-        title = self.application.full_label
         new_args = [comspec, "/c"]
         new_args.extend(self.launch_context.launch_args)
         # Replace launch args with new one


### PR DESCRIPTION
## Issue
- some applications have issues when are launched directly from python process namely foundry products but may be more

## Changes
- implemented prelaunch hook that add shell executable before app executable
    - this will cause that application is launched the same way as from command line or .bat

## TODO
- we should check if this is also issue for Linux and Mac launch