### PR TITLE
Ftrack module use modules manager for ftrack paths

### DIFF
--- a/pype/modules/clockify/ftrack/server/action_clockify_sync_server.py
+++ b/pype/modules/clockify/ftrack/server/action_clockify_sync_server.py
@@ -1,17 +1,17 @@
 import os
 import json
-from pype.modules.ftrack.lib import BaseAction
+from pype.modules.ftrack.lib import ServerAction
 from pype.modules.clockify.clockify_api import ClockifyAPI
 
 
-class SyncClocifyServer(BaseAction):
+class SyncClocifyServer(ServerAction):
     '''Synchronise project names and task types.'''
 
     identifier = "clockify.sync.server"
     label = "Sync To Clockify (server)"
     description = "Synchronise data to Clockify workspace"
 
-    discover_role_list = ["Pypeclub", "Administrator", "project Manager"]
+    role_list = ["Pypeclub", "Administrator", "project Manager"]
 
     def __init__(self, *args, **kwargs):
         super(SyncClocifyServer, self).__init__(*args, **kwargs)
@@ -45,32 +45,7 @@ class SyncClocifyServer(BaseAction):
             or entities[0].entity_type.lower() != "project"
         ):
             return False
-
-        # Get user and check his roles
-        user_id = event.get("source", {}).get("user", {}).get("id")
-        if not user_id:
-            return False
-
-        user = session.query("User where id is \"{}\"".format(user_id)).first()
-        if not user:
-            return False
-
-        for role in user["user_security_roles"]:
-            if role["security_role"]["name"] in self.discover_role_list:
-                return True
-        return False
-
-    def register(self):
-        self.session.event_hub.subscribe(
-            "topic=ftrack.action.discover",
-            self._discover,
-            priority=self.priority
-        )
-
-        launch_subscription = (
-            "topic=ftrack.action.launch and data.actionIdentifier={}"
-        ).format(self.identifier)
-        self.session.event_hub.subscribe(launch_subscription, self._launch)
+        return True
 
     def launch(self, session, entities, event):
         if self.clockapi.workspace_id is None:

--- a/pype/modules/clockify/ftrack/user/action_clockify_sync_local.py
+++ b/pype/modules/clockify/ftrack/user/action_clockify_sync_local.py
@@ -17,8 +17,10 @@ class SyncClocifyLocal(BaseAction):
     #: icon
     icon = statics_icon("app_icons", "clockify-white.png")
 
-    #: CLockifyApi
-    clockapi = ClockifyAPI()
+    def __init__(self, *args, **kwargs):
+        super(SyncClocifyLocal, self).__init__(*args, **kwargs)
+        #: CLockifyApi
+        self.clockapi = ClockifyAPI()
 
     def discover(self, session, entities, event):
         if (

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -24,7 +24,10 @@ class Delivery(BaseAction):
     role_list = ["Pypeclub", "Administrator", "Project manager"]
     icon = statics_icon("ftrack", "action_icons", "Delivery.svg")
 
-    db_con = AvalonMongoDB()
+    def __init__(self, *args, **kwargs):
+        self.db_con = AvalonMongoDB()
+
+        super(Delivery, self).__init__(*args, **kwargs)
 
     def discover(self, session, entities, event):
         for entity in entities:

--- a/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
+++ b/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
@@ -25,7 +25,10 @@ class StoreThumbnailsToAvalon(BaseAction):
     icon = statics_icon("ftrack", "action_icons", "PypeAdmin.svg")
 
     thumbnail_key = "AVALON_THUMBNAIL_ROOT"
-    db_con = AvalonMongoDB()
+
+    def __init__(self, *args, **kwargs):
+        self.db_con = AvalonMongoDB()
+        super(StoreThumbnailsToAvalon, self).__init__(*args, **kwargs)
 
     def discover(self, session, entities, event):
         for entity in entities:
@@ -34,9 +37,6 @@ class StoreThumbnailsToAvalon(BaseAction):
         return False
 
     def launch(self, session, entities, event):
-        # DEBUG LINE
-        # root_path = r"C:\Users\jakub.trllo\Desktop\Tests\ftrack_thumbnails"
-
         user = session.query(
             "User where username is '{0}'".format(session.api_user)
         ).one()

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -23,9 +23,6 @@ from avalon.api import AvalonMongoDB
 
 
 class SyncToAvalonEvent(BaseEvent):
-
-    dbcon = AvalonMongoDB()
-
     interest_entTypes = ["show", "task"]
     ignore_ent_types = ["Milestone"]
     ignore_keys = ["statusid", "thumbid"]
@@ -67,6 +64,7 @@ class SyncToAvalonEvent(BaseEvent):
         #   only entityTypes in interest instead of filtering by ignored
         self.debug_sync_types = collections.defaultdict(list)
 
+        self.dbcon = AvalonMongoDB()
         # Set processing session to not use global
         self.set_process_session(session)
         super().__init__(session, plugins_presets)

--- a/pype/modules/ftrack/ftrack_module.py
+++ b/pype/modules/ftrack/ftrack_module.py
@@ -29,9 +29,15 @@ class FtrackModule(
         self.enabled = ftrack_settings["enabled"]
         self.ftrack_url = ftrack_settings["ftrack_server"]
 
-        # TODO load from settings
-        self.server_event_handlers_paths = []
-        self.user_event_handlers_paths = []
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.server_event_handlers_paths = [
+            os.path.join(current_dir, "events"),
+            *ftrack_settings["ftrack_events_path"]
+        ]
+        self.user_event_handlers_paths = [
+            os.path.join(current_dir, "actions"),
+            *ftrack_settings["ftrack_actions_path"]
+        ]
 
         # Prepare attribute
         self.tray_module = None

--- a/pype/modules/ftrack/ftrack_server/sub_event_processor.py
+++ b/pype/modules/ftrack/ftrack_server/sub_event_processor.py
@@ -10,7 +10,7 @@ from pype.modules.ftrack.ftrack_server.lib import (
     ProcessEventHub,
     TOPIC_STATUS_SERVER
 )
-from pype.modules.ftrack.lib import get_server_event_handler_paths
+from pype.modules import ModulesManager
 
 from pype.api import Logger
 
@@ -80,8 +80,12 @@ def main(args):
         register(session)
         SessionFactory.session = session
 
-        event_handler_paths = get_server_event_handler_paths()
-        server = FtrackServer(event_handler_paths, "event")
+        manager = ModulesManager()
+        ftrack_module = manager.modules_by_name["ftrack"]
+        server = FtrackServer(
+            ftrack_module.server_event_handlers_paths,
+            "event"
+        )
         log.debug("Launched Ftrack Event processor")
         server.run_server(session)
 

--- a/pype/modules/ftrack/ftrack_server/sub_legacy_server.py
+++ b/pype/modules/ftrack/ftrack_server/sub_legacy_server.py
@@ -7,9 +7,7 @@ import threading
 from ftrack_server import FtrackServer
 import ftrack_api
 from pype.api import Logger
-from pype.modules.ftrack.ftrack_server.lib import (
-    get_server_event_handler_paths
-)
+from pype.modules import ModulesManager
 
 log = Logger().get_logger("Event Server Legacy")
 
@@ -65,8 +63,12 @@ class TimerChecker(threading.Thread):
 def main(args):
     check_thread = None
     try:
-        event_handler_paths = get_server_event_handler_paths()
-        server = FtrackServer(event_handler_paths, "event")
+        manager = ModulesManager()
+        ftrack_module = manager.modules_by_name["ftrack"]
+        server = FtrackServer(
+            ftrack_module.server_event_handlers_paths,
+            "event"
+        )
         session = ftrack_api.Session(auto_connect_event_hub=True)
 
         check_thread = TimerChecker(server, session)

--- a/pype/modules/ftrack/ftrack_server/sub_user_server.py
+++ b/pype/modules/ftrack/ftrack_server/sub_user_server.py
@@ -7,7 +7,7 @@ from pype.modules.ftrack.ftrack_server.lib import (
     SocketSession,
     SocketBaseEventHub
 )
-from pype.modules.ftrack.lib import get_user_event_handler_paths
+from pype.modules import ModulesManager
 
 from pype.api import Logger
 
@@ -32,8 +32,12 @@ def main(args):
         session = SocketSession(
             auto_connect_event_hub=True, sock=sock, Eventhub=SocketBaseEventHub
         )
-        event_handler_paths = get_user_event_handler_paths()
-        server = FtrackServer(event_handler_paths, "action")
+        manager = ModulesManager()
+        ftrack_module = manager.modules_by_name["ftrack"]
+        ftrack_module.user_event_handlers_paths
+        server = FtrackServer(
+            ftrack_module.user_event_handlers_paths, "action"
+        )
         log.debug("Launching User Ftrack Server")
         server.run_server(session=session)
 

--- a/pype/modules/ftrack/lib/__init__.py
+++ b/pype/modules/ftrack/lib/__init__.py
@@ -1,8 +1,5 @@
 from . settings import (
-    FTRACK_MODULE_DIR,
-    SERVER_HANDLERS_DIR,
     get_ftrack_url_from_settings,
-    get_server_event_handler_paths,
     get_ftrack_event_mongo_info
 )
 from . import avalon_sync
@@ -13,10 +10,7 @@ from .ftrack_action_handler import BaseAction, ServerAction, statics_icon
 
 
 __all__ = (
-    "FTRACK_MODULE_DIR",
-    "SERVER_HANDLERS_DIR",
     "get_ftrack_url_from_settings",
-    "get_server_event_handler_paths",
     "get_ftrack_event_mongo_info",
 
     "avalon_sync",

--- a/pype/modules/ftrack/lib/__init__.py
+++ b/pype/modules/ftrack/lib/__init__.py
@@ -1,10 +1,8 @@
 from . settings import (
     FTRACK_MODULE_DIR,
     SERVER_HANDLERS_DIR,
-    USER_HANDLERS_DIR,
     get_ftrack_url_from_settings,
     get_server_event_handler_paths,
-    get_user_event_handler_paths,
     get_ftrack_event_mongo_info
 )
 from . import avalon_sync
@@ -17,10 +15,8 @@ from .ftrack_action_handler import BaseAction, ServerAction, statics_icon
 __all__ = (
     "FTRACK_MODULE_DIR",
     "SERVER_HANDLERS_DIR",
-    "USER_HANDLERS_DIR",
     "get_ftrack_url_from_settings",
     "get_server_event_handler_paths",
-    "get_user_event_handler_paths",
     "get_ftrack_event_mongo_info",
 
     "avalon_sync",

--- a/pype/modules/ftrack/lib/settings.py
+++ b/pype/modules/ftrack/lib/settings.py
@@ -11,7 +11,6 @@ log = Logger().get_logger(__name__)
 
 FTRACK_MODULE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SERVER_HANDLERS_DIR = os.path.join(FTRACK_MODULE_DIR, "events")
-USER_HANDLERS_DIR = os.path.join(FTRACK_MODULE_DIR, "actions")
 
 
 def get_ftrack_settings():
@@ -42,27 +41,6 @@ def get_server_event_handler_paths():
             paths.append(clockify_path)
     except Exception:
         log.warning("Clockify paths function failed.", exc_info=True)
-
-    # Filter only existing paths
-    _paths = []
-    for path in paths:
-        if os.path.exists(path):
-            _paths.append(path)
-        else:
-            log.warning((
-                "Registered event handler path is not accessible: {}"
-            ).format(path))
-    return _paths
-
-
-def get_user_event_handler_paths():
-    paths = []
-    # Add pype's default dir
-    paths.append(USER_HANDLERS_DIR)
-    # Add additional paths from settings
-    paths.extend(
-        get_ftrack_settings()["ftrack_actions_path"]
-    )
 
     # Filter only existing paths
     _paths = []

--- a/pype/modules/ftrack/lib/settings.py
+++ b/pype/modules/ftrack/lib/settings.py
@@ -9,9 +9,6 @@ from pype.api import (
 
 log = Logger().get_logger(__name__)
 
-FTRACK_MODULE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SERVER_HANDLERS_DIR = os.path.join(FTRACK_MODULE_DIR, "events")
-
 
 def get_ftrack_settings():
     return get_system_settings()["modules"]["ftrack"]
@@ -19,55 +16,6 @@ def get_ftrack_settings():
 
 def get_ftrack_url_from_settings():
     return get_ftrack_settings()["ftrack_server"]
-
-
-def get_server_event_handler_paths():
-    paths = []
-    # Environment variable overrides settings
-    if "FTRACK_EVENTS_PATH" in os.environ:
-        env_paths = os.environ.get("FTRACK_EVENTS_PATH")
-        paths.extend(env_paths.split(os.pathsep))
-        return paths
-
-    # Add pype's default dir
-    paths.append(SERVER_HANDLERS_DIR)
-    # Add additional paths from settings
-    paths.extend(
-        get_ftrack_settings()["ftrack_events_path"]
-    )
-    try:
-        clockify_path = clockify_event_path()
-        if clockify_path:
-            paths.append(clockify_path)
-    except Exception:
-        log.warning("Clockify paths function failed.", exc_info=True)
-
-    # Filter only existing paths
-    _paths = []
-    for path in paths:
-        if os.path.exists(path):
-            _paths.append(path)
-        else:
-            log.warning((
-                "Registered event handler path is not accessible: {}"
-            ).format(path))
-    return _paths
-
-
-def clockify_event_path():
-    api_key = os.environ.get("CLOCKIFY_API_KEY")
-    if not api_key:
-        log.warning("Clockify API key is not set.")
-        return
-
-    workspace_name = os.environ.get("CLOCKIFY_WORKSPACE")
-    if not workspace_name:
-        log.warning("Clockify Workspace is not set.")
-        return
-
-    from pype.modules.clockify.constants import CLOCKIFY_FTRACK_SERVER_PATH
-
-    return CLOCKIFY_FTRACK_SERVER_PATH
 
 
 def get_ftrack_event_mongo_info():


### PR DESCRIPTION
## Changes
- server and user server is not using lib functions to get paths to handlers but load Ftrack module with ModulesManager and get it from modules manager instead
    - this way all registered paths to ftrack module are registered
- Clockify server sync action inherit from `ServerAction`
- few objects in Ftrack actions/events are created on object initialization instead of in class definition