### PR TITLE
Remove get_application usage

### DIFF
--- a/pype/hosts/maya/__init__.py
+++ b/pype/hosts/maya/__init__.py
@@ -206,23 +206,6 @@ def on_new(_):
 
 def on_task_changed(*args):
     """Wrapped function of app initialize and maya's on task changed"""
-
-    # Inputs (from the switched session and running app)
-    session = avalon.Session.copy()
-    app_name = os.environ["AVALON_APP_NAME"]
-
-    # Find the application definition
-    app_definition = pipeline.lib.get_application(app_name)
-
-    App = type("app_%s" % app_name,
-               (avalon.Application,),
-               {"config": app_definition.copy()})
-
-    # Initialize within the new session's environment
-    app = App()
-    env = app.environ(session)
-    app.initialize(env)
-
     # Run
     maya.pipeline._on_task_changed()
     with maya.suspended_refresh():

--- a/pype/hosts/nuke/lib.py
+++ b/pype/hosts/nuke/lib.py
@@ -149,9 +149,7 @@ def get_render_path(node):
     nuke_dataflow_writes = get_node_dataflow_preset(**data_preset)
     nuke_colorspace_writes = get_node_colorspace_preset(**data_preset)
 
-    application = lib.get_application(os.environ["AVALON_APP_NAME"])
     data.update({
-        "application": application,
         "nuke_dataflow_writes": nuke_dataflow_writes,
         "nuke_colorspace_writes": nuke_colorspace_writes
     })
@@ -204,7 +202,7 @@ def format_anatomy(data):
         "project": {"name": project_document["name"],
                     "code": project_document["data"].get("code", '')},
         "representation": data["nuke_dataflow_writes"]["file_type"],
-        "app": data["application"]["application_dir"],
+        "app": api.Session["AVALON_APP"],
         "hierarchy": pype.get_hierarchy(),
         "frame": "#" * padding,
     })
@@ -258,11 +256,9 @@ def create_write_node(name, data, input=None, prenodes=None, review=True):
 
     nuke_dataflow_writes = get_node_dataflow_preset(**data)
     nuke_colorspace_writes = get_node_colorspace_preset(**data)
-    application = lib.get_application(os.environ["AVALON_APP_NAME"])
 
     try:
         data.update({
-            "application": application,
             "nuke_dataflow_writes": nuke_dataflow_writes,
             "nuke_colorspace_writes": nuke_colorspace_writes
         })


### PR DESCRIPTION
## Issue
- there are still several places where `get_application` is used from `avalon.pipeline` which can't work because we don't use tomls anymore

## Changes
- nuke used get_application to fill template key `"{app}"` for which can be used `"AVALON_APP"` key from `Session` or environments
- maya used Application initialization which does nothing special in pype, only set `"AVALON_WORKDIR"` which is already set through Workfiles tool