### PR TITLE
Ftrack custom attributes from settings

### DIFF
--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -94,8 +94,8 @@ Example:
     "avalon_auto_sync": {
       "label": "Avalon auto-sync",
       "type": "boolean",
-      "write_security_role": ["API", "Administrator"],
-      "read_security_role": ["API", "Administrator"]
+      "write_security_roles": ["API", "Administrator"],
+      "read_security_roles": ["API", "Administrator"]
     }
 },
 "is_hierarchical": {
@@ -136,7 +136,11 @@ class CustomAttributes(BaseAction):
 
     required_keys = ("key", "label", "type")
 
-    presetable_keys = ("default", "write_security_role", "read_security_role")
+    presetable_keys = (
+        "default",
+        "write_security_roles",
+        "read_security_roles"
+    )
     hierarchical_key = "is_hierarchical"
 
     type_posibilities = (
@@ -211,17 +215,17 @@ class CustomAttributes(BaseAction):
         self.groups = {}
 
         self.ftrack_settings = get_system_settings()["modules"]["ftrack"]
-        self.attrs_presets = self.prepare_attribute_pressets()
+        self.attrs_settings = self.prepare_attribute_settings()
 
-    def prepare_attribute_pressets(self):
+    def prepare_attribute_settings(self):
         output = {}
-        attr_presets = self.ftrack_settings["custom_attributes"]
-        for entity_type, preset in attr_presets.items():
+        attr_settings = self.ftrack_settings["custom_attributes"]
+        for entity_type, attr_data in attr_settings.items():
             # Lower entity type
             entity_type = entity_type.lower()
             # Just store if entity type is not "task"
             if entity_type != "task":
-                output[entity_type] = preset
+                output[entity_type] = attr_data
                 continue
 
             # Prepare empty dictionary for entity type if not set yet
@@ -229,7 +233,7 @@ class CustomAttributes(BaseAction):
                 output[entity_type] = {}
 
             # Store presets per lowered object type
-            for obj_type, _preset in preset.items():
+            for obj_type, _preset in attr_data.items():
                 output[entity_type][obj_type.lower()] = _preset
 
         return output
@@ -496,21 +500,20 @@ class CustomAttributes(BaseAction):
         else:
             entity_key = attr_data["entity_type"]
 
-        entity_presets = self.attrs_presets.get(entity_key) or {}
+        entity_settings = self.attrs_settings.get(entity_key) or {}
         if entity_key.lower() == "task":
             object_type = attr_data["object_type"]
-            entity_presets = entity_presets.get(object_type.lower()) or {}
+            entity_settings = entity_settings.get(object_type.lower()) or {}
 
-        key_presets = entity_presets.get(attr_key) or {}
-
-        for key, value in key_presets.items():
+        key_settings = entity_settings.get(attr_key) or {}
+        for key, value in key_settings.items():
             if key in self.presetable_keys and value:
                 output[key] = value
         return output
 
     def process_attr_data(self, cust_attr_data, event):
-        attr_presets = self.presets_for_attr_data(cust_attr_data)
-        cust_attr_data.update(attr_presets)
+        attr_settings = self.presets_for_attr_data(cust_attr_data)
+        cust_attr_data.update(attr_settings)
 
         try:
             data = {}
@@ -778,9 +781,9 @@ class CustomAttributes(BaseAction):
             roles_read = attr["read_security_roles"]
         if "write_security_roles" in attr:
             roles_write = attr["write_security_roles"]
-        output['read_security_roles'] = self.get_security_roles(roles_read)
-        output['write_security_roles'] = self.get_security_roles(roles_write)
 
+        output["read_security_roles"] = self.get_security_roles(roles_read)
+        output["write_security_roles"] = self.get_security_roles(roles_write)
         return output
 
     def get_entity_type(self, attr):

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -270,14 +270,11 @@ class CustomAttributes(BaseAction):
 
     def create_hierarchical_mongo_attr(self, session, event):
         # Set security roles for attribute
-        default_role_list = ("API", "Administrator", "Pypeclub")
         data = {
             "key": CUST_ATTR_ID_KEY,
             "label": "Avalon/Mongo ID",
             "type": "text",
             "default": "",
-            "write_security_roles": default_role_list,
-            "read_security_roles": default_role_list,
             "group": CUST_ATTR_GROUP,
             "is_hierarchical": True,
             "config": {"markdown": False}

--- a/pype/modules/ftrack/lib/custom_attributes.json
+++ b/pype/modules/ftrack/lib/custom_attributes.json
@@ -2,15 +2,11 @@
     "show": {
         "avalon_auto_sync": {
           "label": "Avalon auto-sync",
-          "type": "boolean",
-          "write_security_role": ["API", "Administrator"],
-          "read_security_role": ["API", "Administrator"]
+          "type": "boolean"
         },
         "library_project": {
           "label": "Library Project",
-          "type": "boolean",
-          "write_security_role": ["API", "Administrator"],
-          "read_security_role": ["API", "Administrator"]
+          "type": "boolean"
         }
     },
     "is_hierarchical": {

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -28,21 +28,21 @@
         "custom_attributes": {
             "show": {
                 "avalon_auto_sync": {
-                    "write_security_role": [
+                    "write_security_roles": [
                         "API",
                         "Administrator"
                     ],
-                    "read_security_role": [
+                    "read_security_roles": [
                         "API",
                         "Administrator"
                     ]
                 },
                 "library_project": {
-                    "write_security_role": [
+                    "write_security_roles": [
                         "API",
                         "Administrator"
                     ],
-                    "read_security_role": [
+                    "read_security_roles": [
                         "API",
                         "Administrator"
                     ]
@@ -50,44 +50,44 @@
             },
             "is_hierarchical": {
                 "fps": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "frameStart": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "frameEnd": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "clipIn": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "clipOut": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "handleStart": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "handleEnd": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "resolutionWidth": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "resolutionHeight": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 },
                 "pixelAspect": {
-                    "write_security_role": [],
-                    "read_security_role": []
+                    "write_security_roles": [],
+                    "read_security_roles": []
                 }
             }
         }

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -46,9 +46,45 @@
                         "API",
                         "Administrator"
                     ]
+                },
+                "applications": {
+                    "write_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ],
+                    "read_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ]
                 }
             },
             "is_hierarchical": {
+                "avalon_mongo_id": {
+                    "write_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ],
+                    "read_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ]
+                },
+                "tools_env": {
+                    "write_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ],
+                    "read_security_roles": [
+                        "API",
+                        "Administrator",
+                        "Pypeclub"
+                    ]
+                },
                 "fps": {
                     "write_security_roles": [],
                     "read_security_roles": []

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -28,7 +28,6 @@
         "custom_attributes": {
             "show": {
                 "avalon_auto_sync": {
-                    "default": "",
                     "write_security_role": [
                         "API",
                         "Administrator"
@@ -39,7 +38,6 @@
                     ]
                 },
                 "library_project": {
-                    "default": "",
                     "write_security_role": [
                         "API",
                         "Administrator"
@@ -52,52 +50,42 @@
             },
             "is_hierarchical": {
                 "fps": {
-                    "default": "25",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "frameStart": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "frameEnd": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "clipIn": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "clipOut": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "handleStart": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "handleEnd": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "resolutionWidth": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "resolutionHeight": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 },
                 "pixelAspect": {
-                    "default": "",
                     "write_security_role": [],
                     "read_security_role": []
                 }

--- a/pype/tools/settings/settings/gui_schemas/system_schema/host_settings/schema_aftereffects.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/host_settings/schema_aftereffects.json
@@ -21,7 +21,7 @@
             "env_group_key": "aftereffects"
         },
         {
-            "type": "dict-invisible",
+            "type": "dict",
             "key": "variants",
             "children": [
                 {

--- a/pype/tools/settings/settings/gui_schemas/system_schema/host_settings/schema_tvpaint.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/host_settings/schema_tvpaint.json
@@ -21,7 +21,7 @@
             "env_group_key": "tvpaint"
         },
         {
-            "type": "dict-invisible",
+            "type": "dict",
             "key": "variants",
             "children": [
                 {

--- a/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
@@ -87,66 +87,66 @@
             "type": "dict",
             "children": [
                 {
-                    "type": "dict-modifiable",
-                    "label": "Show Attributes",
+                    "type": "dict",
                     "key": "show",
-                    "object_type": {
-                        "type": "dict",
-                        "children": [
-                            {
-                                "key": "default",
-                                "label": "default",
-                                "type": "text"
-                            },
-                            {
-                                "key": "write_security_role",
-                                "label": "write",
-                                "type": "list",
-                                "object_type": {
-                                    "type": "text"
+                    "label": "Project Custom attributes",
+                    "children": [
+                        {
+                            "type": "schema_template",
+                            "name": "template_custom_attribute",
+                            "template_data": [
+                                {
+                                    "key": "avalon_auto_sync"
+                                },
+                                {
+                                    "key": "library_project"
                                 }
-                            },
-                            {
-                                "key": "read_security_role",
-                                "label": "Read",
-                                "type": "list",
-                                "object_type": {
-                                    "type": "text"
-                                }
-                            }
-                        ]
-                    }
+                            ]
+                        }
+                    ]
                 },
                 {
-                    "type": "dict-modifiable",
-                    "label": "Hierarchical Attributes",
+                    "type": "dict",
                     "key": "is_hierarchical",
-                    "object_type": {
-                        "type": "dict",
-                        "children": [
-                            {
-                                "key": "default",
-                                "label": "default",
-                                "type": "text"
-                            },
-                            {
-                                "key": "write_security_role",
-                                "label": "write",
-                                "type": "list",
-                                "object_type": {
-                                    "type": "text"
+                    "label": "Hierarchical Attributes",
+                    "children": [
+                        {
+                            "type": "schema_template",
+                            "name": "template_custom_attribute",
+                            "template_data": [
+                                {
+                                    "key": "fps"
+                                },
+                                {
+                                    "key": "frameStart"
+                                },
+                                {
+                                    "key": "frameEnd"
+                                },
+                                {
+                                    "key": "clipIn"
+                                },
+                                {
+                                    "key": "clipOut"
+                                },
+                                {
+                                    "key": "handleStart"
+                                },
+                                {
+                                    "key": "handleEnd"
+                                },
+                                {
+                                    "key": "resolutionWidth"
+                                },
+                                {
+                                    "key": "resolutionHeight"
+                                },
+                                {
+                                    "key": "pixelAspect"
                                 }
-                            },
-                            {
-                                "key": "read_security_role",
-                                "label": "Read",
-                                "type": "list",
-                                "object_type": {
-                                    "type": "text"
-                                }
-                            }
-                        ]
-                    }
+                            ]
+                        }
+                    ]
                 }
             ]
         }

--- a/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/schema_ftrack.json
@@ -100,6 +100,9 @@
                                 },
                                 {
                                     "key": "library_project"
+                                },
+                                {
+                                    "key": "applications"
                                 }
                             ]
                         }
@@ -114,6 +117,12 @@
                             "type": "schema_template",
                             "name": "template_custom_attribute",
                             "template_data": [
+                                {
+                                    "key": "tools_env"
+                                },
+                                {
+                                    "key": "avalon_mongo_id"
+                                },
                                 {
                                     "key": "fps"
                                 },

--- a/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/template_custom_attribute.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/template_custom_attribute.json
@@ -5,13 +5,13 @@
         "type": "dict",
         "children": [
             {
-                "key": "write_security_role",
+                "key": "write_security_roles",
                 "label": "Write roles",
                 "type": "list",
                 "object_type": "text"
             },
             {
-                "key": "read_security_role",
+                "key": "read_security_roles",
                 "label": "Read roles",
                 "type": "list",
                 "object_type": "text"

--- a/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/template_custom_attribute.json
+++ b/pype/tools/settings/settings/gui_schemas/system_schema/module_settings/template_custom_attribute.json
@@ -1,0 +1,21 @@
+[
+    {
+        "key": "{key}",
+        "label": "{key}",
+        "type": "dict",
+        "children": [
+            {
+                "key": "write_security_role",
+                "label": "Write roles",
+                "type": "list",
+                "object_type": "text"
+            },
+            {
+                "key": "read_security_role",
+                "label": "Read roles",
+                "type": "list",
+                "object_type": "text"
+            }
+        ]
+    }
+]

--- a/pype/tools/settings/settings/widgets/item_types.py
+++ b/pype/tools/settings/settings/widgets/item_types.py
@@ -4121,7 +4121,6 @@ TypeToKlass.types["dict-modifiable"] = ModifiableDict
 # DEPRECATED - remove when removed from schemas
 TypeToKlass.types["splitter"] = SplitterWidget
 TypeToKlass.types["dict-item"] = DictWidget
-TypeToKlass.types["dict-invisible"] = DictWidget
 # ---------------------------------------------
 TypeToKlass.types["dict"] = DictWidget
 TypeToKlass.types["path-widget"] = PathWidget


### PR DESCRIPTION
## Changes
- settings of pype's Ftrack custom attributes was limited to read/write roles and custom attributes are predefined and not set with modifiable dictionary
- fixed keys `write_security_role` and `read_security_role` to `write_security_roles` and `read_security_roles`
- removed remaining items `dict-invisible` items from schemas are removed backwards compatibility for them

Resolves: https://github.com/pypeclub/pype/issues/212