### PR TITLE
TVPaint repair invalid metadata

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -40,6 +40,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
     label = "Collect Workfile Data"
     order = pyblish.api.CollectorOrder - 1.01
     hosts = ["tvpaint"]
+    actions = [ResetTVPaintWorkfileMetadata]
 
     def process(self, context):
         current_project_id = lib.execute_george("tv_projectcurrentid")

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -6,6 +6,36 @@ import avalon.api
 from avalon.tvpaint import pipeline, lib
 
 
+class ResetTVPaintWorkfileMetadata(pyblish.api.Action):
+    """Fix invalid metadata in workfile."""
+    label = "Reset invalid workfile metadata"
+    on = "failed"
+
+    def process(self, context, plugin):
+        metadata_keys = {
+            pipeline.SECTION_NAME_CONTEXT: {},
+            pipeline.SECTION_NAME_INSTANCES: [],
+            pipeline.SECTION_NAME_CONTAINERS: []
+        }
+        for metadata_key, default in metadata_keys.items():
+            json_string = pipeline.get_workfile_metadata_string(metadata_key)
+            if not json_string:
+                continue
+
+            try:
+                return json.loads(json_string)
+            except Exception:
+                self.log.warning(
+                    (
+                        "Couldn't parse metadata from key \"{}\"."
+                        " Will reset to default value \"{}\"."
+                        " Loaded value was: {}"
+                    ).format(metadata_key, default, json_string),
+                    exc_info=True
+                )
+                pipeline.write_workfile_metadata(metadata_key, default)
+
+
 class CollectWorkfileData(pyblish.api.ContextPlugin):
     label = "Collect Workfile Data"
     order = pyblish.api.CollectorOrder - 1.01


### PR DESCRIPTION
## Issue
- invalid metadata can't be fixed in TVPaint and auto repair is not safe enough to be used in production

## Changes
- implemented action that will show if workfile data collector fail
   - action tries to load all metadata keys and parse it -> if parse crash metadata keys is set to default value

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/252|