### PR TITLE
terminal.py crash on import

### DIFF
--- a/pype/lib/terminal.py
+++ b/pype/lib/terminal.py
@@ -40,6 +40,9 @@ class Terminal:
         it's terminal object. Colorized output is not used if import of python
         module or terminal object creation fails.
         """
+        # Mark that Terminal's initialization was already triggered
+        Terminal._initialized = True
+
         from . import env_value_to_bool
         use_colors = env_value_to_bool(
             "PYPE_LOG_NO_COLORS", default=Terminal.use_colors


### PR DESCRIPTION
## Issue
- python module `blessed` crash on import when `sys.__stdin__` is null (Resolve)

## Changes
- `Terminal` class has 2 attributes `_initialized` and `use_colors` and new static method `_initialize`
    - `_initialize` should be called only once on first call of `log` method and define if colored output should be used