### PR TITLE
Extension key in templates

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -329,6 +329,17 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             if repre.get("outputName"):
                 template_data["output"] = repre['outputName']
 
+            ext = repre["ext"]
+            if ext.startswith("."):
+                self.log.warning((
+                    "Implementaion warning: <\"{}\">"
+                    " Representation's extension stored under \"ext\" key "
+                    " started with dot (\"{}\")."
+                ).format(repre["name"], ext))
+                ext = ext[1:]
+            repre["ext"] = ext
+            template_data["ext"] = ext
+
             template = os.path.normpath(
                 anatomy.templates[template_name]["path"])
 

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -368,7 +368,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
                 test_dest_files = list()
                 for i in [1, 2]:
-                    template_data["representation"] = repre['ext']
                     template_data["frame"] = src_padding_exp % i
                     anatomy_filled = anatomy.format(template_data)
                     template_filled = anatomy_filled[template_name]["path"]
@@ -389,6 +388,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
                 index_frame_start = None
 
+                # TODO use frame padding from right template group
                 if repre.get("frameStart") is not None:
                     frame_start_padding = int(
                         anatomy.templates["render"].get(
@@ -424,7 +424,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     dst = "{0}{1}{2}".format(
                         dst_head,
                         dst_padding,
-                        dst_tail).replace("..", ".")
+                        dst_tail
+                    )
 
                     self.log.debug("destination: `{}`".format(dst))
                     src = os.path.join(stagingdir, src_file_name)
@@ -444,7 +445,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     dst_head,
                     dst_start_frame,
                     dst_tail
-                ).replace("..", ".")
+                )
                 repre['published_path'] = dst
 
             else:
@@ -468,7 +469,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 anatomy_filled = anatomy.format(template_data)
                 template_filled = anatomy_filled[template_name]["path"]
                 repre_context = template_filled.used_values
-                dst = os.path.normpath(template_filled).replace("..", ".")
+                dst = os.path.normpath(template_filled)
 
                 instance.data["transfers"].append([src, dst])
 

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -329,6 +329,8 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
             if repre.get("outputName"):
                 template_data["output"] = repre['outputName']
 
+            template_data["representation"] = repre["name"]
+
             ext = repre["ext"]
             if ext.startswith("."):
                 self.log.warning((

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -463,8 +463,6 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                     "Given file name is a full path"
                 )
 
-                template_data["representation"] = repre['ext']
-
                 src = os.path.join(stagingdir, fname)
                 anatomy_filled = anatomy.format(template_data)
                 template_filled = anatomy_filled[template_name]["path"]

--- a/pype/plugins/global/publish/integrate_thumbnail.py
+++ b/pype/plugins/global/publish/integrate_thumbnail.py
@@ -95,7 +95,7 @@ class IntegrateThumbnails(pyblish.api.InstancePlugin):
         template_data.update({
             "_id": str(thumbnail_id),
             "thumbnail_root": os.environ.get("AVALON_THUMBNAIL_ROOT"),
-            "ext": file_extension,
+            "ext": file_extension[1:],
             "thumbnail_type": "thumbnail"
         })
 

--- a/pype/plugins/houdini/publish/extract_alembic.py
+++ b/pype/plugins/houdini/publish/extract_alembic.py
@@ -42,7 +42,7 @@ class ExtractAlembic(pype.api.Extractor):
 
         representation = {
             'name': 'abc',
-            'ext': '.abc',
+            'ext': 'abc',
             'files': file_name,
             "stagingDir": staging_dir,
         }

--- a/pype/plugins/houdini/publish/extract_vdb_cache.py
+++ b/pype/plugins/houdini/publish/extract_vdb_cache.py
@@ -42,7 +42,7 @@ class ExtractVDBCache(pype.api.Extractor):
 
         representation = {
             'name': 'mov',
-            'ext': '.mov',
+            'ext': 'mov',
             'files': output,
             "stagingDir": staging_dir,
         }

--- a/pype/plugins/standalonepublisher/publish/collect_context.py
+++ b/pype/plugins/standalonepublisher/publish/collect_context.py
@@ -145,11 +145,15 @@ class CollectContextDataSAPublish(pyblish.api.ContextPlugin):
             component["stagingDir"] = component["stagingDir"]
 
             if isinstance(component["files"], list):
-                collections, remainder = clique.assemble(component["files"])
+                collections, _remainder = clique.assemble(component["files"])
                 self.log.debug("collecting sequence: {}".format(collections))
                 instance.data["frameStart"] = int(component["frameStart"])
                 instance.data["frameEnd"] = int(component["frameEnd"])
                 instance.data["fps"] = int(component["fps"])
+
+            ext = component["ext"]
+            if ext.startswith("."):
+                component["ext"] = ext[1:]
 
             if component["preview"]:
                 instance.data["families"].append("review")

--- a/pype/plugins/standalonepublisher/publish/collect_context.py
+++ b/pype/plugins/standalonepublisher/publish/collect_context.py
@@ -66,23 +66,23 @@ class CollectContextDataSAPublish(pyblish.api.ContextPlugin):
 
         in_data_list = list()
         representations = in_data.pop("representations")
-        for repr in representations:
+        for repre in representations:
             in_data_copy = copy.deepcopy(in_data)
-            ext = repr["ext"][1:]
+            ext = repre["ext"][1:]
             subset = in_data_copy["subset"]
             # filter out non editorial files
             if ext not in self.batch_extensions:
-                in_data_copy["representations"] = [repr]
+                in_data_copy["representations"] = [repre]
                 in_data_copy["subset"] = f"{ext}{subset}"
                 in_data_list.append(in_data_copy)
 
-            files = repr.get("files")
+            files = repre.get("files")
 
             # delete unneeded keys
             delete_repr_keys = ["frameStart", "frameEnd"]
             for k in delete_repr_keys:
-                if repr.get(k):
-                    repr.pop(k)
+                if repre.get(k):
+                    repre.pop(k)
 
             # convert files to list if it isnt
             if not isinstance(files, (tuple, list)):

--- a/pype/settings/defaults/project_anatomy/templates.json
+++ b/pype/settings/defaults/project_anatomy/templates.json
@@ -10,18 +10,18 @@
     },
     "render": {
         "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/render/{subset}/{@version}",
-        "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{representation}",
+        "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{ext}",
         "path": "{@folder}/{@file}"
     },
     "publish": {
         "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/{@version}",
-        "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{representation}",
+        "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{ext}",
         "path": "{@folder}/{@file}",
-        "thumbnail": "{thumbnail_root}/{project[name]}/{_id}_{thumbnail_type}{ext}"
+        "thumbnail": "{thumbnail_root}/{project[name]}/{_id}_{thumbnail_type}.{ext}"
     },
     "master": {
         "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/master",
-        "file": "{project[code]}_{asset}_{subset}_master<_{output}><.{frame}>.{representation}",
+        "file": "{project[code]}_{asset}_{subset}_master<_{output}><.{frame}>.{ext}",
         "path": "{@folder}/{@file}"
     },
     "delivery": {},


### PR DESCRIPTION
## Changes
- templates use key `{ext}` instead of `{representation}` in default publish templates
    - `"ext"` key is now filled with extension
    - `"representation"` key is now filled with representation name
    - `"output"` key was kept as it can be filled optionally but representation name is filled all the time
        - don't know why it is filled optionally so was scared to go deep into the rabbit hole
- extensions collected to representation during publishing should always use extension without dot (`mov`, `exr` etc.)
- removed replacements of filled path `.replace("..", ".")` in Integrate New (as it is not "Kosher")
    - extensions are checked before template filling
    - if `"ext"` key on representation contain dot plugin `Integreate New` will log warning message that got extension with dot
        - this should help us find out when it happens

Resolves: https://github.com/pypeclub/pype/issues/85