### PR TITLE
Reset to pype default action show properly

### DIFF
--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -444,7 +444,7 @@ class SettingObject:
         if (
             not self.is_overidable
             and (
-                self.has_studio_override
+                self.has_studio_override or self.child_has_studio_override
             )
         ):
             action = QtWidgets.QAction("Reset to pype default")


### PR DESCRIPTION
## Issue
- `Reset to pype defauts` will show only on entities that are last in hierarchy or marked as groups

## Changes
- fix reset to pype's default in hiearchy to show also on their parents