### PR TITLE
Pype: add vendor folder

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,3 @@
+### Pype vendor folder
+
+Everything here will be included in frozen code during build but is ignored by git. Useful for binaries like ffmpeg/oiio/etc.


### PR DESCRIPTION
Adding vendor folder. Content is ignored by git but is included during Pype build. Useful for ffmpeg/oiio/etc.