### PR TITLE
Optionally hide image planes from reviews.

### DIFF
--- a/pype/plugins/maya/create/create_review.py
+++ b/pype/plugins/maya/create/create_review.py
@@ -13,6 +13,7 @@ class CreateReview(avalon.maya.Creator):
     defaults = ['Main']
     keepImages = False
     isolate = False
+    imagePlane = True
 
     def __init__(self, *args, **kwargs):
         super(CreateReview, self).__init__(*args, **kwargs)
@@ -25,5 +26,6 @@ class CreateReview(avalon.maya.Creator):
 
         data["isolate"] = self.isolate
         data["keepImages"] = self.keepImages
+        data["imagePlane"] = self.imagePlane
 
         self.data = data

--- a/pype/plugins/maya/publish/extract_playblast.py
+++ b/pype/plugins/maya/publish/extract_playblast.py
@@ -81,6 +81,13 @@ class ExtractPlayblast(pype.api.Extractor):
         if instance.data.get("isolate"):
             preset["isolate"] = instance.data["setMembers"]
 
+        # Show/Hide image planes on request.
+        image_plane = instance.data.get("imagePlane", True)
+        if "viewport_options" in preset:
+            preset["viewport_options"]["imagePlane"] = image_plane
+        else:
+            preset["viewport_options"] = {"imagePlane": image_plane}
+
         with maintained_time():
             filename = preset.get("filename", "%TEMP%")
 


### PR DESCRIPTION
This adds an attribute to the review object set so users can choose to hide image planes when publishing.

Use case is that we have two reviews in our animation files; review and precomp. Precomp needs the image plane hidden.