### PR TITLE
Launcher fix actions discover

### DIFF
--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -196,14 +196,17 @@ class ActionModel(QtGui.QStandardItemModel):
             if icon is None:
                 icon = self.default_icon
 
-            item = QtGui.QStandardItem(icon, action.label)
+            item = QtGui.QStandardItem(icon, label)
+            item.setData(label, QtCore.Qt.ToolTipRole)
             item.setData(actions, self.ACTION_ROLE)
             item.setData(True, self.VARIANT_GROUP_ROLE)
             items_by_order[order].append(item)
 
         for action in single_actions:
             icon = self.get_icon(action)
-            item = QtGui.QStandardItem(icon, lib.get_action_label(action))
+            label = lib.get_action_label(action)
+            item = QtGui.QStandardItem(icon, label)
+            item.setData(label, QtCore.Qt.ToolTipRole)
             item.setData(action, self.ACTION_ROLE)
             items_by_order[action.order].append(item)
 

--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -139,7 +139,7 @@ class ActionModel(QtGui.QStandardItemModel):
             return self.default_icon
         return icon
 
-    def refresh(self):
+    def filter_actions(self):
         # Validate actions based on compatibility
         self.clear()
 

--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -115,7 +115,6 @@ class ActionModel(QtGui.QStandardItemModel):
         super(ActionModel, self).__init__(parent=parent)
         self.dbcon = dbcon
 
-        self._session = {}
         self._groups = {}
         self.default_icon = qtawesome.icon("fa.cube", color="white")
         # Cache of available actions
@@ -237,11 +236,6 @@ class ActionModel(QtGui.QStandardItemModel):
 
         self.endResetModel()
 
-    def set_session(self, session):
-        assert isinstance(session, dict)
-        self._session = copy.deepcopy(session)
-        self.refresh()
-
     def filter_compatible_actions(self, actions):
         """Collect all actions which are compatible with the environment
 
@@ -256,8 +250,15 @@ class ActionModel(QtGui.QStandardItemModel):
         """
 
         compatible = []
+        _session = copy.deepcopy(self.dbcon.Session)
+        session = {
+            key: value
+            for key, value in _session.items()
+            if value
+        }
+
         for action in actions:
-            if action().is_compatible(self._session):
+            if action().is_compatible(session):
                 compatible.append(action)
 
         # Sort by order and name

--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -120,8 +120,6 @@ class ActionModel(QtGui.QStandardItemModel):
         # Cache of available actions
         self._registered_actions = list()
 
-        self.discover()
-
     def discover(self):
         """Set up Actions cache. Run this for each new project."""
         # Discover all registered actions

--- a/pype/tools/launcher/models.py
+++ b/pype/tools/launcher/models.py
@@ -125,17 +125,14 @@ class ActionModel(QtGui.QStandardItemModel):
 
     def discover(self):
         """Set up Actions cache. Run this for each new project."""
-        if not self.dbcon.Session.get("AVALON_PROJECT"):
-            self._registered_actions = list()
-            return
-
         # Discover all registered actions
         actions = api.discover(api.Action)
 
         # Get available project actions and the application actions
-        project_doc = self.dbcon.find_one({"type": "project"})
-        app_actions = lib.get_application_actions(project_doc)
-        actions.extend(app_actions)
+        if self.dbcon.Session.get("AVALON_PROJECT"):
+            project_doc = self.dbcon.find_one({"type": "project"})
+            app_actions = lib.get_application_actions(project_doc)
+            actions.extend(app_actions)
 
         self._registered_actions = actions
 

--- a/pype/tools/launcher/widgets.py
+++ b/pype/tools/launcher/widgets.py
@@ -123,6 +123,12 @@ class ActionBar(QtWidgets.QWidget):
 
         view.clicked.connect(self.on_clicked)
 
+    def discover_actions(self):
+        self.model.discover()
+
+    def filter_actions(self):
+        self.model.filter_actions()
+
     def set_row_height(self, rows):
         self.setMinimumHeight(rows * 75)
 

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -192,6 +192,8 @@ class AssetsPanel(QtWidgets.QWidget):
         project_bar.project_changed.connect(self.on_project_changed)
         assets_widget.selection_changed.connect(self.on_asset_changed)
         assets_widget.refreshed.connect(self.on_asset_changed)
+        tasks_widget.task_changed.connect(self.on_task_change)
+
         btn_back.clicked.connect(self.back_clicked)
 
         # Force initial refresh for the assets since we might not be
@@ -255,6 +257,10 @@ class AssetsPanel(QtWidgets.QWidget):
             asset_id = asset_doc["_id"]
         self.tasks_widget.set_asset(asset_id)
 
+    def on_task_change(self):
+        task_name = self.tasks_widget.get_current_task()
+        self.dbcon.Session["AVALON_TASK"] = task_name
+        self.session_changed.emit()
 
 
 class LauncherWindow(QtWidgets.QDialog):

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -340,6 +340,11 @@ class LauncherWindow(QtWidgets.QDialog):
 
         self.resize(520, 740)
 
+    def showEvent(self, event):
+        super().showEvent(event)
+        # TODO implement refresh/reset which will trigger updating
+        self.discover_actions()
+
     def set_page(self, page):
         current = self.page_slider.currentIndex()
         if current == page and self._page == page:
@@ -348,10 +353,6 @@ class LauncherWindow(QtWidgets.QDialog):
         direction = "right" if page > current else "left"
         self._page = page
         self.page_slider.slide_view(page, direction=direction)
-
-    def refresh(self):
-        self.asset_panel.assets_widget.refresh()
-        self.refresh_actions()
 
     def echo(self, message):
         self.message_label.setText(str(message))

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -186,6 +186,7 @@ class AssetsPanel(QtWidgets.QWidget):
         # signals
         project_bar.project_changed.connect(self.on_project_changed)
         assets_widget.selection_changed.connect(self.on_asset_changed)
+        assets_widget.refreshed.connect(self.on_asset_changed)
         btn_back.clicked.connect(self.back_clicked)
 
         # Force initial refresh for the assets since we might not be
@@ -206,8 +207,6 @@ class AssetsPanel(QtWidgets.QWidget):
         self.dbcon.Session["AVALON_PROJECT"] = project_name
         self.assets_widget.refresh()
 
-        # Force asset change callback to ensure tasks are correctly reset
-        self.assets_widget.refreshed.connect(self.on_asset_changed)
 
     def on_asset_changed(self):
         """Callback on asset selection changed

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -383,14 +383,10 @@ class LauncherWindow(QtWidgets.QDialog):
         self.discover_actions()
 
     def on_back_clicked(self):
+        self.dbcon.Session["AVALON_PROJECT"] = None
         self.set_page(0)
         self.project_panel.model.refresh()    # Refresh projects
-        self.refresh_actions()
-
-    def on_refresh_actions(self):
-        session = self.get_current_session()
-        self.actions_bar.model.set_session(session)
-        self.actions_bar.model.refresh()
+        self.discover_actions()
 
     def on_action_clicked(self, action):
         self.echo("Running action: {}".format(action.name))

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -123,6 +123,7 @@ class ProjectsPanel(QtWidgets.QWidget):
 class AssetsPanel(QtWidgets.QWidget):
     """Assets page"""
     back_clicked = QtCore.Signal()
+    session_changed = QtCore.Signal()
 
     def __init__(self, dbcon, parent=None):
         super(AssetsPanel, self).__init__(parent=parent)
@@ -209,8 +210,10 @@ class AssetsPanel(QtWidgets.QWidget):
     def on_project_changed(self):
         project_name = self.project_bar.get_current_project()
         self.dbcon.Session["AVALON_PROJECT"] = project_name
-        self.assets_widget.refresh()
 
+        self.session_changed.emit()
+
+        self.assets_widget.refresh()
 
     def on_asset_changed(self):
         """Callback on asset selection changed

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -363,20 +363,24 @@ class LauncherWindow(QtWidgets.QDialog):
         self.dbcon.Session["AVALON_PROJECT"] = project_name
 
         # Update the Action plug-ins available for the current project
-        self.actions_bar.model.discover()
+        self.discover_actions()
 
     def on_session_changed(self):
-        self.refresh_actions()
+        self.filter_actions()
 
-    def refresh_actions(self, delay=1):
-        tools_lib.schedule(self.on_refresh_actions, delay)
+    def discover_actions(self):
+        self.actions_bar.discover_actions()
+        self.filter_actions()
+
+    def filter_actions(self):
+        self.actions_bar.filter_actions()
 
     def on_project_clicked(self, project_name):
         self.dbcon.Session["AVALON_PROJECT"] = project_name
         # Refresh projects
         self.asset_panel.set_project(project_name)
         self.set_page(1)
-        self.refresh_actions()
+        self.discover_actions()
 
     def on_back_clicked(self):
         self.set_page(0)

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -405,33 +405,21 @@ class LauncherWindow(QtWidgets.QDialog):
             # User is holding control, rerun the action
             self.run_action(action, session=session)
 
-    def get_current_session(self):
-        if self._page == 1:
-            # Assets page
-            return self.asset_panel.get_current_session()
-
-        session = copy.deepcopy(self.dbcon.Session)
-
-        # Remove some potential invalid session values
-        # that we know are not set when not browsing in
-        # a project.
-        session.pop("AVALON_PROJECT", None)
-        session.pop("AVALON_ASSET", None)
-        session.pop("AVALON_SILO", None)
-        session.pop("AVALON_TASK", None)
-
-        return session
-
     def run_action(self, action, session=None):
         if session is None:
-            session = self.get_current_session()
+            session = copy.deepcopy(self.dbcon.Session)
 
+        filtered_session = {
+            key: value
+            for key, value in session.items()
+            if value
+        }
         # Add to history
-        self.action_history.add_action(action, session)
+        self.action_history.add_action(action, filtered_session)
 
         # Process the Action
         try:
-            action().process(session)
+            action().process(filtered_session)
         except Exception as exc:
             self.log.warning("Action launch failed.", exc_info=True)
             self.echo("Failed: {}".format(str(exc)))

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -204,10 +204,12 @@ class AssetsPanel(QtWidgets.QWidget):
 
     def set_project(self, project):
         before = self.project_bar.get_current_project()
-        self.project_bar.set_project(project)
-        if project == before:
-            # Force a refresh on the assets if the project hasn't changed
+        if before == project:
             self.assets_widget.refresh()
+            return
+
+        self.project_bar.set_project(project)
+        self.on_project_changed()
 
     def on_project_changed(self):
         project_name = self.project_bar.get_current_project()

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -331,14 +331,7 @@ class LauncherWindow(QtWidgets.QDialog):
         action_history.trigger_history.connect(self.on_history_action)
         project_panel.project_clicked.connect(self.on_project_clicked)
         asset_panel.back_clicked.connect(self.on_back_clicked)
-
-        # Add some signals to propagate from the asset panel
-        for signal in (
-            asset_panel.project_bar.project_changed,
-            asset_panel.assets_widget.selection_changed,
-            asset_panel.tasks_widget.task_changed
-        ):
-            signal.connect(self.on_session_changed)
+        asset_panel.session_changed.connect(self.on_session_changed)
 
         # todo: Simplify this callback connection
         asset_panel.project_bar.project_changed.connect(

--- a/pype/tools/launcher/window.py
+++ b/pype/tools/launcher/window.py
@@ -12,7 +12,11 @@ from avalon.tools.widgets import AssetWidget
 from avalon.vendor import qtawesome
 from .models import ProjectModel
 from .widgets import (
-    ProjectBar, ActionBar, TasksWidget, ActionHistory, SlidePageWidget
+    ProjectBar,
+    ActionBar,
+    TasksWidget,
+    ActionHistory,
+    SlidePageWidget
 )
 
 from .flickcharm import FlickCharm


### PR DESCRIPTION
## Issue
- discovery of actions in launcher is broken that clicking on first project in project list won't discover actions

## Changes
- launcher items do not hold session data separately but are corresponding to `dbcon.Session` which is used across all widgets
- widgets/models/views access less to children of their children
- actions are now discovered on launcher show event and on project change properly
    - TODO add refresh/reset method to main launcher window to also refresh projects which is not possible right now
- actions have set tooltips to their labels so it is possible to see whole label on hover