### PR TITLE
Fix TVPaint loading of path with spaces

### DIFF
--- a/pype/plugins/tvpaint/load/load_image.py
+++ b/pype/plugins/tvpaint/load/load_image.py
@@ -14,7 +14,7 @@ class ImportImage(pipeline.Loader):
     color = "white"
 
     import_script = (
-        "filepath = \"{}\"\n"
+        "filepath = '\"'\"{}\"'\"'\n"
         "layer_name = \"{}\"\n"
         "tv_loadsequence filepath {}PARSE layer_id\n"
         "tv_layerrename layer_id layer_name"

--- a/pype/plugins/tvpaint/load/load_reference_image.py
+++ b/pype/plugins/tvpaint/load/load_reference_image.py
@@ -15,7 +15,7 @@ class LoadImage(pipeline.Loader):
     color = "white"
 
     import_script = (
-        "filepath = \"{}\"\n"
+        "filepath = '\"'\"{}\"'\"'\n"
         "layer_name = \"{}\"\n"
         "tv_loadsequence filepath {}PARSE layer_id\n"
         "tv_layerrename layer_id layer_name"


### PR DESCRIPTION
## Issue
Current TVPaint loaders can't load anything that has space in path

## Changes
Paths to file are wrapped with formatting string `'"'"{}"'"'` which should solve the issue