### PR TITLE
Python 2: make user settings compatible with python 2 hosts

### DIFF
--- a/pype.py
+++ b/pype.py
@@ -145,6 +145,8 @@ def boot():
         os.environ["PYPE_ROOT"] = pype_root
         repos = os.listdir(os.path.join(pype_root, "repos"))
         repos = [os.path.join(pype_root, "repos", repo) for repo in repos]
+        # add self to python paths
+        repos.insert(0, pype_root)
         for repo in repos:
             sys.path.append(repo)
 

--- a/pype/hosts/maya/menu.py
+++ b/pype/hosts/maya/menu.py
@@ -8,7 +8,7 @@ from ...lib import BuildWorkfile
 import maya.cmds as cmds
 
 self = sys.modules[__name__]
-self._menu = os.environ['PYPE_STUDIO_NAME']
+self._menu = os.environ.get('PYPE_STUDIO_NAME') or "Pype"
 
 log = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pytest-print
 pyqt5
 Qt.py
 speedcopy
+six
 Sphinx
 sphinx-rtd-theme
 sphinxcontrib-websupport


### PR DESCRIPTION
## Problem

This solves problem when `user_settings` was written with Python 3 features but was pulled into Python 2 hosts. It also changes Pype so it adds itself to Python paths.