### PR TITLE
Standalone publisher fix in 3.0

### DIFF
--- a/pype/tools/standalonepublish/app.py
+++ b/pype/tools/standalonepublish/app.py
@@ -62,6 +62,7 @@ class Window(QtWidgets.QDialog):
 
         # signals
         widget_assets.selection_changed.connect(self.on_asset_changed)
+        widget_assets.project_changed.connect(self.on_project_change)
         widget_family.stateChanged.connect(self.set_valid_family)
 
         self.widget_assets = widget_assets
@@ -115,6 +116,9 @@ class Window(QtWidgets.QDialog):
             parents.extend(self.get_avalon_parent(parent))
             parents.append(parent['name'])
         return parents
+
+    def on_project_change(self, project_name):
+        self.widget_family.refresh()
 
     def on_asset_changed(self):
         '''Callback on asset selection changed

--- a/pype/tools/standalonepublish/widgets/widget_asset.py
+++ b/pype/tools/standalonepublish/widgets/widget_asset.py
@@ -121,6 +121,7 @@ class AssetWidget(QtWidgets.QWidget):
 
     """
 
+    project_changed = QtCore.Signal(str)
     assets_refreshed = QtCore.Signal()   # on model refresh
     selection_changed = QtCore.Signal()  # on view selection change
     current_changed = QtCore.Signal()    # on view current index change
@@ -249,6 +250,9 @@ class AssetWidget(QtWidgets.QWidget):
         project_name = self.combo_projects.currentText()
         if project_name in projects:
             self.dbcon.Session["AVALON_PROJECT"] = project_name
+
+        self.project_changed.emit(project_name)
+
         self.refresh()
 
     def _refresh_model(self):

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -318,7 +318,8 @@ class FamilyWidget(QtWidgets.QWidget):
             return
         settings = get_project_settings(project_name)
         sp_settings = settings.get('standalonepublisher', {})
-        print(sp_settings)
+
+        self.list_families.clear()
 
         for key, creator in sp_settings.get("create", {}).items():
             if key == "__dynamic_keys_labels__":

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -285,7 +285,10 @@ class FamilyWidget(QtWidgets.QWidget):
         self.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
-        plugin = self.list_families.currentItem().data(PluginRole)
+        item = self.list_families.currentItem()
+        if not item:
+            return
+        plugin = item.data(PluginRole)
         if plugin is None:
             return
 

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -310,7 +310,10 @@ class FamilyWidget(QtWidgets.QWidget):
 
     def refresh(self):
         has_families = False
-        settings = get_project_settings(os.environ['AVALON_PROJECT'])
+        project_name = self.dbcon.Session.get("AVALON_PROJECT")
+        if not project_name:
+            return
+        settings = get_project_settings(project_name)
         sp_settings = settings.get('standalonepublisher', {})
         print(sp_settings)
 

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -312,14 +312,15 @@ class FamilyWidget(QtWidgets.QWidget):
         """
 
     def refresh(self):
+        self.list_families.clear()
+
         has_families = False
         project_name = self.dbcon.Session.get("AVALON_PROJECT")
         if not project_name:
             return
+
         settings = get_project_settings(project_name)
         sp_settings = settings.get('standalonepublisher', {})
-
-        self.list_families.clear()
 
         for key, creator in sp_settings.get("create", {}).items():
             if key == "__dynamic_keys_labels__":


### PR DESCRIPTION
## Issue
- family widget take project from environments which is not actual project
- family widget crash if project is not set because of settings

## Changes
- family widget skip setting families if project is not set
- family widget is refreshed on each project change