### PR TITLE
List item without label in settings gui

### DIFF
--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1600,8 +1600,15 @@ class ListWidget(QtWidgets.QWidget, InputObject):
         layout.setSpacing(5)
 
         if not self.as_widget and not label_widget:
-            label_widget = QtWidgets.QLabel(self.schema_data["label"], self)
-            layout.addWidget(label_widget, alignment=QtCore.Qt.AlignTop)
+            label = self.schema_data.get("label")
+            if label:
+                label_widget = QtWidgets.QLabel(label, self)
+                layout.addWidget(label_widget, alignment=QtCore.Qt.AlignTop)
+            elif self._is_group:
+                raise KeyError((
+                    "Schema item must contain \"label\" if `is_group` is True"
+                    " to be able visualize changes and show actions."
+                ))
 
         self.label_widget = label_widget
 
@@ -1835,8 +1842,15 @@ class ListStrictWidget(QtWidgets.QWidget, InputObject):
         layout.setSpacing(5)
 
         if not self.as_widget and not label_widget:
-            label_widget = QtWidgets.QLabel(self.schema_data["label"], self)
-            layout.addWidget(label_widget, alignment=QtCore.Qt.AlignTop)
+            label = self.schema_data.get("label")
+            if label:
+                label_widget = QtWidgets.QLabel(label, self)
+                layout.addWidget(label_widget, alignment=QtCore.Qt.AlignTop)
+            elif self._is_group:
+                raise KeyError((
+                    "Schema item must contain \"label\" if `is_group` is True"
+                    " to be able visualize changes and show actions."
+                ))
 
         self.label_widget = label_widget
 


### PR DESCRIPTION
## Changes
- items `list` and `list-strict` may not contain "label" key in schema if are not marked with `is_group` to True
    - when would be marked with `is_group` visualization of overrides wouldn't work and actions may not show properly

## TODO
- remove empty labels from schemas after merge of PR https://github.com/pypeclub/pype/pull/820