### PR TITLE
Maya: Deadline submitter - shared data access violation

### DIFF
--- a/pype/plugins/global/publish/extract_scanline_exr.py
+++ b/pype/plugins/global/publish/extract_scanline_exr.py
@@ -46,6 +46,10 @@ class ExtractScanlineExr(pyblish.api.InstancePlugin):
             stagingdir = os.path.normpath(repre.get("stagingDir"))
 
             oiio_tool_path = os.getenv("PYPE_OIIO_PATH", "")
+            if not os.path.exists(oiio_tool_path):
+                self.log.error(
+                    "OIIO tool not found in {}".format(oiio_tool_path))
+                raise AssertionError("OIIO tool not found")
 
             for file in input_files:
 
@@ -53,14 +57,11 @@ class ExtractScanlineExr(pyblish.api.InstancePlugin):
                 temp_name = os.path.join(stagingdir, "__{}".format(file))
                 # move original render to temp location
                 shutil.move(original_name, temp_name)
-                oiio_cmd = []
-                oiio_cmd.append(oiio_tool_path)
-                oiio_cmd.append(
-                    os.path.join(stagingdir, temp_name)
-                )
-                oiio_cmd.append("--scanline")
-                oiio_cmd.append("-o")
-                oiio_cmd.append(os.path.join(stagingdir, original_name))
+                oiio_cmd = [
+                    oiio_tool_path,
+                    os.path.join(stagingdir, temp_name), "--scanline", "-o",
+                    os.path.join(stagingdir, original_name)
+                ]
 
                 subprocess_exr = " ".join(oiio_cmd)
                 self.log.info(f"running: {subprocess_exr}")


### PR DESCRIPTION
## Bug description

There was data structure defined outside *Submit Maya Deadline* instance scope. It should have been read-only, but was written to, affecting all subsequent submitted instances.  It probably only affected `Frames`.

### Example:

Publishing two render layers with different frame range resulted in render jobs with only one frame range (derived from first render layer submission).

This is fixing it, making data copy for each and every instance.

🎫 **Ticket ID:** [#438](https://pype.freshdesk.com/a/tickets/438)
|---|