### PR TITLE
Sync hier attributes with settings

### DIFF
--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -61,16 +61,22 @@ class PushHierValuesToNonHier(ServerAction):
     # configurable
     interest_entity_types = ["Shot"]
     interest_attributes = ["frameStart", "frameEnd"]
-    role_list = ["Pypeclub", "Administrator", "Project Manager"]
+
+    settings_key = "sync_hier_entity_attributes"
 
     def discover(self, session, entities, event):
         """ Validation """
         # Check if selection is valid
+        is_valid = False
         for ent in event["data"]["selection"]:
             # Ignore entities that are not tasks or projects
             if ent["entityType"].lower() in ("task", "show"):
-                return True
-        return False
+                is_valid = True
+                break
+
+        if is_valid:
+            is_valid = self.valid_roles(session, entities, event)
+        return is_valid
 
     def launch(self, session, entities, event):
         self.log.debug("{}: Creating job".format(self.label))

--- a/pype/modules/ftrack/events/action_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/action_push_frame_values_to_task.py
@@ -115,7 +115,7 @@ class PushHierValuesToNonHier(ServerAction):
                 job["status"] = "failed"
                 session.commit()
 
-    def attrs_configurations(self, session, object_ids, interest_attributess):
+    def attrs_configurations(self, session, object_ids, interest_attributes):
         attrs = session.query(self.cust_attrs_query.format(
             self.join_query_keys(interest_attributes),
             self.join_query_keys(object_ids)
@@ -169,10 +169,10 @@ class PushHierValuesToNonHier(ServerAction):
             for obj_type in destination_object_types
         )
 
-        interest_attributess = action_settings["interest_attributess"]
+        interest_attributes = action_settings["interest_attributes"]
         # Find custom attributes definitions
         attrs_by_obj_id, hier_attrs = self.attrs_configurations(
-            session, destination_object_type_ids, interest_attributess
+            session, destination_object_type_ids, interest_attributes
         )
         # Filter destination object types if they have any object specific
         # custom attribute

--- a/pype/modules/ftrack/events/event_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/event_push_frame_values_to_task.py
@@ -31,10 +31,6 @@ class PushFrameValuesToTaskEvent(BaseEvent):
     interest_entity_types = {"Shot"}
     interest_attributes = {"frameStart", "frameEnd"}
 
-    @staticmethod
-    def join_keys(keys):
-        return ",".join(["\"{}\"".format(key) for key in keys])
-
     @classmethod
     def task_object_id(cls, session):
         if cls._cached_task_object_id is None:
@@ -49,7 +45,7 @@ class PushFrameValuesToTaskEvent(BaseEvent):
         if cls._cached_interest_object_ids is None:
             object_types = session.query(
                 "ObjectType where name in ({})".format(
-                    cls.join_keys(cls.interest_entity_types)
+                    cls.join_query_keys(cls.interest_entity_types)
                 )
             ).all()
             cls._cached_interest_object_ids = tuple(
@@ -113,8 +109,8 @@ class PushFrameValuesToTaskEvent(BaseEvent):
                 "There is not created Custom Attributes {} "
                 " for entity types: {}"
             ).format(
-                self.join_keys(self.interest_attributes),
-                self.join_keys(self.interest_entity_types)
+                self.join_query_keys(self.interest_attributes),
+                self.join_query_keys(self.interest_entity_types)
             ))
             return
 
@@ -220,8 +216,8 @@ class PushFrameValuesToTaskEvent(BaseEvent):
         current_values_by_id = {}
         if not attr_ids or not entity_ids:
             return current_values_by_id
-        joined_conf_ids = self.join_keys(attr_ids)
-        joined_entity_ids = self.join_keys(entity_ids)
+        joined_conf_ids = self.join_query_keys(attr_ids)
+        joined_entity_ids = self.join_query_keys(entity_ids)
 
         call_expr = [{
             "action": "query",
@@ -324,7 +320,7 @@ class PushFrameValuesToTaskEvent(BaseEvent):
     def get_entities(self, session, interesting_data):
         entities = session.query(
             "TypedContext where id in ({})".format(
-                self.join_keys(interesting_data.keys())
+                self.join_query_keys(interesting_data.keys())
             )
         ).all()
 
@@ -338,7 +334,7 @@ class PushFrameValuesToTaskEvent(BaseEvent):
     def get_task_entities(self, session, interesting_data):
         return session.query(
             "Task where parent_id in ({})".format(
-                self.join_keys(interesting_data.keys())
+                self.join_query_keys(interesting_data.keys())
             )
         ).all()
 
@@ -347,8 +343,8 @@ class PushFrameValuesToTaskEvent(BaseEvent):
         object_ids.append(self.task_object_id(session))
 
         attrs = session.query(self.cust_attrs_query.format(
-            self.join_keys(self.interest_attributes),
-            self.join_keys(object_ids)
+            self.join_query_keys(self.interest_attributes),
+            self.join_query_keys(object_ids)
         )).all()
 
         output = {}

--- a/pype/modules/ftrack/events/event_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/event_push_frame_values_to_task.py
@@ -171,8 +171,11 @@ class PushFrameValuesToTaskEvent(BaseEvent):
         )
 
         task_attrs = attrs_by_obj_id.get(task_object_id)
+
+        changed_keys = set()
         # Skip keys that are not both in hierachical and type specific
         for object_id, keys in changed_keys_by_object_id.items():
+            changed_keys |= set(keys)
             object_id_attrs = attrs_by_obj_id.get(object_id)
             for key in keys:
                 if key not in hier_attrs:
@@ -213,10 +216,17 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             task_entity_ids.add(task_id)
             parent_id_by_task_id[task_id] = task_entity["parent_id"]
 
-        changed_keys = set()
-        for keys in changed_keys_by_object_id.values():
-            changed_keys |= set(keys)
+        self.finalize(
+            session, interesting_data,
+            changed_keys, attrs_by_obj_id, hier_attrs,
+            task_entity_ids, parent_id_by_task_id
+        )
 
+    def finalize(
+        self, session, interesting_data,
+        changed_keys, attrs_by_obj_id, hier_attrs,
+        task_entity_ids, parent_id_by_task_id
+    ):
         attr_id_to_key = {}
         for attr_confs in attrs_by_obj_id.values():
             for key in changed_keys:

--- a/pype/modules/ftrack/events/event_push_frame_values_to_task.py
+++ b/pype/modules/ftrack/events/event_push_frame_values_to_task.py
@@ -143,8 +143,6 @@ class PushFrameValuesToTaskEvent(BaseEvent):
                 self.log.warning("Couldn't find object type \"{}\"".format(
                     entity_type
                 ))
-                # TODO remove - only for testing
-                return
 
             interest_object_ids.append(object_type["id"])
 
@@ -393,10 +391,9 @@ class PushFrameValuesToTaskEvent(BaseEvent):
             "select id from TypedContext"
             " where id in ({}) and object_type_id in ({})"
         ).format(
-                self.join_query_keys(interesting_data.keys()),
-                self.join_query_keys(interest_object_ids)
-            )
-        ).all()
+            self.join_query_keys(interesting_data.keys()),
+            self.join_query_keys(interest_object_ids)
+        )).all()
 
     def get_task_entities(self, session, interesting_data):
         return session.query(

--- a/pype/modules/ftrack/lib/ftrack_action_handler.py
+++ b/pype/modules/ftrack/lib/ftrack_action_handler.py
@@ -30,6 +30,7 @@ class BaseAction(BaseHandler):
     type = 'Action'
 
     settings_frack_subkey = "user_handlers"
+    settings_enabled_key = "enabled"
 
     def __init__(self, session):
         '''Expects a ftrack_api.Session instance'''
@@ -298,8 +299,9 @@ class BaseAction(BaseHandler):
         settings = (
             ftrack_settings[self.settings_frack_subkey][self.settings_key]
         )
-        if not settings.get("enabled", True):
-            return False
+        if self.settings_enabled_key:
+            if not settings.get(self.settings_enabled_key, True):
+                return False
 
         user_role_list = self.get_user_roles_from_event(session, event)
         if not self.roles_check(settings.get("role_list"), user_role_list):

--- a/pype/settings/defaults/project_settings/ftrack.json
+++ b/pype/settings/defaults/project_settings/ftrack.json
@@ -9,15 +9,21 @@
                 "not ready"
             ]
         },
-        "push_frame_values_to_task": {
+        "sync_hier_entity_attributes": {
             "enabled": true,
             "interest_entity_types": [
-                "shot",
-                "asset build"
+                "Shot",
+                "Asset Build"
             ],
             "interest_attributess": [
                 "frameStart",
                 "frameEnd"
+            ],
+            "action_enabled": true,
+            "role_list": [
+                "Pypeclub",
+                "Administrator",
+                "Project Manager"
             ]
         },
         "thumbnail_updates": {

--- a/pype/settings/defaults/project_settings/ftrack.json
+++ b/pype/settings/defaults/project_settings/ftrack.json
@@ -15,7 +15,7 @@
                 "Shot",
                 "Asset Build"
             ],
-            "interest_attributess": [
+            "interest_attributes": [
                 "frameStart",
                 "frameEnd"
             ],

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
@@ -61,7 +61,7 @@
                 },
                 {
                     "type": "dict",
-                    "key": "push_frame_values_to_task",
+                    "key": "sync_hier_entity_attributes",
                     "label": "Sync Hierarchical and Entity Attributes",
                     "checkbox_key": "enabled",
                     "children": [

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
@@ -92,6 +92,11 @@
                             "type": "separator"
                         },
                         {
+                            "type": "boolean",
+                            "key": "action_enabled",
+                            "label": "Enable Action"
+                        },
+                        {
                             "type": "list",
                             "key": "role_list",
                             "label": "Roles for action",

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
@@ -81,7 +81,7 @@
                         },
                         {
                             "type": "list",
-                            "key": "interest_attributess",
+                            "key": "interest_attributes",
                             "label": "Attributes to sync",
                             "object_type": {
                                 "type": "text",

--- a/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/projects_schema/schema_project_ftrack.json
@@ -87,6 +87,15 @@
                                 "type": "text",
                                 "multiline": false
                             }
+                        },
+                        {
+                            "type": "separator"
+                        },
+                        {
+                            "type": "list",
+                            "key": "role_list",
+                            "label": "Roles for action",
+                            "object_type": "text"
                         }
                     ]
                 },


### PR DESCRIPTION
## Changes
- `Sync Hierarchical and Entity Attributes` event and action are using settings
- both use same settings key
    - added role list to settings and special "enable" button for action
    - enable button on top control's event
    - NOTE: this is not clear maybe both should be under label or split action enable (and role list) under different label
- event had to be rewritten drastically as it was based on knowing the attributes at the beginning of filtering 