### PR TITLE
Settings store in mongo

### DIFF
--- a/pype.py
+++ b/pype.py
@@ -113,7 +113,7 @@ def boot():
         """
 
     print(art)
-    set_environments()
+
     # find pype versions
     bootstrap = BootstrapRepos()
     pype_versions = bootstrap.find_pype()
@@ -139,6 +139,7 @@ def boot():
         else:
             os.environ["PYPE_MONGO"] = pype_mongo
 
+    set_environments()
     if getattr(sys, 'frozen', False):
         if not pype_versions:
             import igniter

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -131,6 +131,8 @@ __all__ = [
     "decompose_url",
     "compose_url",
     "get_default_components",
+    "PypeMongoConnection",
+
     "IniSettingRegistry",
     "JSONSettingRegistry",
     "PypeSettingsRegistry",

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -7,7 +7,8 @@ from .log import PypeLogger, timeit
 from .mongo import (
     decompose_url,
     compose_url,
-    get_default_components
+    get_default_components,
+    PypeMongoConnection
 )
 from .anatomy import Anatomy
 

--- a/pype/settings/constants.py
+++ b/pype/settings/constants.py
@@ -16,7 +16,6 @@ METADATA_KEYS = (
 
 # File where studio's system overrides are stored
 SYSTEM_SETTINGS_KEY = "system_settings"
-ENVIRONMENTS_KEY = "environments"
 PROJECT_SETTINGS_KEY = "project_settings"
 PROJECT_ANATOMY_KEY = "project_anatomy"
 
@@ -30,7 +29,6 @@ __all__ = (
     "METADATA_KEYS",
 
     "SYSTEM_SETTINGS_KEY",
-    "ENVIRONMENTS_KEY",
     "PROJECT_SETTINGS_KEY",
     "PROJECT_ANATOMY_KEY"
 )

--- a/pype/settings/constants.py
+++ b/pype/settings/constants.py
@@ -1,0 +1,36 @@
+# Metadata keys for work with studio and project overrides
+M_OVERRIDEN_KEY = "__overriden_keys__"
+# Metadata key for storing information about environments
+M_ENVIRONMENT_KEY = "__environment_keys__"
+# Metadata key for storing dynamic created labels
+M_DYNAMIC_KEY_LABEL = "__dynamic_keys_labels__"
+# NOTE key popping not implemented yet
+M_POP_KEY = "__pop_key__"
+
+METADATA_KEYS = (
+    M_OVERRIDEN_KEY,
+    M_ENVIRONMENT_KEY,
+    M_DYNAMIC_KEY_LABEL,
+    M_POP_KEY
+)
+
+# File where studio's system overrides are stored
+SYSTEM_SETTINGS_KEY = "system_settings"
+ENVIRONMENTS_KEY = "environments"
+PROJECT_SETTINGS_KEY = "project_settings"
+PROJECT_ANATOMY_KEY = "project_anatomy"
+
+
+__all__ = (
+    "M_OVERRIDEN_KEY",
+    "M_ENVIRONMENT_KEY",
+    "M_DYNAMIC_KEY_LABEL",
+    "M_POP_KEY",
+
+    "METADATA_KEYS",
+
+    "SYSTEM_SETTINGS_KEY",
+    "ENVIRONMENTS_KEY",
+    "PROJECT_SETTINGS_KEY",
+    "PROJECT_ANATOMY_KEY"
+)

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -1,5 +1,24 @@
+import os
+import json
+import logging
 from abc import ABCMeta, abstractmethod
 import six
+import pype
+from .constants import (
+    M_OVERRIDEN_KEY,
+    M_ENVIRONMENT_KEY,
+    M_DYNAMIC_KEY_LABEL,
+    M_POP_KEY,
+
+    METADATA_KEYS,
+
+    SYSTEM_SETTINGS_KEY,
+    ENVIRONMENTS_KEY,
+    PROJECT_SETTINGS_KEY,
+    PROJECT_ANATOMY_KEY
+)
+
+JSON_EXC = getattr(json.decoder, "JSONDecodeError", ValueError)
 
 
 @six.add_metaclass(ABCMeta)
@@ -87,3 +106,192 @@ class SettingsHandler:
         """
         pass
 
+
+class SettingsFileHandler(SettingsHandler):
+    def __init__(self):
+        self.log = logging.getLogger("SettingsFileHandler")
+
+        # Folder where studio overrides are stored
+        studio_overrides_dir = os.getenv("PYPE_PROJECT_CONFIGS")
+        if not studio_overrides_dir:
+            studio_overrides_dir = os.path.dirname(os.path.dirname(
+                os.path.abspath(pype.__file__)
+            ))
+        system_settings_path = os.path.join(
+            studio_overrides_dir, SYSTEM_SETTINGS_KEY + ".json"
+        )
+
+        # File where studio's default project overrides are stored
+        project_settings_filename = PROJECT_SETTINGS_KEY + ".json"
+        project_settings_path = os.path.join(
+            studio_overrides_dir, project_settings_filename
+        )
+
+        project_anatomy_filename = PROJECT_ANATOMY_KEY + ".json"
+        project_anatomy_path = os.path.join(
+            studio_overrides_dir, project_anatomy_filename
+        )
+
+        self.studio_overrides_dir = studio_overrides_dir
+        self.system_settings_path = system_settings_path
+
+        self.project_settings_filename = project_settings_filename
+        self.project_anatomy_filename = project_anatomy_filename
+
+        self.project_settings_path = project_settings_path
+        self.project_anatomy_path = project_anatomy_path
+
+    def load_json_file(self, fpath):
+        # Load json data
+        try:
+            with open(fpath, "r") as opened_file:
+                return json.load(opened_file)
+
+        except JSON_EXC:
+            self.log.warning(
+                "File has invalid json format \"{}\"".format(fpath),
+                exc_info=True
+            )
+        return {}
+
+    def path_to_project_settings(self, project_name):
+        if not project_name:
+            return self.project_settings_path
+        return os.path.join(
+            self.studio_overrides_dir,
+            project_name,
+            self.project_settings_filename
+        )
+
+    def path_to_project_anatomy(self, project_name):
+        if not project_name:
+            return self.project_anatomy_path
+        return os.path.join(
+            self.studio_overrides_dir,
+            project_name,
+            self.project_anatomy_filename
+        )
+
+    def save_studio_settings(self, data):
+        """Save studio overrides of system settings.
+
+        Do not use to store whole system settings data with defaults but only
+        it's overrides with metadata defining how overrides should be applied
+        in load function. For loading should be used function
+        `studio_system_settings`.
+
+        Args:
+            data(dict): Data of studio overrides with override metadata.
+        """
+        dirpath = os.path.dirname(self.system_settings_path)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+
+        self.log.debug(
+            "Saving studio overrides. Output path: {}".format(
+                self.system_settings_path
+            )
+        )
+        with open(self.system_settings_path, "w") as file_stream:
+            json.dump(data, file_stream, indent=4)
+
+    def save_project_settings(self, project_name, overrides):
+        """Save studio overrides of project settings.
+
+        Data are saved for specific project or as defaults for all projects.
+
+        Do not use to store whole project settings data with defaults but only
+        it's overrides with metadata defining how overrides should be applied
+        in load function. For loading should be used function
+        `get_studio_project_settings_overrides` for global project settings
+        and `get_project_settings_overrides` for project specific settings.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+        project_overrides_json_path = self.path_to_project_settings(
+            project_name
+        )
+        dirpath = os.path.dirname(project_overrides_json_path)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+
+        self.log.debug(
+            "Saving overrides of project \"{}\". Output path: {}".format(
+                project_name, project_overrides_json_path
+            )
+        )
+        with open(project_overrides_json_path, "w") as file_stream:
+            json.dump(overrides, file_stream, indent=4)
+
+    def save_project_anatomy(self, project_name, anatomy_data):
+        """Save studio overrides of project anatomy data.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+        project_anatomy_json_path = self.path_to_project_anatomy(project_name)
+        dirpath = os.path.dirname(project_anatomy_json_path)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+
+        self.log.debug(
+            "Saving anatomy of project \"{}\". Output path: {}".format(
+                project_name, project_anatomy_json_path
+            )
+        )
+        with open(project_anatomy_json_path, "w") as file_stream:
+            json.dump(anatomy_data, file_stream, indent=4)
+
+    def get_studio_system_settings_overrides(self):
+        """Studio overrides of system settings."""
+        if os.path.exists(self.system_settings_path):
+            return self.load_json_file(self.system_settings_path)
+        return {}
+
+    def get_studio_project_settings_overrides(self):
+        """Studio overrides of default project settings."""
+        if os.path.exists(self.project_settings_path):
+            return self.load_json_file(self.project_settings_path)
+        return {}
+
+    def get_studio_project_anatomy_overrides(self):
+        """Studio overrides of default project anatomy data."""
+        if os.path.exists(self.project_anatomy_path):
+            return self.load_json_file(self.project_anatomy_path)
+        return {}
+
+    def get_project_settings_overrides(self, project_name):
+        """Studio overrides of project settings for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """
+        path_to_json = self.path_to_project_settings(project_name)
+        if not os.path.exists(path_to_json):
+            return {}
+        return self.load_json_file(path_to_json)
+
+    def get_project_anatomy_overrides(self, project_name):
+        """Studio overrides of project anatomy for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """
+        if not project_name:
+            return {}
+
+        path_to_json = self.path_to_project_anatomy(project_name)
+        if not os.path.exists(path_to_json):
+            return {}
+        return self.load_json_file(path_to_json)

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -5,15 +5,7 @@ from abc import ABCMeta, abstractmethod
 import six
 import pype
 from .constants import (
-    M_OVERRIDEN_KEY,
-    M_ENVIRONMENT_KEY,
-    M_DYNAMIC_KEY_LABEL,
-    M_POP_KEY,
-
-    METADATA_KEYS,
-
     SYSTEM_SETTINGS_KEY,
-    ENVIRONMENTS_KEY,
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY
 )
@@ -295,3 +287,75 @@ class SettingsFileHandler(SettingsHandler):
         if not os.path.exists(path_to_json):
             return {}
         return self.load_json_file(path_to_json)
+
+
+class MongoSettingsHandler(SettingsHandler):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def save_studio_settings(self, data):
+        """Save studio overrides of system settings.
+
+        Do not use to store whole system settings data with defaults but only it's
+        overrides with metadata defining how overrides should be applied in load
+        function. For loading should be used function `studio_system_settings`.
+
+        Args:
+            data(dict): Data of studio overrides with override metadata.
+        """
+
+    def save_project_settings(self, project_name, overrides):
+        """Save studio overrides of project settings.
+
+        Data are saved for specific project or as defaults for all projects.
+
+        Do not use to store whole project settings data with defaults but only it's
+        overrides with metadata defining how overrides should be applied in load
+        function. For loading should be used function
+        `get_studio_project_settings_overrides` for global project settings
+        and `get_project_settings_overrides` for project specific settings.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+
+    def save_project_anatomy(self, project_name, anatomy_data):
+        """Save studio overrides of project anatomy data.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+
+    def get_studio_system_settings_overrides(self):
+        """Studio overrides of system settings."""
+
+    def get_studio_project_settings_overrides(self):
+        """Studio overrides of default project settings."""
+
+    def get_studio_project_anatomy_overrides(self):
+        """Studio overrides of default project anatomy data."""
+
+    def get_project_settings_overrides(self, project_name):
+        """Studio overrides of project settings for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """
+
+    def get_project_anatomy_overrides(self, project_name):
+        """Studio overrides of project anatomy for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -1,5 +1,6 @@
 import os
 import json
+import copy
 import logging
 import collections
 import datetime
@@ -286,6 +287,11 @@ class CacheValues:
         self.data = None
         self.creation_time = None
 
+    def data_copy(self):
+        if not self.data:
+            return {}
+        return copy.deepcopy(self.data)
+
     def update_data(self, data):
         self.data = data
         self.creation_time = datetime.datetime.now()
@@ -424,7 +430,7 @@ class MongoSettingsHandler(SettingsHandler):
             })
 
             self.system_settings_cache.update_from_document(document)
-        return self.system_settings_cache.data
+        return self.system_settings_cache.data_copy()
 
     def _get_project_settings_overrides(self, project_name):
         if self.project_settings_cache[project_name].is_outdated:
@@ -439,7 +445,7 @@ class MongoSettingsHandler(SettingsHandler):
             self.project_settings_cache[project_name].update_from_document(
                 document
             )
-        return self.project_settings_cache[project_name].data
+        return self.project_settings_cache[project_name].data_copy()
 
     def get_studio_project_settings_overrides(self):
         """Studio overrides of default project settings."""
@@ -471,7 +477,7 @@ class MongoSettingsHandler(SettingsHandler):
             self.project_anatomy_cache[project_name].update_from_document(
                 document
             )
-        return self.project_anatomy_cache[project_name].data
+        return self.project_anatomy_cache[project_name].data_copy()
 
     def get_studio_project_anatomy_overrides(self):
         """Studio overrides of default project anatomy data."""

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import datetime
 from abc import ABCMeta, abstractmethod
 import six
 import pype
@@ -287,6 +288,34 @@ class SettingsFileHandler(SettingsHandler):
         if not os.path.exists(path_to_json):
             return {}
         return self.load_json_file(path_to_json)
+
+
+class CacheValues:
+    cache_lifetime = 10
+
+    def __init__(self):
+        self.data = None
+        self.creation_time = None
+
+    def update_data(self, data):
+        self.data = data
+        self.creation_time = datetime.datetime.now()
+
+    def update_from_document(self, document):
+        value = "{}"
+        if document:
+            value = document.get("value") or value
+        self.data = json.loads(value)
+
+    def to_json_string(self):
+        return json.dumps(self.data or {})
+
+    @property
+    def is_outdated(self):
+        if self.creation_time is None:
+            return True
+        delta = (datetime.datetime.now() - self.creation_time).seconds
+        return delta > self.cache_lifetime
 
 
 class MongoSettingsHandler(SettingsHandler):

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -11,6 +11,7 @@ from .constants import (
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY
 )
+from .lib import load_json_file
 
 JSON_EXC = getattr(json.decoder, "JSONDecodeError", ValueError)
 
@@ -135,19 +136,6 @@ class SettingsFileHandler(SettingsHandler):
         self.project_settings_path = project_settings_path
         self.project_anatomy_path = project_anatomy_path
 
-    def load_json_file(self, fpath):
-        # Load json data
-        try:
-            with open(fpath, "r") as opened_file:
-                return json.load(opened_file)
-
-        except JSON_EXC:
-            self.log.warning(
-                "File has invalid json format \"{}\"".format(fpath),
-                exc_info=True
-            )
-        return {}
-
     def path_to_project_settings(self, project_name):
         if not project_name:
             return self.project_settings_path
@@ -244,19 +232,19 @@ class SettingsFileHandler(SettingsHandler):
     def get_studio_system_settings_overrides(self):
         """Studio overrides of system settings."""
         if os.path.exists(self.system_settings_path):
-            return self.load_json_file(self.system_settings_path)
+            return load_json_file(self.system_settings_path)
         return {}
 
     def get_studio_project_settings_overrides(self):
         """Studio overrides of default project settings."""
         if os.path.exists(self.project_settings_path):
-            return self.load_json_file(self.project_settings_path)
+            return load_json_file(self.project_settings_path)
         return {}
 
     def get_studio_project_anatomy_overrides(self):
         """Studio overrides of default project anatomy data."""
         if os.path.exists(self.project_anatomy_path):
-            return self.load_json_file(self.project_anatomy_path)
+            return load_json_file(self.project_anatomy_path)
         return {}
 
     def get_project_settings_overrides(self, project_name):
@@ -271,7 +259,7 @@ class SettingsFileHandler(SettingsHandler):
         path_to_json = self.path_to_project_settings(project_name)
         if not os.path.exists(path_to_json):
             return {}
-        return self.load_json_file(path_to_json)
+        return load_json_file(path_to_json)
 
     def get_project_anatomy_overrides(self, project_name):
         """Studio overrides of project anatomy for specific project.
@@ -288,7 +276,7 @@ class SettingsFileHandler(SettingsHandler):
         path_to_json = self.path_to_project_anatomy(project_name)
         if not os.path.exists(path_to_json):
             return {}
-        return self.load_json_file(path_to_json)
+        return load_json_file(path_to_json)
 
 
 class CacheValues:

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -1,0 +1,89 @@
+from abc import ABCMeta, abstractmethod
+import six
+
+
+@six.add_metaclass(ABCMeta)
+class SettingsHandler:
+    @abstractmethod
+    def save_studio_settings(self, data):
+        """Save studio overrides of system settings.
+
+        Do not use to store whole system settings data with defaults but only
+        it's overrides with metadata defining how overrides should be applied
+        in load function. For loading should be used function
+        `studio_system_settings`.
+
+        Args:
+            data(dict): Data of studio overrides with override metadata.
+        """
+        pass
+
+    @abstractmethod
+    def save_project_settings(self, project_name, overrides):
+        """Save studio overrides of project settings.
+
+        Data are saved for specific project or as defaults for all projects.
+
+        Do not use to store whole project settings data with defaults but only
+        it's overrides with metadata defining how overrides should be applied
+        in load function. For loading should be used function
+        `get_studio_project_settings_overrides` for global project settings
+        and `get_project_settings_overrides` for project specific settings.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+        pass
+
+    @abstractmethod
+    def save_project_anatomy(self, project_name, anatomy_data):
+        """Save studio overrides of project anatomy data.
+
+        Args:
+            project_name(str, null): Project name for which overrides are
+                or None for global settings.
+            data(dict): Data of project overrides with override metadata.
+        """
+        pass
+
+    @abstractmethod
+    def get_studio_system_settings_overrides(self):
+        """Studio overrides of system settings."""
+        pass
+
+    @abstractmethod
+    def get_studio_project_settings_overrides(self):
+        """Studio overrides of default project settings."""
+        pass
+
+    @abstractmethod
+    def get_studio_project_anatomy_overrides(self):
+        """Studio overrides of default project anatomy data."""
+        pass
+
+    @abstractmethod
+    def get_project_settings_overrides(self, project_name):
+        """Studio overrides of project settings for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """
+        pass
+
+    @abstractmethod
+    def get_project_anatomy_overrides(self, project_name):
+        """Studio overrides of project anatomy for specific project.
+
+        Args:
+            project_name(str): Name of project for which data should be loaded.
+
+        Returns:
+            dict: Only overrides for entered project, may be empty dictionary.
+        """
+        pass
+

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -314,7 +314,6 @@ class MongoSettingsHandler(SettingsHandler):
 
         self.collection = settings_collection[database_name][collection_name]
 
-    @classmethod
     def save_studio_settings(self, data):
         """Save studio overrides of system settings.
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -14,10 +14,6 @@ from .constants import (
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY
 )
-from .handlers import (
-    SettingsFileHandler,
-    MongoSettingsHandler
-)
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +45,9 @@ def require_handler(func):
 
 
 def create_settings_handler():
-    # This may be logic which handler is used (in future)
+    from .handlers import MongoSettingsHandler
+    # Handler can't be created in global space on initialization but only when
+    # needed. Plus here may be logic: Which handler is used (in future).
     return MongoSettingsHandler()
 
 

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -5,13 +5,11 @@ import copy
 from .constants import (
     M_OVERRIDEN_KEY,
     M_ENVIRONMENT_KEY,
-    M_DYNAMIC_KEY_LABEL,
     M_POP_KEY,
 
     METADATA_KEYS,
 
     SYSTEM_SETTINGS_KEY,
-    ENVIRONMENTS_KEY,
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY
 )

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -2,52 +2,26 @@ import os
 import json
 import logging
 import copy
+from .constants import (
+    M_OVERRIDEN_KEY,
+    M_ENVIRONMENT_KEY,
+    M_DYNAMIC_KEY_LABEL,
+    M_POP_KEY,
+
+    METADATA_KEYS,
+
+    SYSTEM_SETTINGS_KEY,
+    ENVIRONMENTS_KEY,
+    PROJECT_SETTINGS_KEY,
+    PROJECT_ANATOMY_KEY
+)
+)
 
 log = logging.getLogger(__name__)
 
 # Py2 + Py3 json decode exception
 JSON_EXC = getattr(json.decoder, "JSONDecodeError", ValueError)
 
-# Metadata keys for work with studio and project overrides
-M_OVERRIDEN_KEY = "__overriden_keys__"
-# Metadata key for storing information about environments
-M_ENVIRONMENT_KEY = "__environment_keys__"
-# Metadata key for storing dynamic created labels
-M_DYNAMIC_KEY_LABEL = "__dynamic_keys_labels__"
-# NOTE key popping not implemented yet
-M_POP_KEY = "__pop_key__"
-
-METADATA_KEYS = (
-    M_OVERRIDEN_KEY,
-    M_ENVIRONMENT_KEY,
-    M_DYNAMIC_KEY_LABEL,
-    M_POP_KEY
-)
-
-# Folder where studio overrides are stored
-STUDIO_OVERRIDES_PATH = os.getenv("PYPE_PROJECT_CONFIGS") or ""
-
-# File where studio's system overrides are stored
-SYSTEM_SETTINGS_KEY = "system_settings"
-SYSTEM_SETTINGS_PATH = os.path.join(
-    STUDIO_OVERRIDES_PATH, SYSTEM_SETTINGS_KEY + ".json"
-)
-
-# File where studio's environment overrides are stored
-ENVIRONMENTS_KEY = "environments"
-
-# File where studio's default project overrides are stored
-PROJECT_SETTINGS_KEY = "project_settings"
-PROJECT_SETTINGS_FILENAME = PROJECT_SETTINGS_KEY + ".json"
-PROJECT_SETTINGS_PATH = os.path.join(
-    STUDIO_OVERRIDES_PATH, PROJECT_SETTINGS_FILENAME
-)
-
-PROJECT_ANATOMY_KEY = "project_anatomy"
-PROJECT_ANATOMY_FILENAME = PROJECT_ANATOMY_KEY + ".json"
-PROJECT_ANATOMY_PATH = os.path.join(
-    STUDIO_OVERRIDES_PATH, PROJECT_ANATOMY_FILENAME
-)
 
 # Path to default settings
 DEFAULTS_DIR = os.path.join(os.path.dirname(__file__), "defaults")

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -55,42 +55,42 @@ def create_settings_handler():
 
 @require_handler
 def save_studio_settings(data):
-    _SETTINGS_HANDLER.save_studio_settings(data)
+    return _SETTINGS_HANDLER.save_studio_settings(data)
 
 
 @require_handler
 def save_project_settings(project_name, overrides):
-    _SETTINGS_HANDLER.save_project_settings(project_name, overrides)
+    return _SETTINGS_HANDLER.save_project_settings(project_name, overrides)
 
 
 @require_handler
 def save_project_anatomy(project_name, anatomy_data):
-    _SETTINGS_HANDLER.save_project_anatomy(project_name, anatomy_data)
+    return _SETTINGS_HANDLER.save_project_anatomy(project_name, anatomy_data)
 
 
 @require_handler
 def get_studio_system_settings_overrides():
-    _SETTINGS_HANDLER.get_studio_system_settings_overrides()
+    return _SETTINGS_HANDLER.get_studio_system_settings_overrides()
 
 
 @require_handler
 def get_studio_project_settings_overrides():
-    _SETTINGS_HANDLER.get_studio_project_settings_overrides()
+    return _SETTINGS_HANDLER.get_studio_project_settings_overrides()
 
 
 @require_handler
 def get_studio_project_anatomy_overrides():
-    _SETTINGS_HANDLER.get_studio_project_anatomy_overrides()
+    return _SETTINGS_HANDLER.get_studio_project_anatomy_overrides()
 
 
 @require_handler
 def get_project_settings_overrides(project_name):
-    _SETTINGS_HANDLER.get_project_settings_overrides(project_name)
+    return _SETTINGS_HANDLER.get_project_settings_overrides(project_name)
 
 
 @require_handler
 def get_project_anatomy_overrides(project_name):
-    _SETTINGS_HANDLER.get_project_anatomy_overrides(project_name)
+    return _SETTINGS_HANDLER.get_project_anatomy_overrides(project_name)
 
 
 class DuplicatedEnvGroups(Exception):

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -26,7 +26,10 @@ JSON_EXC = getattr(json.decoder, "JSONDecodeError", ValueError)
 
 
 # Path to default settings
-DEFAULTS_DIR = os.path.join(os.path.dirname(__file__), "defaults")
+DEFAULTS_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "defaults"
+)
 
 # Variable where cache of default settings are stored
 _DEFAULT_SETTINGS = None

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -7,12 +7,23 @@ from pype.settings.constants import (
     PROJECT_SETTINGS_KEY,
     PROJECT_ANATOMY_KEY
 )
+
 from pype.settings.lib import (
     DEFAULTS_DIR,
-    SETTINGS_HANDLER,
 
     reset_default_settings,
     get_default_settings,
+
+    get_studio_system_settings_overrides,
+    get_studio_project_settings_overrides,
+    get_studio_project_anatomy_overrides,
+
+    get_project_settings_overrides,
+    get_project_anatomy_overrides,
+
+    save_studio_settings,
+    save_project_settings,
+    save_project_anatomy,
 
     apply_overrides,
     find_environments,
@@ -360,7 +371,7 @@ class SystemWidget(SettingsCategoryWidget):
         if not self.duplicated_env_group_validation(overrides=values):
             return
 
-        SETTINGS_HANDLER.save_studio_settings(values)
+        save_studio_settings(values)
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data({
@@ -372,11 +383,8 @@ class SystemWidget(SettingsCategoryWidget):
         if self._hide_studio_overrides:
             system_values = lib.NOT_SET
         else:
-            studio_system_overrides = (
-                SETTINGS_HANDLER.get_studio_system_settings_overrides()
-            )
             system_values = lib.convert_overrides_to_gui_data(
-                {self.main_schema_key: studio_system_overrides}
+                {self.main_schema_key: get_studio_system_settings_overrides()}
             )
 
         for input_field in self.input_fields:
@@ -540,12 +548,8 @@ class ProjectWidget(SettingsCategoryWidget):
             _project_anatomy = lib.NOT_SET
             self.is_overidable = False
         else:
-            _project_overrides = (
-                SETTINGS_HANDLER.get_project_settings_overrides(project_name)
-            )
-            _project_anatomy = (
-                SETTINGS_HANDLER.get_project_anatomy_overrides(project_name)
-            )
+            _project_overrides = get_project_settings_overrides(project_name)
+            _project_anatomy = get_project_anatomy_overrides(project_name)
             self.is_overidable = True
 
         overrides = {self.main_schema_key: {
@@ -579,15 +583,11 @@ class ProjectWidget(SettingsCategoryWidget):
 
         # Saving overrides data
         project_overrides_data = output_data.get(PROJECT_SETTINGS_KEY, {})
-        SETTINGS_HANDLER.save_project_settings(
-            self.project_name, project_overrides_data
-        )
+        save_project_settings(self.project_name, project_overrides_data)
 
         # Saving anatomy data
         project_anatomy_data = output_data.get(PROJECT_ANATOMY_KEY, {})
-        SETTINGS_HANDLER.save_project_anatomy(
-            self.project_name, project_anatomy_data
-        )
+        save_project_anatomy(self.project_name, project_anatomy_data)
 
     def update_values(self):
         if self.project_name is not None:
@@ -603,16 +603,14 @@ class ProjectWidget(SettingsCategoryWidget):
         if self._hide_studio_overrides:
             studio_values = lib.NOT_SET
         else:
-            project_settings_value = (
-                SETTINGS_HANDLER.get_studio_project_settings_overrides()
-            )
-            project_anatomy_value = (
-                SETTINGS_HANDLER.get_studio_project_anatomy_overrides()
-            )
             studio_values = lib.convert_overrides_to_gui_data({
                 self.main_schema_key: {
-                    PROJECT_SETTINGS_KEY: project_settings_value,
-                    PROJECT_ANATOMY_KEY: project_anatomy_value
+                    PROJECT_SETTINGS_KEY: (
+                        get_studio_project_settings_overrides()
+                    ),
+                    PROJECT_ANATOMY_KEY: (
+                        get_studio_project_anatomy_overrides()
+                    )
                 }
             })
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -9,20 +9,10 @@ from pype.settings.constants import (
 )
 from pype.settings.lib import (
     DEFAULTS_DIR,
+    SETTINGS_HANDLER,
 
     reset_default_settings,
     get_default_settings,
-
-    get_studio_system_settings_overrides,
-    get_studio_project_settings_overrides,
-    get_studio_project_anatomy_overrides,
-
-    get_project_settings_overrides,
-    get_project_anatomy_overrides,
-
-    save_studio_settings,
-    save_project_settings,
-    save_project_anatomy,
 
     apply_overrides,
     find_environments,
@@ -370,7 +360,7 @@ class SystemWidget(SettingsCategoryWidget):
         if not self.duplicated_env_group_validation(overrides=values):
             return
 
-        save_studio_settings(values)
+        SETTINGS_HANDLER.save_studio_settings(values)
 
     def update_values(self):
         default_values = lib.convert_data_to_gui_data({
@@ -382,8 +372,11 @@ class SystemWidget(SettingsCategoryWidget):
         if self._hide_studio_overrides:
             system_values = lib.NOT_SET
         else:
+            studio_system_overrides = (
+                SETTINGS_HANDLER.get_studio_system_settings_overrides()
+            )
             system_values = lib.convert_overrides_to_gui_data(
-                {self.main_schema_key: get_studio_system_settings_overrides()}
+                {self.main_schema_key: studio_system_overrides}
             )
 
         for input_field in self.input_fields:
@@ -547,8 +540,12 @@ class ProjectWidget(SettingsCategoryWidget):
             _project_anatomy = lib.NOT_SET
             self.is_overidable = False
         else:
-            _project_overrides = get_project_settings_overrides(project_name)
-            _project_anatomy = get_project_anatomy_overrides(project_name)
+            _project_overrides = (
+                SETTINGS_HANDLER.get_project_settings_overrides(project_name)
+            )
+            _project_anatomy = (
+                SETTINGS_HANDLER.get_project_anatomy_overrides(project_name)
+            )
             self.is_overidable = True
 
         overrides = {self.main_schema_key: {
@@ -582,11 +579,15 @@ class ProjectWidget(SettingsCategoryWidget):
 
         # Saving overrides data
         project_overrides_data = output_data.get(PROJECT_SETTINGS_KEY, {})
-        save_project_settings(self.project_name, project_overrides_data)
+        SETTINGS_HANDLER.save_project_settings(
+            self.project_name, project_overrides_data
+        )
 
         # Saving anatomy data
         project_anatomy_data = output_data.get(PROJECT_ANATOMY_KEY, {})
-        save_project_anatomy(self.project_name, project_anatomy_data)
+        SETTINGS_HANDLER.save_project_anatomy(
+            self.project_name, project_anatomy_data
+        )
 
     def update_values(self):
         if self.project_name is not None:
@@ -602,14 +603,16 @@ class ProjectWidget(SettingsCategoryWidget):
         if self._hide_studio_overrides:
             studio_values = lib.NOT_SET
         else:
+            project_settings_value = (
+                SETTINGS_HANDLER.get_studio_project_settings_overrides()
+            )
+            project_anatomy_value = (
+                SETTINGS_HANDLER.get_studio_project_anatomy_overrides()
+            )
             studio_values = lib.convert_overrides_to_gui_data({
                 self.main_schema_key: {
-                    PROJECT_SETTINGS_KEY: (
-                        get_studio_project_settings_overrides()
-                    ),
-                    PROJECT_ANATOMY_KEY: (
-                        get_studio_project_anatomy_overrides()
-                    )
+                    PROJECT_SETTINGS_KEY: project_settings_value,
+                    PROJECT_ANATOMY_KEY: project_anatomy_value
                 }
             })
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -2,11 +2,12 @@ import os
 import copy
 import json
 from Qt import QtWidgets, QtCore, QtGui
-from pype.settings.lib import (
+from pype.settings.constants import (
     SYSTEM_SETTINGS_KEY,
     PROJECT_SETTINGS_KEY,
-    PROJECT_ANATOMY_KEY,
-
+    PROJECT_ANATOMY_KEY
+)
+from pype.settings.lib import (
     DEFAULTS_DIR,
 
     reset_default_settings,

--- a/pype/tools/settings/settings/widgets/lib.py
+++ b/pype/tools/settings/settings/widgets/lib.py
@@ -2,7 +2,7 @@ import os
 import re
 import json
 import copy
-from pype.settings.lib import (
+from pype.settings.constants import (
     M_OVERRIDEN_KEY,
     M_ENVIRONMENT_KEY,
     M_DYNAMIC_KEY_LABEL


### PR DESCRIPTION
## Changes
- moved first loading of environments later in pype bootstrap because `PYPE_MONGO` is required to load them
- added `PypeMongoConnection` which creates and store  mongo connections by url
    - this is good to use to not create multiple connections to one mongo
    - has no no special logic - imeplemented 2 classmethods `create_connection` and `get_mongo_client`
    - to not use multiple connections use `get_mongo_client` which create and cache the connection and checks if existing connection is alive
- settings overrides are handled by `SettingsHandler`
    - logic for storing had to be separated from `settings.lib` to separate class created on first use so it was easier to create abstraction of studio overrides handler
    - previous implementation of storing overrides to json files was kept in `SettingsFileHandler` but is not used
    - implemented `MongoSettingsHandler` which store and load data from mongo and cache them (lifetime is now hardcoded to 10 seconds)