### PR TITLE
List item with wrapper

### DIFF
--- a/pype/tools/settings/settings/README.md
+++ b/pype/tools/settings/settings/README.md
@@ -269,13 +269,17 @@
 ```
 
 ## Inputs for setting value using Pure inputs
-- these inputs also have required `"key"` and `"label"`
+- these inputs also have required `"key"`
+- attribute `"label"` is required in few conditions
+    - when item is marked `as_group` or when `use_label_wrap`
 - they use Pure inputs "as widgets"
 
 ### list
 - output is list
 - items can be added and removed
 - items in list must be the same type
+- to wrap item in collapsible widget with label on top set `use_label_wrap` to `True`
+    - when this is used `collapsible` and `collapsed` can be set (same as `dict` item does)
 - type of items is defined with key `"object_type"`
 - there are 2 possible ways how to set the type:
     1.) dictionary with item modifiers (`number` input has `minimum`, `maximum` and `decimals`) in that case item type must be set as value of `"type"` (example below)

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_main.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_main.json
@@ -9,6 +9,7 @@
                 {
                     "type": "anatomy_roots",
                     "key": "roots",
+                    "label": "Roots",
                     "is_file": true
                 },
                 {

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
@@ -180,6 +180,7 @@
                             "type": "list",
                             "key": "parent_status_by_task_status",
                             "label": "Change parent status if a single task matches",
+                            "use_label_wrap": true,
                             "object_type": {
                                 "type": "dict",
                                 "children": [

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_global.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_global.json
@@ -18,11 +18,11 @@
         "type": "collapsible-wrap",
         "label": "Project Folder Structure",
         "children": [
-          {
-              "type": "raw-json",
-              "key": "project_folder_structure",
-              "label": ""
-          }]
+            {
+                "type": "raw-json",
+                "key": "project_folder_structure"
+            }
+        ]
     },
 
     {

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -92,7 +92,6 @@
                         {
                             "type": "list",
                             "key": "inputs",
-                            "label": "",
                             "object_type": {
                                 "type": "dict",
                                 "children": [
@@ -330,7 +329,6 @@
                         {
                             "type": "list",
                             "key": "inputs",
-                            "label": "",
                             "object_type": {
                                 "type": "dict",
                                 "children": [

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schemas/schema_global_tools.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schemas/schema_global_tools.json
@@ -29,41 +29,36 @@
             "label": "Workfiles",
             "children": [
                 {
-                    "type": "collapsible-wrap",
+                    "type": "list",
+                    "key": "last_workfile_on_startup",
                     "label": "Open last workfiles on launch",
-                    "children": [
-                        {
-                            "type": "list",
-                            "key": "last_workfile_on_startup",
-                            "label": "",
-                            "is_group": true,
-                            "object_type": {
-                                "type": "dict",
-                                "children": [
-                                    {
-                                        "key": "hosts",
-                                        "label": "Hosts",
-                                        "type": "list",
-                                        "object_type": "text"
-                                    },
-                                    {
-                                        "key": "tasks",
-                                        "label": "Tasks",
-                                        "type": "list",
-                                        "object_type": "text"
-                                    },
-                                    {
-                                        "type": "splitter"
-                                    },
-                                    {
-                                        "type": "boolean",
-                                        "key": "enabled",
-                                        "label": "Enabled"
-                                    }
-                                ]
+                    "is_group": true,
+                    "use_label_wrap": true,
+                    "object_type": {
+                        "type": "dict",
+                        "children": [
+                            {
+                                "key": "hosts",
+                                "label": "Hosts",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "key": "tasks",
+                                "label": "Tasks",
+                                "type": "list",
+                                "object_type": "text"
+                            },
+                            {
+                                "type": "splitter"
+                            },
+                            {
+                                "type": "boolean",
+                                "key": "enabled",
+                                "label": "Enabled"
                             }
-                        }
-                    ]
+                        ]
+                    }
                 },
                 {
                     "type": "dict-modifiable",

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1610,14 +1610,6 @@ class ListWidget(QtWidgets.QWidget, InputObject):
             self.item_schema = {
                 "type": object_type
             }
-            # Backwards compatibility
-            input_modifiers = schema_data.get("input_modifiers") or {}
-            if input_modifiers:
-                self.log.warning((
-                    "Used deprecated key `input_modifiers` to define item."
-                    " Rather use `object_type` as dictionary with modifiers."
-                ))
-                self.item_schema.update(input_modifiers)
 
     def create_ui(self, label_widget=None):
         layout = QtWidgets.QHBoxLayout(self)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1329,9 +1329,9 @@ class RawJsonWidget(QtWidgets.QWidget, InputObject):
         self.setFocusProxy(self.input_field)
 
         if not self.as_widget and not label_widget:
-            label = self.schema_data["label"]
-            label_widget = QtWidgets.QLabel(label)
-            layout.addWidget(label_widget, 0, alignment=QtCore.Qt.AlignTop)
+            if self.label:
+                label_widget = QtWidgets.QLabel(self.label)
+                layout.addWidget(label_widget, 0, alignment=QtCore.Qt.AlignTop)
         self.label_widget = label_widget
 
         layout.addWidget(self.input_field, 1, alignment=QtCore.Qt.AlignTop)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1840,17 +1840,43 @@ class ListWidget(QtWidgets.QWidget, InputObject):
                 return True
         return False
 
-    def update_style(self):
+    def update_style(self, is_overriden=None):
         if not self.label_widget:
             return
 
-        state = self._style_state()
+        child_invalid = self.child_invalid
+        if self.body_widget:
+            child_state = self.style_state(
+                self.child_has_studio_override,
+                child_invalid,
+                self.child_overriden,
+                self.child_modified
+            )
+            if child_state:
+                child_state = "child-{}".format(child_state)
+
+            if child_state != self._child_state:
+                self.body_widget.side_line_widget.setProperty(
+                    "state", child_state
+                )
+                self.body_widget.side_line_widget.style().polish(
+                    self.body_widget.side_line_widget
+                )
+                self._child_state = child_state
+
+        state = self.style_state(
+            self.had_studio_override,
+            child_invalid,
+            self.is_overriden,
+            self.is_modified
+        )
         if self._state == state:
             return
 
-        self._state = state
         self.label_widget.setProperty("state", state)
         self.label_widget.style().polish(self.label_widget)
+
+        self._state = state
 
     def item_value(self):
         output = []

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -1582,6 +1582,25 @@ class ListWidget(QtWidgets.QWidget, InputObject):
 
         self.initial_attributes(schema_data, parent, as_widget)
 
+        self.use_label_wrap = schema_data.get("use_label_wrap") or False
+        # Used only if `use_label_wrap` is set to True
+        self.collapsible = schema_data.get("collapsible") or True
+        self.collapsed = schema_data.get("collapsed") or False
+
+        self.expand_in_grid = bool(self.use_label_wrap)
+
+        if self.as_widget and self.use_label_wrap:
+            raise ValueError(
+                "`ListWidget` can't have set `use_label_wrap` to True and"
+                " be used as widget at the same time."
+            )
+
+        if self.use_label_wrap and not self.label:
+            raise ValueError(
+                "`ListWidget` can't have set `use_label_wrap` to True and"
+                " not have set \"label\" key at the same time."
+            )
+
         self.input_fields = []
 
         object_type = schema_data["object_type"]

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -196,6 +196,12 @@ class SettingObject:
 
             self.key = self.schema_data["key"]
 
+        self.label = self.schema_data.get("label")
+        if not self.label and self._is_group:
+            raise ValueError(
+                "Item is set as `is_group` but has empty `label`."
+            )
+
     @property
     def user_role(self):
         """Tool is running with any user role.


### PR DESCRIPTION
## Changes
- item `list` can be wrapped in collapsible label with setting `use_label_wrap` to `True` (default is `False`)
- added few validation about set label
- item `raw-json` does not need to have filled label
- empty labels are removed from schemas