### PR TITLE
Settings shadow widget when working

### DIFF
--- a/pype/modules/settings_action.py
+++ b/pype/modules/settings_action.py
@@ -45,8 +45,16 @@ class SettingsAction(PypeModule, ITrayAction):
         if not self.settings_window:
             raise AssertionError("Window is not initialized.")
 
+        # Store if was visible
+        was_visible = self.settings_window.isVisible()
+
+        # Show settings gui
         self.settings_window.show()
 
         # Pull window to the front.
         self.settings_window.raise_()
         self.settings_window.activateWindow()
+
+        # Reset content if was not visible
+        if not was_visible:
+            self.settings_window.reset()

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -19,7 +19,6 @@ def main(user_role=None):
     app.setWindowIcon(QtGui.QIcon(style.app_icon_path()))
 
     widget = MainWidget(user_role)
-    widget.reset()
     widget.show()
     widget.reset()
 

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -19,6 +19,7 @@ def main(user_role=None):
     app.setWindowIcon(QtGui.QIcon(style.app_icon_path()))
 
     widget = MainWidget(user_role)
+    widget.reset()
     widget.show()
     widget.reset()
 

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -20,6 +20,7 @@ def main(user_role=None):
 
     widget = MainWidget(user_role)
     widget.show()
+    widget.reset()
 
     sys.exit(app.exec_())
 

--- a/pype/tools/settings/settings/style/style.css
+++ b/pype/tools/settings/settings/style/style.css
@@ -193,6 +193,9 @@ QPushButton[btn-type="expand-toggle"] {
     background-color: #21252B;
 }
 
+#ShadowWidget {
+    font-size: 36pt;
+}
 QTabWidget::pane {
     border-top-style: none;
 }

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -76,6 +76,8 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
 
         self._state = state
         self.state_changed.emit()
+
+        # Process events so emitted signal is processed
         app = QtWidgets.QApplication.instance()
         if app:
             app.processEvents()

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -578,6 +578,8 @@ class ProjectWidget(SettingsCategoryWidget):
         return True
 
     def _on_project_change(self):
+        self.set_state(CategoryState.Working)
+
         project_name = self.project_list_widget.project_name()
         if project_name is None:
             _project_overrides = lib.NOT_SET
@@ -601,6 +603,8 @@ class ProjectWidget(SettingsCategoryWidget):
         for item in self.input_fields:
             item.apply_overrides(overrides)
         self.ignore_value_changes = False
+
+        self.set_state(CategoryState.Idle)
 
     def save(self):
         data = {}

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -50,6 +50,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
     initial_schema_name = None
 
     state_changed = QtCore.Signal()
+    saved = QtCore.Signal(QtWidgets.QWidget)
 
     def __init__(self, user_role, parent=None):
         super(SettingsCategoryWidget, self).__init__(parent)

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -430,7 +430,7 @@ class SettingObject:
                 return self.mouseReleaseEvent(event)
             return
 
-        menu = QtWidgets.QMenu()
+        menu = QtWidgets.QMenu(self)
 
         actions_mapping = {}
         if self.child_modified:

--- a/pype/tools/settings/settings/widgets/widgets.py
+++ b/pype/tools/settings/settings/widgets/widgets.py
@@ -2,6 +2,48 @@ from Qt import QtWidgets, QtCore, QtGui
 from avalon.vendor import qtawesome
 
 
+class ShadowWidget(QtWidgets.QWidget):
+    def __init__(self, message, parent):
+        super(ShadowWidget, self).__init__(parent)
+        self.setObjectName("ShadowWidget")
+
+        self.parent_widget = parent
+        self.message = message
+
+        def wrapper(func):
+            def wrapped(*args, **kwarg):
+                result = func(*args, **kwarg)
+                self._update_geometry()
+                return result
+            return wrapped
+
+        parent.resizeEvent = wrapper(parent.resizeEvent)
+        parent.moveEvent = wrapper(parent.moveEvent)
+        parent.showEvent = wrapper(parent.showEvent)
+
+    def set_message(self, message):
+        self.message = message
+        if self.isVisible():
+            self.repaint()
+
+    def _update_geometry(self):
+        self.setGeometry(self.parent_widget.rect())
+
+    def paintEvent(self, event):
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing)
+        painter.fillRect(
+            event.rect(), QtGui.QBrush(QtGui.QColor(0, 0, 0, 127))
+        )
+        if self.message:
+            painter.drawText(
+                event.rect(),
+                QtCore.Qt.AlignCenter | QtCore.Qt.AlignCenter,
+                self.message
+            )
+        painter.end()
+
+
 class IconButton(QtWidgets.QPushButton):
     def __init__(self, icon_name, color, hover_color, *args, **kwargs):
         super(IconButton, self).__init__(*args, **kwargs)

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -1,5 +1,6 @@
 from Qt import QtWidgets, QtGui
-from .base import SystemWidget, ProjectWidget
+from .base import CategoryState, SystemWidget, ProjectWidget
+from .widgets import ShadowWidget
 from .. import style
 
 
@@ -31,3 +32,32 @@ class MainWidget(QtWidgets.QWidget):
         layout.addWidget(header_tab_widget)
 
         self.setLayout(layout)
+
+        self.tab_widgets = [
+            studio_widget,
+            project_widget
+        ]
+
+        self._shadow_widget = ShadowWidget("Working...", self)
+
+        for widget in self.tab_widgets:
+            widget.state_changed.connect(self._on_state_change)
+
+    def _on_state_change(self):
+        any_working = False
+        for widget in self.tab_widgets:
+            if widget.state is CategoryState.Working:
+                any_working = True
+                break
+
+        if (
+            (any_working and self._shadow_widget.isVisible())
+            or (not any_working and not self._shadow_widget.isVisible())
+        ):
+            return
+
+        self._shadow_widget.setVisible(any_working)
+
+    def reset(self):
+        for widget in self.tab_widgets:
+            widget.reset()

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -66,6 +66,11 @@ class MainWidget(QtWidgets.QWidget):
 
         self._shadow_widget.setVisible(any_working)
 
+        # Process events to apply shadow widget visibility
+        app = QtWidgets.QApplication.instance()
+        if app:
+            app.processEvents()
+
     def reset(self):
         for tab_widget in self.tab_widgets:
             tab_widget.reset()

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -23,6 +23,12 @@ class MainWidget(QtWidgets.QWidget):
 
         studio_widget = SystemWidget(user_role, header_tab_widget)
         project_widget = ProjectWidget(user_role, header_tab_widget)
+
+        tab_widgets = [
+            studio_widget,
+            project_widget
+        ]
+
         header_tab_widget.addTab(studio_widget, "System")
         header_tab_widget.addTab(project_widget, "Project")
 
@@ -33,31 +39,15 @@ class MainWidget(QtWidgets.QWidget):
 
         self.setLayout(layout)
 
-        self.tab_widgets = [
-            studio_widget,
-            project_widget
-        ]
+        for tab_widget in tab_widgets:
+            tab_widget.saved.connect(self._on_tab_save)
 
-        self._shadow_widget = ShadowWidget("Working...", self)
+        self.tab_widgets = tab_widgets
 
-        for widget in self.tab_widgets:
-            widget.state_changed.connect(self._on_state_change)
-
-    def _on_state_change(self):
-        any_working = False
-        for widget in self.tab_widgets:
-            if widget.state is CategoryState.Working:
-                any_working = True
-                break
-
-        if (
-            (any_working and self._shadow_widget.isVisible())
-            or (not any_working and not self._shadow_widget.isVisible())
-        ):
-            return
-
-        self._shadow_widget.setVisible(any_working)
+    def _on_tab_save(self, source_widget):
+        for tab_widget in self.tab_widgets:
+            tab_widget.on_saved(source_widget)
 
     def reset(self):
-        for widget in self.tab_widgets:
-            widget.reset()
+        for tab_widget in self.tab_widgets:
+            tab_widget.reset()

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -39,14 +39,32 @@ class MainWidget(QtWidgets.QWidget):
 
         self.setLayout(layout)
 
+        self._shadow_widget = ShadowWidget("Working...", self)
+
         for tab_widget in tab_widgets:
             tab_widget.saved.connect(self._on_tab_save)
+            tab_widget.state_changed.connect(self._on_state_change)
 
         self.tab_widgets = tab_widgets
 
     def _on_tab_save(self, source_widget):
         for tab_widget in self.tab_widgets:
             tab_widget.on_saved(source_widget)
+
+    def _on_state_change(self):
+        any_working = False
+        for widget in self.tab_widgets:
+            if widget.state is CategoryState.Working:
+                any_working = True
+                break
+
+        if (
+            (any_working and self._shadow_widget.isVisible())
+            or (not any_working and not self._shadow_widget.isVisible())
+        ):
+            return
+
+        self._shadow_widget.setVisible(any_working)
 
     def reset(self):
         for tab_widget in self.tab_widgets:


### PR DESCRIPTION
## Changes
- settings gui sets overlay widget with text when can't response to user events (on save and load)
- it's not perfect but it is at least visible that user should wait

## Changes moved from https://github.com/pypeclub/pype/pull/867
- settings gui is not loading settings on initialization but must be explicitelly called
- with this change is possible to have faster loading of settings action in tray and call reset on settings show
    - tray initialization is faster but loading of settings gui will take a longer time on each show (settings gui is always reset when opened from tray)
- Settings gui is not using `avalon.io` but `AvalonMongoDB` which is also reset if `AVALON_MONGO` is changed in system category

## Screenshot
![image](https://user-images.githubusercontent.com/43494761/103014470-14d9b400-453f-11eb-8165-488cc4c2750c.png)
