### PR TITLE
Module manager time report

### DIFF
--- a/pype/modules/base.py
+++ b/pype/modules/base.py
@@ -582,7 +582,7 @@ class ModulesManager:
             col_widths[key] = max_width
 
         rows = []
-        for idx in range(total_rows):
+        for _idx in range(total_rows):
             rows.append([])
 
         for key, values in cols.items():

--- a/pype/tools/tray/pype_tray.py
+++ b/pype/tools/tray/pype_tray.py
@@ -55,6 +55,9 @@ class TrayManager:
         # Tell each module which modules were imported
         self.modules_manager.start_modules()
 
+        # Print time report
+        self.modules_manager.print_report()
+
     def _add_version_item(self):
         subversion = os.environ.get("PYPE_SUBVERSION")
         client_name = os.environ.get("PYPE_CLIENT")


### PR DESCRIPTION
## Changes
- modules manager collect time spent on module's initialization
- tray will print it out so we can reveal modules slowing down initialization

## Example output
```
-----------------------+--------------+---------+---------------+---------+-------------+-----
Module name            |Initialization|Tray init|Connect modules|Tray menu|Modules start|Total
-----------------------+--------------+---------+---------------+---------+-------------+-----
AvalonModule           |0.000         |0.195    |0.001          |0.000    |0.000        |0.196
ClockifyModule         |0.000         |N/A      |N/A            |N/A      |N/A          |0.000
FtrackModule           |0.001         |0.777    |0.000          |0.000    |0.936        |1.714
IdleManager            |0.000         |0.000    |0.000          |0.003    |0.001        |0.004
LauncherAction         |0.000         |0.035    |0.000          |0.000    |0.000        |0.035
LogViewModule          |0.000         |0.145    |0.000          |0.000    |0.000        |0.145
MusterModule           |0.000         |N/A      |N/A            |N/A      |N/A          |0.000
RestApiModule          |0.000         |2.003    |0.003          |0.000    |0.002        |2.008
SettingsAction         |0.001         |4.505    |0.000          |0.000    |0.000        |4.506
StandAlonePublishAction|0.000         |0.000    |0.000          |0.000    |0.000        |0.000
SyncServer             |0.001         |N/A      |N/A            |N/A      |N/A          |0.001
TimersManager          |0.000         |0.010    |0.000          |0.000    |0.000        |0.010
UserModule             |0.000         |0.008    |0.000          |0.001    |0.000        |0.009
WebsocketModule        |0.001         |0.438    |0.000          |0.000    |0.001        |0.441
-----------------------+--------------+---------+---------------+---------+-------------+-----
Total                  |0.004         |8.117    |0.004          |0.004    |0.940        |9.068
```