### PR TITLE
Settings explicit reset

### DIFF
--- a/pype/modules/settings_action.py
+++ b/pype/modules/settings_action.py
@@ -45,8 +45,16 @@ class SettingsAction(PypeModule, ITrayAction):
         if not self.settings_window:
             raise AssertionError("Window is not initialized.")
 
+        # Store if was visible
+        was_visible = self.settings_window.isVisible()
+
+        # Show settings gui
         self.settings_window.show()
 
         # Pull window to the front.
         self.settings_window.raise_()
         self.settings_window.activateWindow()
+
+        # Reset content if was not visible
+        if not was_visible:
+            self.settings_window.reset()

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -19,6 +19,7 @@ def main(user_role=None):
     app.setWindowIcon(QtGui.QIcon(style.app_icon_path()))
 
     widget = MainWidget(user_role)
+    widget.reset()
     widget.show()
 
     sys.exit(app.exec_())

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -34,8 +34,7 @@ from .widgets import UnsavedChangesDialog
 from . import lib
 from avalon.mongodb import (
     AvalonMongoConnection,
-    AvalonMongoDB,
-    session_data_from_environment
+    AvalonMongoDB
 )
 from avalon.vendor import qtawesome
 

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -46,7 +46,6 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
 
         self.initialize_attributes()
         self.create_ui()
-        self.reset()
 
     def initialize_attributes(self):
         self._hide_studio_overrides = False

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -39,6 +39,8 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
     schema_category = None
     initial_schema_name = None
 
+    saved = QtCore.Signal(QtWidgets.QWidget)
+
     def __init__(self, user_role, parent=None):
         super(SettingsCategoryWidget, self).__init__(parent)
 
@@ -231,6 +233,10 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
             first_invalid_item.setFocus(True)
         return False
 
+    def on_saved(self, saved_tab_widget):
+        """Callback on any tab widget save."""
+        return
+
     def _save(self):
         if not self.items_are_valid():
             return
@@ -238,6 +244,8 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         self.save()
 
         self._update_values()
+
+        self.saved.emit(self)
 
     def _on_refresh(self):
         self.reset()

--- a/pype/tools/settings/settings/widgets/base.py
+++ b/pype/tools/settings/settings/widgets/base.py
@@ -576,6 +576,23 @@ class ProjectWidget(SettingsCategoryWidget):
         # Projects does not have any specific validations
         return True
 
+    def on_saved(self, saved_tab_widget):
+        """Callback on any tab widget save.
+
+        Check if AVALON_MONGO is still same.
+        """
+        if self is saved_tab_widget:
+            return
+
+        system_settings = get_system_settings()
+        mongo_url = system_settings["modules"]["avalon"]["AVALON_MONGO"]
+        if not mongo_url:
+            mongo_url = os.environ["PYPE_MONGO"]
+
+        # If mongo url is not the same as was then refresh projects
+        if mongo_url != os.environ["AVALON_MONGO"]:
+            self.project_list_widget.refresh()
+
     def _on_project_change(self):
         project_name = self.project_list_widget.project_name()
         if project_name is None:

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -22,6 +22,7 @@ class MainWidget(QtWidgets.QWidget):
 
         studio_widget = SystemWidget(user_role, header_tab_widget)
         project_widget = ProjectWidget(user_role, header_tab_widget)
+
         header_tab_widget.addTab(studio_widget, "System")
         header_tab_widget.addTab(project_widget, "Project")
 
@@ -31,3 +32,12 @@ class MainWidget(QtWidgets.QWidget):
         layout.addWidget(header_tab_widget)
 
         self.setLayout(layout)
+
+        self.tab_widgets = [
+            studio_widget,
+            project_widget
+        ]
+
+    def reset(self):
+        for tab_widget in self.tab_widgets:
+            tab_widget.reset()

--- a/pype/tools/settings/settings/widgets/window.py
+++ b/pype/tools/settings/settings/widgets/window.py
@@ -23,6 +23,11 @@ class MainWidget(QtWidgets.QWidget):
         studio_widget = SystemWidget(user_role, header_tab_widget)
         project_widget = ProjectWidget(user_role, header_tab_widget)
 
+        tab_widgets = [
+            studio_widget,
+            project_widget
+        ]
+
         header_tab_widget.addTab(studio_widget, "System")
         header_tab_widget.addTab(project_widget, "Project")
 
@@ -33,10 +38,14 @@ class MainWidget(QtWidgets.QWidget):
 
         self.setLayout(layout)
 
-        self.tab_widgets = [
-            studio_widget,
-            project_widget
-        ]
+        for tab_widget in tab_widgets:
+            tab_widget.saved.connect(self._on_tab_save)
+
+        self.tab_widgets = tab_widgets
+
+    def _on_tab_save(self, source_widget):
+        for tab_widget in self.tab_widgets:
+            tab_widget.on_saved(source_widget)
 
     def reset(self):
         for tab_widget in self.tab_widgets:


### PR DESCRIPTION
## Changes
- settings gui is not loading settings on initialization but must be explicitelly called
- with this change is possible to have faster loading settings action in tray and call reset on settings show
- Settings gui is not using `avalon.io` but `AvalonMongoDB` which is also reset if `AVALON_MONGO` is changed in system category