### PR TITLE
Ftrack action to push hierarchical values

### DIFF
--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -5,7 +5,37 @@ from pype.modules.ftrack.lib import ServerAction
 
 
 class PushFrameValuesToTaskAction(ServerAction):
-    """Action for testing purpose or as base for new actions."""
+    """Action push hierarchical custom attribute values to non hierarchical.
+
+    Hierarchical value is also pushed to their task entities.
+
+    Action has 3 configurable attributes:
+    - `role_list`: List of use roles that can discover the action.
+    - `interest_attributes`: Keys of custom attributes that will be looking
+        for to push values. Attribute key must have both custom attribute types
+        hierarchical and on specific object type (entity type).
+    - `interest_entity_types`: Entity types that will be in focus of pushing
+        hierarchical to object type's custom attribute.
+
+    EXAMPLE:
+    * Before action
+    |_ Project
+      |_ Shot1
+        - hierarchical custom attribute value: `frameStart`: 1001
+        - custom attribute for `Shot`: frameStart: 1
+        |_ Task1
+            - hierarchical custom attribute value: `frameStart`: 10
+            - custom attribute for `Task`: frameStart: 0
+
+    * After action
+    |_ Project
+      |_ Shot1
+        - hierarchical custom attribute value: `frameStart`: 1001
+        - custom attribute for `Shot`: frameStart: 1001
+        |_ Task1
+            - hierarchical custom attribute value: `frameStart`: 1001
+            - custom attribute for `Task`: frameStart: 1001
+    """
 
     identifier = "admin.push_frame_values_to_task"
     label = "Pype Admin"

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -41,7 +41,7 @@ class PushFrameValuesToTaskAction(ServerAction):
         # Check if selection is valid
         for ent in event["data"]["selection"]:
             # Ignore entities that are not tasks or projects
-            if ent["entityType"].lower() == "show":
+            if ent["entityType"].lower() in ("task", "show"):
                 return True
         return False
 

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -14,6 +14,9 @@ class PushFrameValuesToTaskAction(ServerAction):
     label = "Pype Admin"
     variant = "- Push Frame values to Task"
 
+    hierarchy_entities_query = (
+        "select id, parent_id from TypedContext where project_id is \"{}\""
+    )
     entities_query = (
         "select id, name, parent_id, link from TypedContext"
         " where project_id is \"{}\" and object_type_id in ({})"
@@ -28,13 +31,10 @@ class PushFrameValuesToTaskAction(ServerAction):
         " where entity_id in ({}) and configuration_id in ({})"
     )
 
-    pushing_entity_types = {"Shot"}
-    hierarchical_custom_attribute_keys = {"frameStart", "frameEnd"}
-    custom_attribute_mapping = {
-        "frameStart": "fstart",
-        "frameEnd": "fend"
-    }
-    role_list = {"Pypeclub", "Administrator", "Project Manager"}
+    # configurable
+    interest_entity_types = ["Shot"]
+    interest_attributes = ["frameStart", "frameEnd"]
+    role_list = ["Pypeclub", "Administrator", "Project Manager"]
 
     def discover(self, session, entities, event):
         """ Validation """

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -4,7 +4,7 @@ import ftrack_api
 from pype.modules.ftrack.lib import ServerAction
 
 
-class PushFrameValuesToTaskAction(ServerAction):
+class PushHierValuesToNonHier(ServerAction):
     """Action push hierarchical custom attribute values to non hierarchical.
 
     Hierarchical value is also pushed to their task entities.
@@ -37,9 +37,9 @@ class PushFrameValuesToTaskAction(ServerAction):
             - custom attribute for `Task`: frameStart: 1001
     """
 
-    identifier = "admin.push_frame_values_to_task"
+    identifier = "admin.push_hier_values_to_non_hier"
     label = "Pype Admin"
-    variant = "- Push Frame values to Task"
+    variant = "- Push Hierarchical values To Non-Hierarchical"
 
     hierarchy_entities_query = (
         "select id, parent_id from TypedContext where project_id is \"{}\""
@@ -425,4 +425,4 @@ class PushFrameValuesToTaskAction(ServerAction):
 
 
 def register(session, plugins_presets={}):
-    PushFrameValuesToTaskAction(session, plugins_presets).register()
+    PushHierValuesToNonHier(session, plugins_presets).register()

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -7,9 +7,6 @@ from pype.modules.ftrack.lib import ServerAction
 class PushFrameValuesToTaskAction(ServerAction):
     """Action for testing purpose or as base for new actions."""
 
-    # Ignore event handler by default
-    ignore_me = True
-
     identifier = "admin.push_frame_values_to_task"
     label = "Pype Admin"
     variant = "- Push Frame values to Task"

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -207,6 +207,12 @@ class PushHierValuesToNonHier(ServerAction):
             obj_id = entity["object_type_id"]
             entities_by_obj_id[obj_id].append(entity_id)
 
+        if not non_task_entity_ids:
+            return {
+                "success": True,
+                "message": "Nothing to do in your selection."
+            }
+
         self.log.debug("Getting Hierarchical custom attribute values parents.")
         hier_values_by_entity_id = self.get_hier_values(
             session,

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -198,8 +198,18 @@ class PushFrameValuesToTaskAction(ServerAction):
         )
 
 
+    def all_hierarchy_ids(self, session, project_entity):
+        parent_id_by_entity_id = {}
 
+        hierarchy_entities = session.query(
+            self.hierarchy_entities_query.format(project_entity["id"])
         )
+        for hierarchy_entity in hierarchy_entities:
+            entity_id = hierarchy_entity["id"]
+            parent_id = hierarchy_entity["parent_id"]
+            parent_id_by_entity_id[entity_id] = parent_id
+        return parent_id_by_entity_id
+
 
 
 

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -196,59 +196,13 @@ class PushFrameValuesToTaskAction(ServerAction):
             non_task_entities,
             hier_values_by_entity_id
         )
-        if task_missing_keys:
-            missing_keys_by_object_name["Task"] = task_missing_keys
-        if missing_keys_by_object_name:
-            self.report(missing_keys_by_object_name, event)
-        return True
 
-    def report(self, missing_keys_by_object_name, event):
-        splitter = {"type": "label", "value": "---"}
 
-        title = "Push Custom Attribute values report:"
 
-        items = []
-        items.append({
-            "type": "label",
-            "value": "# Pushing values was not complete"
-        })
-        items.append({
-            "type": "label",
-            "value": (
-                "<p>It was due to missing custom"
-                " attribute configurations for specific entity type/s."
-                " These configurations are not created automatically.</p>"
-            )
-        })
-
-        log_message_items = []
-        log_message_item_template = (
-            "Entity type \"{}\" does not have created Custom Attribute/s: {}"
         )
-        for object_name, missing_attr_names in (
-            missing_keys_by_object_name.items()
-        ):
-            log_message_items.append(log_message_item_template.format(
-                object_name, self.join_keys(missing_attr_names)
-            ))
 
-            items.append(splitter)
-            items.append({
-                "type": "label",
-                "value": "## Entity type: {}".format(object_name)
-            })
 
-            items.append({
-                "type": "label",
-                "value": "<p>{}</p>".format("<br>".join(missing_attr_names))
-            })
 
-        self.log.warning((
-            "Couldn't finish pushing attribute values because"
-            " few entity types miss Custom attribute configurations:\n{}"
-        ).format("\n".join(log_message_items)))
-
-        self.show_interface(items, title, event)
 
     def get_hier_values(self, session, hier_attrs, focus_entity_ids):
         joined_entity_ids = self.join_keys(focus_entity_ids)

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -61,8 +61,7 @@ class PushFrameValuesToTaskAction(ServerAction):
         session.commit()
 
         try:
-            project_entity = self.get_project_from_entity(entities[0])
-            result = self.propagate_values(session, project_entity, event)
+            result = self.propagate_values(session, entities)
             job["status"] = "done"
             session.commit()
 
@@ -103,10 +102,10 @@ class PushFrameValuesToTaskAction(ServerAction):
             output[obj_id].append(attr)
         return output, hiearchical
 
-    def join_keys(self, items):
-        return ",".join(["\"{}\"".format(item) for item in items])
+    def propagate_values(self, session, selected_entities):
+        project_entity = self.get_project_from_entity(selected_entities[0])
+        selected_ids = [entity["id"] for entity in selected_entities]
 
-    def propagate_values(self, session, project_entity, event):
         self.log.debug("Querying project's entities \"{}\".".format(
             project_entity["full_name"]
         ))

--- a/pype/modules/ftrack/lib/ftrack_base_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_base_handler.py
@@ -37,6 +37,11 @@ class BaseHandler(object):
     preactions = []
     role_list = []
 
+    @staticmethod
+    def join_query_keys(keys):
+        """Helper to join keys to query."""
+        return ",".join(["\"{}\"".format(key) for key in keys])
+
     def __init__(self, session, plugins_presets=None):
         '''Expects a ftrack_api.Session instance'''
         self.log = Logger().get_logger(self.__class__.__name__)


### PR DESCRIPTION
## Changes
- modified `PushFrameValuesToTaskAction` action to be able push hierarchical values to non hierachical custom attributes and it's tasks
- pushing these values is applied on selection and all children under selection
- configurable attributes
    - `interest_attributes` - attributes that will be pushed from hierarchical custom attribute to object type(entity type) specific (Default: `["frameStart", "frameEnd"]`)
    - `interest_entity_types` -  entitiy types on which this will be applied (Default: `["Shot"]`)