### PR TITLE
Ftrack project entity is not stored to event data

### DIFF
--- a/pype/modules/ftrack/events/event_task_to_parent_status.py
+++ b/pype/modules/ftrack/events/event_task_to_parent_status.py
@@ -56,17 +56,16 @@ class TaskStatusToParent(BaseEvent):
         return filtered_entity_info
 
     def process_by_project(self, session, event, project_id, entities_info):
-        # Get project entity
-        project_entity = self.get_project_entity_from_event(
+        # Get project name
+        project_name = self.get_project_name_from_event(
             session, event, project_id
         )
         # Load settings
         project_settings = self.get_project_settings_from_event(
-            event, project_entity
+            event, project_name
         )
 
         # Prepare loaded settings and check if can be processed
-        project_name = project_entity["full_name"]
         result = self.prepare_settings(project_settings, project_name)
         if not result:
             return
@@ -133,6 +132,7 @@ class TaskStatusToParent(BaseEvent):
             obj_id = object_type["id"]
             object_type_name_by_id[obj_id] = types_mapping[mapping_name]
 
+        project_entity = session.get("Project", project_id)
         project_schema = project_entity["project_schema"]
         available_statuses_by_obj_id = {}
         for obj_id in obj_ids:

--- a/pype/modules/ftrack/events/event_task_to_version_status.py
+++ b/pype/modules/ftrack/events/event_task_to_version_status.py
@@ -99,14 +99,14 @@ class TaskToVersionStatus(BaseEvent):
         if not entities_info:
             return
 
-        project_entity = self.get_project_entity_from_event(
+        project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        # Load settings
         project_settings = self.get_project_settings_from_event(
-            event, project_entity
+            event, project_name
         )
 
-        project_name = project_entity["full_name"]
         event_settings = (
             project_settings["ftrack"]["events"][self.settings_key]
         )
@@ -171,6 +171,7 @@ class TaskToVersionStatus(BaseEvent):
         }
 
         # Final process of changing statuses
+        project_entity = session.get("Project", project_id)
         av_statuses_by_low_name, av_statuses_by_id = (
             self.get_asset_version_statuses(project_entity)
         )

--- a/pype/modules/ftrack/events/event_thumbnail_updates.py
+++ b/pype/modules/ftrack/events/event_thumbnail_updates.py
@@ -19,14 +19,14 @@ class ThumbnailEvents(BaseEvent):
     def process_project_entities(
         self, session, event, project_id, entities_info
     ):
-        project_entity = self.get_project_entity_from_event(
+        project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        # Load settings
         project_settings = self.get_project_settings_from_event(
-            event, project_entity
+            event, project_name
         )
 
-        project_name = project_entity["full_name"]
         event_settings = (
             project_settings
             ["ftrack"]

--- a/pype/modules/ftrack/events/event_version_to_task_statuses.py
+++ b/pype/modules/ftrack/events/event_version_to_task_statuses.py
@@ -48,14 +48,15 @@ class VersionToTaskStatus(BaseEvent):
     def process_by_project(self, session, event, project_id, entities_info):
         # Check for project data if event is enabled for event handler
         status_mapping = None
-        project_entity = self.get_project_entity_from_event(
+
+        project_name = self.get_project_name_from_event(
             session, event, project_id
         )
+        # Load settings
         project_settings = self.get_project_settings_from_event(
-            event, project_entity
+            event, project_name
         )
 
-        project_name = project_entity["full_name"]
         # Load status mapping from presets
         event_settings = (
             project_settings["ftrack"]["events"]["status_version_to_task"]
@@ -147,7 +148,7 @@ class VersionToTaskStatus(BaseEvent):
 
         # Qeury statuses
         statusese_by_obj_id = self.statuses_for_tasks(
-            session, task_entities, project_entity
+            session, task_entities, project_id
         )
         # Prepare status names by their ids
         status_name_by_id = {
@@ -224,11 +225,12 @@ class VersionToTaskStatus(BaseEvent):
                     exc_info=True
                 )
 
-    def statuses_for_tasks(self, session, task_entities, project_entity):
+    def statuses_for_tasks(self, session, task_entities, project_id):
         task_type_ids = set()
         for task_entity in task_entities:
             task_type_ids.add(task_entity["type_id"])
 
+        project_entity = session.get("Project", project_id)
         project_schema = project_entity["project_schema"]
         output = {}
         for task_type_id in task_type_ids:

--- a/pype/modules/ftrack/lib/ftrack_action_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_action_handler.py
@@ -281,7 +281,7 @@ class BaseAction(BaseHandler):
         return project_name
 
     def get_ftrack_settings(self, session, event, entities):
-        project_name = self.get_project_data_from_event(
+        project_name = self.get_project_name_from_event(
             session, event, entities
         )
         project_settings = self.get_project_settings_from_event(

--- a/pype/modules/ftrack/lib/ftrack_action_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_action_handler.py
@@ -257,7 +257,7 @@ class BaseAction(BaseHandler):
             event["data"]["user_roles"] = user_roles
         return user_roles
 
-    def get_project_entity_from_event(self, session, event, entities):
+    def get_project_name_from_event(self, session, event, entities):
         """Load or query and fill project entity from/to event data.
 
         Project data are stored by ftrack id because in most cases it is
@@ -270,20 +270,22 @@ class BaseAction(BaseHandler):
         """
 
         # Try to get project entity from event
-        project_entity = event["data"].get("project_entity")
-        if not project_entity:
+        project_name = event["data"].get("project_name")
+        if not project_name:
             project_entity = self.get_project_from_entity(
                 entities[0], session
             )
-            event["data"]["project_entity"] = project_entity
-        return project_entity
+            project_name = project_entity["full_name"]
+
+            event["data"]["project_name"] = project_name
+        return project_name
 
     def get_ftrack_settings(self, session, event, entities):
-        project_entity = self.get_project_entity_from_event(
+        project_name = self.get_project_data_from_event(
             session, event, entities
         )
         project_settings = self.get_project_settings_from_event(
-            event, project_entity
+            event, project_name
         )
         return project_settings["ftrack"]
 

--- a/pype/modules/ftrack/lib/ftrack_base_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_base_handler.py
@@ -556,7 +556,7 @@ class BaseHandler(object):
             "Project where id is {}".format(project_data["id"])
         ).one()
 
-    def get_project_settings_from_event(self, event, project_entity):
+    def get_project_settings_from_event(self, event, project_name):
         """Load or fill pype's project settings from event data.
 
         Project data are stored by ftrack id because in most cases it is
@@ -566,24 +566,15 @@ class BaseHandler(object):
             event (ftrack_api.Event): Processed event by session.
             project_entity (ftrack_api.Entity): Project entity.
         """
-        if not project_entity:
-            raise AssertionError((
-                "Invalid arguments entered. Project entity or project id"
-                "must be entered."
-            ))
-
-        project_id = project_entity["id"]
-        project_name = project_entity["full_name"]
-
         project_settings_by_id = event["data"].get("project_settings")
         if not project_settings_by_id:
             project_settings_by_id = {}
             event["data"]["project_settings"] = project_settings_by_id
 
-        project_settings = project_settings_by_id.get(project_id)
+        project_settings = project_settings_by_id.get(project_name)
         if not project_settings:
             project_settings = get_project_settings(project_name)
-            event["data"]["project_settings"][project_id] = project_settings
+            event["data"]["project_settings"][project_name] = project_settings
         return project_settings
 
     @staticmethod

--- a/pype/modules/ftrack/lib/ftrack_event_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_event_handler.py
@@ -65,14 +65,15 @@ class BaseEvent(BaseHandler):
                 )
             )
         # Try to get project entity from event
-        project_entities = event["data"].get("project_entities")
-        if not project_entities:
-            project_entities = {}
-            event["data"]["project_entities"] = project_entities
+        project_data = event["data"].get("project_data")
+        if not project_data:
+            project_data = {}
+            event["data"]["project_data"] = project_data
 
-        project_entity = project_entities.get(project_id)
-        if not project_entity:
+        project_name = project_data.get(project_id)
+        if not project_name:
             # Get project entity from task and store to event
             project_entity = session.get("Project", project_id)
-            event["data"]["project_entities"][project_id] = project_entity
-        return project_entity
+            project_name = project_entity["full_name"]
+            event["data"]["project_data"][project_id] = project_name
+        return project_name

--- a/pype/modules/ftrack/lib/ftrack_event_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_event_handler.py
@@ -47,7 +47,7 @@ class BaseEvent(BaseHandler):
             ignore=['socialfeed', 'socialnotification']
         )
 
-    def get_project_entity_from_event(self, session, event, project_id):
+    def get_project_name_from_event(self, session, event, project_id):
         """Load or query and fill project entity from/to event data.
 
         Project data are stored by ftrack id because in most cases it is


### PR DESCRIPTION
## Issue
Ftrack entities are cleared from queried data on `session.rollback()`. Since rollback has stored project entity in event data all attributes and keys (mainly `full_name`) to `NOT_SET`. So each event would have to query project again or will crash if condition is not right.

## Changes
- project settings are stored by `project_name` and method to get project settings from event data expect only `project_name` argument which is all it need
- project entity is not stored to event data only project name, which is string so can't be changed to `NOT_SET` so event rollback won't cause requery of project for loading settings
- all this is applied for implementations and usage in current `develop` branch
    - must be pushed and modified in PR: https://github.com/pypeclub/pype/pull/847