### PR TITLE
Pype.py do not boot on import

### DIFF
--- a/pype.py
+++ b/pype.py
@@ -260,4 +260,5 @@ def get_info() -> list:
     return formatted
 
 
-boot()
+if __name__ == "__main__":
+    boot()


### PR DESCRIPTION
## Issue
- if pype.py is (accidentally) imported it will always run `boot` function which may cause infinite tray execution if it happens on tray initialization
    - it may cause huge issues due to a bug on different place e.g. whensomething like this is executed `__import__(".")`

## Changes
- do not run `boot` on pype.py import until it's in `__main__`