### PR TITLE
Launcher actions update

### DIFF
--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -129,10 +129,6 @@ class ActionModel(QtGui.QStandardItemModel):
 
     def discover(self):
         """Set up Actions cache. Run this for each new project."""
-        if not self.dbcon.Session.get("AVALON_PROJECT"):
-            self._registered_actions = list()
-            return
-
         # Discover all registered actions
         actions = api.discover(api.Action)
 
@@ -144,6 +140,9 @@ class ActionModel(QtGui.QStandardItemModel):
 
     def get_application_actions(self):
         actions = []
+        if not self.dbcon.Session.get("AVALON_PROJECT"):
+            return actions
+
         project_doc = self.dbcon.find_one({"type": "project"})
         if not project_doc:
             return actions

--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -184,6 +184,8 @@ class ActionModel(QtGui.QStandardItemModel):
 
         self._groups.clear()
 
+        self.discover()
+
         actions = self.filter_compatible_actions(self._registered_actions)
 
         self.beginResetModel()

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -186,6 +186,7 @@ class AssetsPanel(QtWidgets.QWidget):
         # signals
         project_bar.project_changed.connect(self.on_project_changed)
         assets_widget.selection_changed.connect(self.on_asset_changed)
+        assets_widget.refreshed.connect(self.on_asset_changed)
         btn_back.clicked.connect(self.back_clicked)
 
         # Force initial refresh for the assets since we might not be
@@ -205,9 +206,6 @@ class AssetsPanel(QtWidgets.QWidget):
         project_name = self.project_bar.get_current_project()
         self.dbcon.Session["AVALON_PROJECT"] = project_name
         self.assets_widget.refresh()
-
-        # Force asset change callback to ensure tasks are correctly reset
-        self.assets_widget.refreshed.connect(self.on_asset_changed)
 
     def on_asset_changed(self):
         """Callback on asset selection changed


### PR DESCRIPTION
## Issue
- actions in launcher are not discovered at all if project is not set

## Chagnes
- do not skip all actions discover if project is not available only skip applications
- trigger discover on refresh