### PR TITLE
Services menu do not popup on tray start

### DIFF
--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -150,15 +150,15 @@ class ITrayService(ITrayModule):
         if ITrayService._services_submenu is None:
             from Qt import QtWidgets
             services_submenu = QtWidgets.QMenu("Services", tray_menu)
-            services_submenu.setVisible(False)
+            services_submenu.menuAction().setVisible(False)
             ITrayService._services_submenu = services_submenu
         return ITrayService._services_submenu
 
     @staticmethod
     def add_service_action(action):
         ITrayService._services_submenu.addAction(action)
-        if not ITrayService._services_submenu.isVisible():
-            ITrayService._services_submenu.setVisible(True)
+        if not ITrayService._services_submenu.menuAction().isVisible():
+            ITrayService._services_submenu.menuAction().setVisible(True)
 
     @staticmethod
     def _load_service_icons():


### PR DESCRIPTION
## Issue
- Services menu is visible on tray start because it is set visibility on menu instead of menu's action item

## Changes
- Don't set visibility on service's menu but service's menu action.