### PR TITLE
Hiero: cut videos with correct secons 

### DIFF
--- a/pype/plugins/hiero/publish/extract_review_cutup.py
+++ b/pype/plugins/hiero/publish/extract_review_cutup.py
@@ -151,7 +151,7 @@ class ExtractReviewCutUp(pype.api.Extractor):
                           https://github.com/pypeclub/pype/issues/659
                 """
                 frame_duration_extend = 1
-                if audio_check_output:
+                if audio_check_output and ("audio" in inst_data["families"]):
                     frame_duration_extend = 0
 
                 # translate frame to sec
@@ -267,8 +267,8 @@ class ExtractReviewCutUp(pype.api.Extractor):
                     ).format(**locals()))
 
                 # append ffmpeg input video clip
-                input_args.append("-ss {:0.2f}".format(start_sec))
-                input_args.append("-t {:0.2f}".format(duration_sec))
+                input_args.append("-ss {}".format(start_sec))
+                input_args.append("-t {}".format(duration_sec))
                 input_args.append("-i \"{}\"".format(full_input_path))
 
                 # add copy audio video codec if only shortening clip


### PR DESCRIPTION
- removing approximation to 2 decimals
- audio duration fix only if audio in families