### PR TITLE
Ftrack events are not expecting presets argument

### DIFF
--- a/pype/modules/ftrack/actions/action_applications.py
+++ b/pype/modules/ftrack/actions/action_applications.py
@@ -28,8 +28,8 @@ class AppplicationsAction(BaseAction):
     identifier = "pype_app.{}.".format(str(uuid4()))
     icon_url = os.environ.get("PYPE_STATICS_SERVER")
 
-    def __init__(self, session, plugins_presets=None):
-        super().__init__(session, plugins_presets)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.application_manager = ApplicationManager()
         self.dbcon = AvalonMongoDB()
@@ -210,6 +210,6 @@ class AppplicationsAction(BaseAction):
         }
 
 
-def register(session, plugins_presets=None):
+def register(session):
     """Register action. Called when used as an event plugin."""
-    AppplicationsAction(session, plugins_presets).register()
+    AppplicationsAction(session).register()

--- a/pype/modules/ftrack/actions/action_batch_task_creation.py
+++ b/pype/modules/ftrack/actions/action_batch_task_creation.py
@@ -158,7 +158,7 @@ class BatchTasksAction(BaseAction):
         }
 
 
-def register(session, plugins_presets=None):
+def register(session):
     '''Register action. Called when used as an event plugin.'''
 
-    BatchTasksAction(session, plugins_presets).register()
+    BatchTasksAction(session).register()

--- a/pype/modules/ftrack/actions/action_clean_hierarchical_attributes.py
+++ b/pype/modules/ftrack/actions/action_clean_hierarchical_attributes.py
@@ -98,7 +98,7 @@ class CleanHierarchicalAttrsAction(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    CleanHierarchicalAttrsAction(session, plugins_presets).register()
+    CleanHierarchicalAttrsAction(session).register()

--- a/pype/modules/ftrack/actions/action_client_review_sort.py
+++ b/pype/modules/ftrack/actions/action_client_review_sort.py
@@ -84,7 +84,7 @@ class ClientReviewSort(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register action. Called when used as an event plugin.'''
 
-    ClientReviewSort(session, plugins_presets).register()
+    ClientReviewSort(session).register()

--- a/pype/modules/ftrack/actions/action_component_open.py
+++ b/pype/modules/ftrack/actions/action_component_open.py
@@ -60,7 +60,7 @@ class ComponentOpen(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register action. Called when used as an event plugin.'''
 
-    ComponentOpen(session, plugins_presets).register()
+    ComponentOpen(session).register()

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -814,7 +814,7 @@ class CustomAttributes(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    CustomAttributes(session, plugins_presets).register()
+    CustomAttributes(session).register()

--- a/pype/modules/ftrack/actions/action_create_folders.py
+++ b/pype/modules/ftrack/actions/action_create_folders.py
@@ -243,6 +243,6 @@ class CreateFolders(BaseAction):
         return os.path.normpath(filled_template.split("{")[0])
 
 
-def register(session, plugins_presets={}):
+def register(session):
     """Register plugin. Called when used as an plugin."""
-    CreateFolders(session, plugins_presets).register()
+    CreateFolders(session).register()

--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -238,5 +238,5 @@ class CreateProjectFolders(BaseAction):
                 os.makedirs(path.format(project_root=project_root))
 
 
-def register(session, plugins_presets={}):
-    CreateProjectFolders(session, plugins_presets).register()
+def register(session):
+    CreateProjectFolders(session).register()

--- a/pype/modules/ftrack/actions/action_delete_asset.py
+++ b/pype/modules/ftrack/actions/action_delete_asset.py
@@ -662,7 +662,7 @@ class DeleteAssetSubset(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    DeleteAssetSubset(session, plugins_presets).register()
+    DeleteAssetSubset(session).register()

--- a/pype/modules/ftrack/actions/action_delete_old_versions.py
+++ b/pype/modules/ftrack/actions/action_delete_old_versions.py
@@ -577,7 +577,7 @@ class DeleteOldVersions(BaseAction):
         return (os.path.normpath(path), sequence_path)
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    DeleteOldVersions(session, plugins_presets).register()
+    DeleteOldVersions(session).register()

--- a/pype/modules/ftrack/actions/action_delivery.py
+++ b/pype/modules/ftrack/actions/action_delivery.py
@@ -692,7 +692,7 @@ class Delivery(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    Delivery(session, plugins_presets).register()
+    Delivery(session).register()

--- a/pype/modules/ftrack/actions/action_djvview.py
+++ b/pype/modules/ftrack/actions/action_djvview.py
@@ -20,9 +20,8 @@ class DJVViewAction(BaseAction):
         "sgi", "rgba", "rgb", "bw", "tga", "tiff", "tif", "img"
     ]
 
-    def __init__(self, session, plugins_presets):
-        '''Expects a ftrack_api.Session instance'''
-        super().__init__(session, plugins_presets)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.djv_path = self.find_djv_path()
 
@@ -208,7 +207,7 @@ class DJVViewAction(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     """Register hooks."""
 
-    DJVViewAction(session, plugins_presets).register()
+    DJVViewAction(session).register()

--- a/pype/modules/ftrack/actions/action_job_killer.py
+++ b/pype/modules/ftrack/actions/action_job_killer.py
@@ -112,7 +112,7 @@ class JobKiller(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    JobKiller(session, plugins_presets).register()
+    JobKiller(session).register()

--- a/pype/modules/ftrack/actions/action_multiple_notes.py
+++ b/pype/modules/ftrack/actions/action_multiple_notes.py
@@ -104,7 +104,7 @@ class MultipleNotes(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    MultipleNotes(session, plugins_presets).register()
+    MultipleNotes(session).register()

--- a/pype/modules/ftrack/actions/action_prepare_project.py
+++ b/pype/modules/ftrack/actions/action_prepare_project.py
@@ -454,6 +454,6 @@ class PrepareProject(BaseAction):
         self.log.debug("*** Creating project specifig configs Finished ***")
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
-    PrepareProject(session, plugins_presets).register()
+    PrepareProject(session).register()

--- a/pype/modules/ftrack/actions/action_rv.py
+++ b/pype/modules/ftrack/actions/action_rv.py
@@ -19,13 +19,8 @@ class RVAction(BaseAction):
 
     allowed_types = ["img", "mov", "exr", "mp4"]
 
-    def __init__(self, session, plugins_presets):
-        """ Constructor
-
-            :param session: ftrack Session
-            :type session: :class:`ftrack_api.Session`
-        """
-        super().__init__(session, plugins_presets)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # QUESTION load RV application data from AppplicationManager?
         rv_path = None
@@ -317,7 +312,7 @@ class RVAction(BaseAction):
         return paths
 
 
-def register(session, plugins_presets={}):
+def register(session):
     """Register hooks."""
 
-    RVAction(session, plugins_presets).register()
+    RVAction(session).register()

--- a/pype/modules/ftrack/actions/action_seed.py
+++ b/pype/modules/ftrack/actions/action_seed.py
@@ -428,7 +428,7 @@ class SeedDebugProject(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    SeedDebugProject(session, plugins_presets).register()
+    SeedDebugProject(session).register()

--- a/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
+++ b/pype/modules/ftrack/actions/action_store_thumbnails_to_avalon.py
@@ -457,5 +457,5 @@ class StoreThumbnailsToAvalon(BaseAction):
         return output
 
 
-def register(session, plugins_presets={}):
-    StoreThumbnailsToAvalon(session, plugins_presets).register()
+def register(session):
+    StoreThumbnailsToAvalon(session).register()

--- a/pype/modules/ftrack/actions/action_sync_to_avalon.py
+++ b/pype/modules/ftrack/actions/action_sync_to_avalon.py
@@ -187,7 +187,7 @@ class SyncToAvalonLocal(BaseAction):
                 pass
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    SyncToAvalonLocal(session, plugins_presets).register()
+    SyncToAvalonLocal(session).register()

--- a/pype/modules/ftrack/actions/action_test.py
+++ b/pype/modules/ftrack/actions/action_test.py
@@ -22,5 +22,5 @@ class TestAction(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
-    TestAction(session, plugins_presets).register()
+def register(session):
+    TestAction(session).register()

--- a/pype/modules/ftrack/actions/action_thumbnail_to_childern.py
+++ b/pype/modules/ftrack/actions/action_thumbnail_to_childern.py
@@ -59,7 +59,7 @@ class ThumbToChildren(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register action. Called when used as an event plugin.'''
 
-    ThumbToChildren(session, plugins_presets).register()
+    ThumbToChildren(session).register()

--- a/pype/modules/ftrack/actions/action_thumbnail_to_parent.py
+++ b/pype/modules/ftrack/actions/action_thumbnail_to_parent.py
@@ -85,7 +85,7 @@ class ThumbToParent(BaseAction):
         }
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register action. Called when used as an event plugin.'''
 
-    ThumbToParent(session, plugins_presets).register()
+    ThumbToParent(session).register()

--- a/pype/modules/ftrack/actions/action_where_run_ask.py
+++ b/pype/modules/ftrack/actions/action_where_run_ask.py
@@ -27,7 +27,7 @@ class ActionAskWhereIRun(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    ActionAskWhereIRun(session, plugins_presets).register()
+    ActionAskWhereIRun(session).register()

--- a/pype/modules/ftrack/actions/action_where_run_show.py
+++ b/pype/modules/ftrack/actions/action_where_run_show.py
@@ -76,7 +76,7 @@ class ActionShowWhereIRun(BaseAction):
         return True
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    ActionShowWhereIRun(session, plugins_presets).register()
+    ActionShowWhereIRun(session).register()

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -430,5 +430,5 @@ class PushHierValuesToNonHier(ServerAction):
         session.commit()
 
 
-def register(session, plugins_presets={}):
-    PushHierValuesToNonHier(session, plugins_presets).register()
+def register(session):
+    PushHierValuesToNonHier(session).register()

--- a/pype/modules/ftrack/events/action_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/action_sync_to_avalon.py
@@ -182,6 +182,6 @@ class SyncToAvalonServer(ServerAction):
                 pass
 
 
-def register(session, plugins_presets={}):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
-    SyncToAvalonServer(session, plugins_presets).register()
+    SyncToAvalonServer(session).register()

--- a/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
+++ b/pype/modules/ftrack/events/event_del_avalon_id_from_new.py
@@ -47,6 +47,6 @@ class DelAvalonIdFromNew(BaseEvent):
                 continue
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
-    DelAvalonIdFromNew(session, plugins_presets).register()
+    DelAvalonIdFromNew(session).register()

--- a/pype/modules/ftrack/events/event_first_version_status.py
+++ b/pype/modules/ftrack/events/event_first_version_status.py
@@ -182,7 +182,7 @@ class FirstVersionStatus(BaseEvent):
         return filtered_ents
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    FirstVersionStatus(session, plugins_presets).register()
+    FirstVersionStatus(session).register()

--- a/pype/modules/ftrack/events/event_next_task_update.py
+++ b/pype/modules/ftrack/events/event_next_task_update.py
@@ -225,5 +225,5 @@ class NextTaskUpdate(BaseEvent):
                     )
 
 
-def register(session, plugins_presets):
-    NextTaskUpdate(session, plugins_presets).register()
+def register(session):
+    NextTaskUpdate(session).register()

--- a/pype/modules/ftrack/events/event_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/event_push_frame_values_to_task.py
@@ -364,5 +364,5 @@ class PushFrameValuesToTaskEvent(BaseEvent):
         return output, hiearchical
 
 
-def register(session, plugins_presets):
-    PushFrameValuesToTaskEvent(session, plugins_presets).register()
+def register(session):
+    PushFrameValuesToTaskEvent(session).register()

--- a/pype/modules/ftrack/events/event_radio_buttons.py
+++ b/pype/modules/ftrack/events/event_radio_buttons.py
@@ -34,7 +34,7 @@ class RadioButtons(BaseEvent):
             session.commit()
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    RadioButtons(session, plugins_presets).register()
+    RadioButtons(session).register()

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -53,7 +53,7 @@ class SyncToAvalonEvent(BaseEvent):
     created_entities = []
     report_splitter = {"type": "label", "value": "---"}
 
-    def __init__(self, session, plugins_presets={}):
+    def __init__(self, session):
         '''Expects a ftrack_api.Session instance'''
         # Debug settings
         # - time expiration in seconds
@@ -67,7 +67,7 @@ class SyncToAvalonEvent(BaseEvent):
         self.dbcon = AvalonMongoDB()
         # Set processing session to not use global
         self.set_process_session(session)
-        super().__init__(session, plugins_presets)
+        super().__init__(session)
 
     def debug_logs(self):
         """This is debug method for printing small debugs messages. """
@@ -2513,6 +2513,6 @@ class SyncToAvalonEvent(BaseEvent):
         return mongo_id_configuration_id
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
-    SyncToAvalonEvent(session, plugins_presets).register()
+    SyncToAvalonEvent(session).register()

--- a/pype/modules/ftrack/events/event_task_to_parent_status.py
+++ b/pype/modules/ftrack/events/event_task_to_parent_status.py
@@ -419,5 +419,5 @@ class TaskStatusToParent(BaseEvent):
         return output
 
 
-def register(session, plugins_presets):
-    TaskStatusToParent(session, plugins_presets).register()
+def register(session):
+    TaskStatusToParent(session).register()

--- a/pype/modules/ftrack/events/event_task_to_version_status.py
+++ b/pype/modules/ftrack/events/event_task_to_version_status.py
@@ -372,5 +372,5 @@ class TaskToVersionStatus(BaseEvent):
         return last_asset_versions_by_task_id
 
 
-def register(session, plugins_presets):
-    TaskToVersionStatus(session, plugins_presets).register()
+def register(session):
+    TaskToVersionStatus(session).register()

--- a/pype/modules/ftrack/events/event_test.py
+++ b/pype/modules/ftrack/events/event_test.py
@@ -1,7 +1,3 @@
-import os
-import sys
-import re
-import ftrack_api
 from pype.modules.ftrack import BaseEvent
 
 
@@ -20,7 +16,7 @@ class TestEvent(BaseEvent):
         return True
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    TestEvent(session, plugins_presets).register()
+    TestEvent(session).register()

--- a/pype/modules/ftrack/events/event_thumbnail_updates.py
+++ b/pype/modules/ftrack/events/event_thumbnail_updates.py
@@ -151,5 +151,5 @@ class ThumbnailEvents(BaseEvent):
         return filtered_entities_info
 
 
-def register(session, plugins_presets):
-    ThumbnailEvents(session, plugins_presets).register()
+def register(session):
+    ThumbnailEvents(session).register()

--- a/pype/modules/ftrack/events/event_user_assigment.py
+++ b/pype/modules/ftrack/events/event_user_assigment.py
@@ -250,9 +250,9 @@ class UserAssigmentEvent(BaseEvent):
         return True
 
 
-def register(session, plugins_presets):
+def register(session):
     """
     Register plugin. Called when used as an plugin.
     """
 
-    UserAssigmentEvent(session, plugins_presets).register()
+    UserAssigmentEvent(session).register()

--- a/pype/modules/ftrack/events/event_version_to_task_statuses.py
+++ b/pype/modules/ftrack/events/event_version_to_task_statuses.py
@@ -241,7 +241,7 @@ class VersionToTaskStatus(BaseEvent):
         return output
 
 
-def register(session, plugins_presets):
+def register(session):
     '''Register plugin. Called when used as an plugin.'''
 
-    VersionToTaskStatus(session, plugins_presets).register()
+    VersionToTaskStatus(session).register()

--- a/pype/modules/ftrack/ftrack_server/ftrack_server.py
+++ b/pype/modules/ftrack/ftrack_server/ftrack_server.py
@@ -108,21 +108,10 @@ class FtrackServer:
                 " in registered paths: \"{}\""
             ).format("| ".join(paths)))
 
-        # TODO replace with settings or get rid of passing the dictionary
-        plugins_presets = {}
-
-        function_counter = 0
         for function_dict in register_functions_dict:
             register = function_dict["register"]
             try:
-                if len(inspect.signature(register).parameters) == 1:
-                    register(self.session)
-                else:
-                    register(self.session, plugins_presets=plugins_presets)
-
-                if function_counter % 7 == 0:
-                    time.sleep(0.1)
-                function_counter += 1
+                register(self.session)
             except Exception as exc:
                 msg = '"{}" - register was not successful ({})'.format(
                     function_dict['name'], str(exc)

--- a/pype/modules/ftrack/lib/ftrack_action_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_action_handler.py
@@ -29,7 +29,7 @@ class BaseAction(BaseHandler):
     icon = None
     type = 'Action'
 
-    def __init__(self, session, plugins_presets={}):
+    def __init__(self, session):
         '''Expects a ftrack_api.Session instance'''
         if self.label is None:
             raise ValueError('Action missing label.')
@@ -37,7 +37,7 @@ class BaseAction(BaseHandler):
         if self.identifier is None:
             raise ValueError('Action missing identifier.')
 
-        super().__init__(session, plugins_presets)
+        super().__init__(session)
 
     def register(self):
         '''

--- a/pype/modules/ftrack/lib/ftrack_event_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_event_handler.py
@@ -15,10 +15,6 @@ class BaseEvent(BaseHandler):
 
     type = 'Event'
 
-    def __init__(self, session, plugins_presets={}):
-        '''Expects a ftrack_api.Session instance'''
-        super().__init__(session, plugins_presets)
-
     # Decorator
     def launch_log(self, func):
         @functools.wraps(func)


### PR DESCRIPTION
## Description
- Presets were passed to Ftrack events/actions on initialization which does not make sence anymore as it should be handled inside handlers "on demand" by selection or changes. This passing of empty dictionary was removed.

## Changes
- `plugins_presets` argument was removed from `__init__`