### PR TITLE
add settings, tray and mongo launcher

### DIFF
--- a/dev_mongo.ps1
+++ b/dev_mongo.ps1
@@ -1,0 +1,2 @@
+.\venv\Scripts\Activate.ps1
+python pype.py mongodb

--- a/dev_settings.ps1
+++ b/dev_settings.ps1
@@ -1,0 +1,2 @@
+.\venv\Scripts\Activate.ps1
+python pype.py settings --dev

--- a/dev_tray.ps1
+++ b/dev_tray.ps1
@@ -1,0 +1,2 @@
+.\venv\Scripts\Activate.ps1
+python pype.py tray --debug


### PR DESCRIPTION
in 3.0 we need to activate venv and then run pype with arguments to get it running from source. I've added a few helper launchers, so we don't have to re-type it all the time. 