### PR TITLE
Module keys fix

### DIFF
--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -211,7 +211,7 @@ class CustomAttributes(BaseAction):
 
         self.groups = {}
 
-        self.ftrack_settings = get_system_settings()["modules"]["Ftrack"]
+        self.ftrack_settings = get_system_settings()["modules"]["ftrack"]
         self.attrs_presets = self.prepare_attribute_pressets()
 
     def prepare_attribute_pressets(self):

--- a/pype/modules/ftrack/lib/settings.py
+++ b/pype/modules/ftrack/lib/settings.py
@@ -15,7 +15,7 @@ USER_HANDLERS_DIR = os.path.join(FTRACK_MODULE_DIR, "actions")
 
 
 def get_ftrack_settings():
-    return get_system_settings()["modules"]["Ftrack"]
+    return get_system_settings()["modules"]["ftrack"]
 
 
 def get_ftrack_url_from_settings():

--- a/pype/plugins/maya/publish/submit_maya_muster.py
+++ b/pype/plugins/maya/publish/submit_maya_muster.py
@@ -25,7 +25,7 @@ def _get_template_id(renderer):
     :rtype: int
     """
 
-    templates = get_system_settings()["modules"]["Muster"]["templates_mapping"]
+    templates = get_system_settings()["modules"]["muster"]["templates_mapping"]
     if not templates:
         raise RuntimeError(("Muster template mapping missing in "
                             "pype-settings"))


### PR DESCRIPTION
## Changes
- loading right keys from modules settings
- `"Ftrack"` -> `"ftrack"`
- `"Muster"` ->`"muster"`

