### PR TITLE
Fix terminal inner lock

### DIFF
--- a/pype/lib/terminal.py
+++ b/pype/lib/terminal.py
@@ -64,7 +64,7 @@ class Terminal:
         except Exception:
             # Do not use colors if crashed
             Terminal.use_colors = False
-            Terminal.echo(
+            print(
                 "Module `blessed` failed on import or terminal creation."
                 " Pype terminal won't use colors."
             )


### PR DESCRIPTION
## Issue
- when `blessed` module can't be imported `Terminal.echo(...)` is called which call `Terminal.log(...)` inside -> because of this the thread lock is never released and messages are not logged at all

## Changes
- use `print` instead of `Terminal.echo`