### PR TITLE
Modules keys in settings

### DIFF
--- a/pype/modules/avalon_apps/avalon_app.py
+++ b/pype/modules/avalon_apps/avalon_app.py
@@ -9,7 +9,7 @@ from .. import (
 
 
 class AvalonModule(PypeModule, ITrayModule, IRestApi):
-    name = "Avalon"
+    name = "avalon"
 
     def initialize(self, modules_settings):
         # This module is always enabled

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -384,7 +384,7 @@ class ModulesManager:
 class TrayModulesManager(ModulesManager):
     # Define order of modules in menu
     modules_menu_order = (
-        "User setting",
+        "user",
         "Ftrack",
         "muster",
         "avalon",

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -390,7 +390,7 @@ class TrayModulesManager(ModulesManager):
         "avalon",
         "clockify",
         "Standalone Publish",
-        "Logging",
+        "log_viewer",
         "settings"
     )
 

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -387,7 +387,7 @@ class TrayModulesManager(ModulesManager):
         "User setting",
         "Ftrack",
         "muster",
-        "Avalon",
+        "avalon",
         "Clockify",
         "Standalone Publish",
         "Logging",

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -388,7 +388,7 @@ class TrayModulesManager(ModulesManager):
         "ftrack",
         "muster",
         "avalon",
-        "Clockify",
+        "clockify",
         "Standalone Publish",
         "Logging",
         "settings"

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -389,7 +389,7 @@ class TrayModulesManager(ModulesManager):
         "muster",
         "avalon",
         "clockify",
-        "Standalone Publish",
+        "standalonepublish_tool",
         "log_viewer",
         "settings"
     )

--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -385,7 +385,7 @@ class TrayModulesManager(ModulesManager):
     # Define order of modules in menu
     modules_menu_order = (
         "user",
-        "Ftrack",
+        "ftrack",
         "muster",
         "avalon",
         "Clockify",

--- a/pype/modules/clockify/clockify_module.py
+++ b/pype/modules/clockify/clockify_module.py
@@ -23,7 +23,7 @@ class ClockifyModule(
     IFtrackEventHandlerPaths,
     ITimersManager
 ):
-    name = "Clockify"
+    name = "clockify"
 
     def initialize(self, modules_settings):
         clockify_settings = modules_settings[self.name]

--- a/pype/modules/ftrack/ftrack_module.py
+++ b/pype/modules/ftrack/ftrack_module.py
@@ -21,7 +21,7 @@ class IFtrackEventHandlerPaths:
 class FtrackModule(
     PypeModule, ITrayModule, IPluginPaths, ITimersManager, IUserModule
 ):
-    name = "Ftrack"
+    name = "ftrack"
 
     def initialize(self, settings):
         ftrack_settings = settings[self.name]

--- a/pype/modules/idle_manager/idle_manager.py
+++ b/pype/modules/idle_manager/idle_manager.py
@@ -41,7 +41,7 @@ class IdleManager(PypeModule, ITrayService):
     Is able to emit signals at specific time idle.
     """
     label = "Idle Service"
-    name = "Idle Manager"
+    name = "idle_manager"
 
     def initialize(self, module_settings):
         idle_man_settings = module_settings[self.name]

--- a/pype/modules/logging/logging_module.py
+++ b/pype/modules/logging/logging_module.py
@@ -3,7 +3,7 @@ from .. import PypeModule, ITrayModule
 
 
 class LoggingModule(PypeModule, ITrayModule):
-    name = "Logging"
+    name = "log_viewer"
 
     def initialize(self, modules_settings):
         logging_settings = modules_settings[self.name]

--- a/pype/modules/rest_api/rest_api.py
+++ b/pype/modules/rest_api/rest_api.py
@@ -97,7 +97,7 @@ class RestApiModule(PypeModule, ITrayService):
     `_handle_callback_result` defined in handler.
     """
     label = "Rest API Service"
-    name = "Rest Api"
+    name = "rest_api"
 
     def initialize(self, modules_settings):
         rest_api_settings = modules_settings[self.name]

--- a/pype/modules/standalonepublish/standalonepublish_module.py
+++ b/pype/modules/standalonepublish/standalonepublish_module.py
@@ -7,7 +7,7 @@ from .. import PypeModule, ITrayModule
 
 class StandAlonePublishModule(PypeModule, ITrayModule):
     menu_label = "Publish"
-    name = "Standalone Publish"
+    name = "standalonepublish_tool"
 
     def initialize(self, modules_settings):
         self.enabled = modules_settings[self.name]["enabled"]

--- a/pype/modules/timers_manager/timers_manager.py
+++ b/pype/modules/timers_manager/timers_manager.py
@@ -35,7 +35,7 @@ class TimersManager(PypeModule, ITrayService, IIdleManager):
     If IdleManager is imported then is able to handle about stop timers
         when user idles for a long time (set in presets).
     """
-    name = "Timers Manager"
+    name = "timers_manager"
     label = "Timers Service"
 
     def initialize(self, modules_settings):

--- a/pype/modules/user/user_module.py
+++ b/pype/modules/user/user_module.py
@@ -27,7 +27,7 @@ class UserModule(PypeModule, ITrayModule, IRestApi):
     cred_filename = 'user_info.json'
     env_name = "PYPE_USERNAME"
 
-    name = "User setting"
+    name = "user"
 
     def initialize(self, modules_settings):
         user_settings = modules_settings[self.name]

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -141,7 +141,7 @@
     "Logging": {
         "enabled": true
     },
-    "User setting": {
+    "user": {
         "enabled": true
     },
     "Standalone Publish": {

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -147,7 +147,7 @@
     "standalonepublish_tool": {
         "enabled": true
     },
-    "Idle Manager": {
+    "idle_manager": {
         "enabled": true
     }
 }

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -108,7 +108,7 @@
         "default_port": 8021,
         "exclude_ports": []
     },
-    "Timers Manager": {
+    "timers_manager": {
         "enabled": true,
         "full_time": 15.0,
         "message_time": 0.5

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -113,7 +113,7 @@
         "full_time": 15.0,
         "message_time": 0.5
     },
-    "Clockify": {
+    "clockify": {
         "enabled": false,
         "workspace_name": "studio name"
     },

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -1,5 +1,5 @@
 {
-    "Avalon": {
+    "avalon": {
         "AVALON_MONGO": "",
         "AVALON_TIMEOUT": 1000,
         "AVALON_THUMBNAIL_ROOT": {

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -138,7 +138,7 @@
             "ffmpeg": 48
         }
     },
-    "Logging": {
+    "log_viewer": {
         "enabled": true
     },
     "user": {

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -104,7 +104,7 @@
             }
         }
     },
-    "Rest Api": {
+    "rest_api": {
         "default_port": 8021,
         "exclude_ports": []
     },

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -9,7 +9,7 @@
         },
         "AVALON_DB_DATA": "{PYPE_SETUP_PATH}/../mongo_db_data"
     },
-    "Ftrack": {
+    "ftrack": {
         "enabled": true,
         "ftrack_server": "https://pype.ftrackapp.com",
         "ftrack_actions_path": [],

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -144,7 +144,7 @@
     "user": {
         "enabled": true
     },
-    "Standalone Publish": {
+    "standalonepublish_tool": {
         "enabled": true
     },
     "Idle Manager": {

--- a/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
@@ -1,6 +1,6 @@
 {
     "type": "dict",
-    "key": "Ftrack",
+    "key": "ftrack",
     "label": "Ftrack",
     "collapsable": true,
     "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -177,7 +177,7 @@
             }]
         }, {
             "type": "dict",
-            "key": "Idle Manager",
+            "key": "idle_manager",
             "label": "Idle Manager",
             "collapsable": true,
             "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -86,7 +86,7 @@
             ]
         }, {
             "type": "dict",
-            "key": "Clockify",
+            "key": "clockify",
             "label": "Clockify",
             "collapsable": true,
             "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -63,7 +63,7 @@
             ]
         }, {
             "type": "dict",
-            "key": "Timers Manager",
+            "key": "timers_manager",
             "label": "Timers Manager",
             "collapsable": true,
             "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -40,7 +40,7 @@
         },
         {
             "type": "dict",
-            "key": "Rest Api",
+            "key": "rest_api",
             "label": "Rest Api",
             "collapsable": true,
             "children": [{

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -155,7 +155,7 @@
             }]
         }, {
             "type": "dict",
-            "key": "User setting",
+            "key": "user",
             "label": "User setting",
             "collapsable": true,
             "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -144,7 +144,7 @@
             }]
         }, {
             "type": "dict",
-            "key": "Logging",
+            "key": "log_viewer",
             "label": "Logging",
             "collapsable": true,
             "checkbox_key": "enabled",

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -6,7 +6,7 @@
     "is_file": true,
     "children": [{
             "type": "dict",
-            "key": "Avalon",
+            "key": "avalon",
             "label": "Avalon",
             "collapsable": true,
             "children": [{

--- a/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/schema_modules.json
@@ -166,7 +166,7 @@
             }]
         }, {
             "type": "dict",
-            "key": "Standalone Publish",
+            "key": "standalonepublish_tool",
             "label": "Standalone Publish",
             "collapsable": true,
             "checkbox_key": "enabled",


### PR DESCRIPTION
## Changes
- module keys in settings do not use capitals and spaces

`"Avalon"` -> `"avalon"`
`"Rest Api"` -> `"rest_api"`
`"User Settings"` -> `"user"`
`"Ftrack"` -> `"ftrack"`
`"Clockify"` -> `"clockify"`
`"Logging"` -> `"log_viewer"`
`"Standalone Publish"` -> `"standalonepublish_tool"`
`"Timers Manager"` -> `"timers_manager"`
`"Idle Manager"` -> `"idle_manager"`