### PR TITLE
Tray without subprocess

### DIFF
--- a/pype/lib/log.py
+++ b/pype/lib/log.py
@@ -378,10 +378,8 @@ class PypeLogger:
                     Terminal.echo(line)
                 _mongo_logging = False
 
-        # Remove root's StreamHandler
-        for hdlr in tuple(logger.root.handlers):
-            if isinstance(hdlr, logging.StreamHandler):
-                logger.root.removeHandler(hdlr)
+        # Do not propagate logs to root logger
+        logger.propagate = False
 
         return logger
 

--- a/pype/lib/log.py
+++ b/pype/lib/log.py
@@ -378,6 +378,11 @@ class PypeLogger:
                     Terminal.echo(line)
                 _mongo_logging = False
 
+        # Remove root's StreamHandler
+        for hdlr in tuple(logger.root.handlers):
+            if isinstance(hdlr, logging.StreamHandler):
+                logger.root.removeHandler(hdlr)
+
         return logger
 
 

--- a/pype/pype_commands.py
+++ b/pype/pype_commands.py
@@ -12,42 +12,9 @@ class PypeCommands:
     """
     @staticmethod
     def launch_tray(debug=False):
-        from pype.lib import PypeLogger as Logger
-        from pype.lib import execute
-        if debug:
-            execute([
-                sys.executable,
-                "-m",
-                "pype.tools.tray"
-            ])
-            return
+        from pype.tools import tray
 
-        detached_process = 0x00000008  # noqa: N806
-
-        args = [sys.executable, "-m", "pype.tools.tray"]
-        if sys.platform.startswith('linux'):
-            subprocess.Popen(
-                args,
-                universal_newlines=True,
-                bufsize=1,
-                env=os.environ,
-                stdout=None,
-                stderr=None,
-                preexec_fn=os.setpgrp
-            )
-
-        if sys.platform == 'win32':
-            args = ["pythonw", "-m", "pype.tools.tray"]
-            subprocess.Popen(
-                args,
-                universal_newlines=True,
-                bufsize=1,
-                cwd=None,
-                env=os.environ,
-                stdout=open(Logger.get_file_path(), 'w+'),
-                stderr=subprocess.STDOUT,
-                creationflags=detached_process
-            )
+        tray.main()
 
     @staticmethod
     def launch_settings_gui(dev):

--- a/pype/tools/tray/__init__.py
+++ b/pype/tools/tray/__init__.py
@@ -1,0 +1,5 @@
+from .pype_tray import main
+
+__all__ = (
+    "main",
+)

--- a/pype/tools/tray/__main__.py
+++ b/pype/tools/tray/__main__.py
@@ -1,13 +1,7 @@
-import os
-import sys
+try:
+    from . import pype_tray
+except ImportError:
+    import pype_tray
 
-from . import pype_tray
 
-app = pype_tray.PypeTrayApplication()
-if os.name == "nt":
-    import ctypes
-    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-        u"pype_tray"
-    )
-
-sys.exit(app.exec_())
+pype_tray.main()

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -255,3 +255,14 @@ class PypeTrayApplication(QtWidgets.QApplication):
             QtCore.Qt.WindowStaysOnTopHint | QtCore.Qt.FramelessWindowHint
         )
         return splash
+
+
+def main():
+    app = PypeTrayApplication()
+    if os.name == "nt":
+        import ctypes
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            u"pype_tray"
+        )
+
+    sys.exit(app.exec_())

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -259,6 +259,7 @@ class PypeTrayApplication(QtWidgets.QApplication):
 
 def main():
     app = PypeTrayApplication()
+    # TODO remove when pype.exe will have an icon
     if os.name == "nt":
         import ctypes
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(


### PR DESCRIPTION
## Changes
- tray option in pype cli won't trigger new subprocess of tray tool but execute tray's main directly
- pype logger's do not propage logs to root logger (logs are not doubled)