### PR TITLE
Create dict copy of environments on application launch

### DIFF
--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -531,12 +531,22 @@ class ApplicationLaunchContext:
 
         # Handle launch environemtns
         env = self.data.pop("env", None)
+        if env is not None and not isinstance(env, dict):
+            self.log.warning((
+                "Passed `env` kwarg has invalid type: {}. Expected: `dict`."
+                " Using `os.environ` instead."
+            ).format(str(type(env))))
+            env = None
+
         if env is None:
             env = os.environ
 
         # subprocess.Popen keyword arguments
         self.kwargs = {
-            "env": env.copy()
+            "env": {
+                key: str(value)
+                for key, value in env.items()
+            }
         }
 
         if platform.system().lower() == "windows":

--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -1,5 +1,4 @@
 import os
-import copy
 import platform
 import inspect
 import subprocess

--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -531,15 +531,13 @@ class ApplicationLaunchContext:
         self.launch_args = executable.as_args()
 
         # Handle launch environemtns
-        passed_env = self.data.pop("env", None)
-        if passed_env is None:
+        env = self.data.pop("env", None)
+        if env is None:
             env = os.environ
-        else:
-            env = passed_env
 
         # subprocess.Popen keyword arguments
         self.kwargs = {
-            "env": copy.deepcopy(env)
+            "env": env.copy()
         }
 
         if platform.system().lower() == "windows":


### PR DESCRIPTION
## Issue
- on app launch was used `copy.deepcopy` to create copy of passed environment but if `os.environ` is used it will create copy of object `os._Environ` which is singleton so all modifications are also applied to current process environments

## Change
- variable `env` is always converted to a dictionary