### PR TITLE
Maya: Handling Arnold referenced AOVs - Pype 3

### DIFF
--- a/pype/hosts/maya/plugins/create/create_render.py
+++ b/pype/hosts/maya/plugins/create/create_render.py
@@ -191,7 +191,7 @@ class CreateRender(avalon.maya.Creator):
         self.data["tilesX"] = 2
         self.data["tilesY"] = 2
         self.data["convertToScanline"] = False
-        self.data["vrayUseReferencedAovs"] = False
+        self.data["useReferencedAovs"] = False
         # Disable for now as this feature is not working yet
         # self.data["assScene"] = False
 

--- a/pype/hosts/maya/plugins/publish/collect_render.py
+++ b/pype/hosts/maya/plugins/publish/collect_render.py
@@ -2,7 +2,7 @@
 """Collect render data.
 
 This collector will go through render layers in maya and prepare all data
-needed to create instances and their representations for submition and
+needed to create instances and their representations for submission and
 publishing on farm.
 
 Requires:
@@ -248,8 +248,11 @@ class CollectMayaRender(pyblish.api.ContextPlugin):
                 "tilesX": render_instance.data.get("tilesX") or 2,
                 "tilesY": render_instance.data.get("tilesY") or 2,
                 "priority": render_instance.data.get("priority"),
-                "convertToScanline": render_instance.data.get("convertToScanline") or False,  # noqa: E501
-                "vrayUseReferencedAovs": render_instance.data.get("vrayUseReferencedAovs") or False  # noqa: E501
+                "convertToScanline": render_instance.data.get(
+                    "convertToScanline") or False,
+                "useReferencedAovs": render_instance.data.get(
+                    "useReferencedAovs") or render_instance.data.get(
+                        "vrayUseReferencedAovs") or False
             }
 
             if self.sync_workfile_version:


### PR DESCRIPTION
## Problem
Pype was expecting all enabled AOVs returned by Maya to be rendered. But Maya by default returns all AOVs, even those coming from references and they are not rendered.

## Solution
Add option use referenced aovs on render instance that is disabled by default. If enabled Pype is expecting referenced AOVs to be rendered.

❕ **Pype 2 pull request:** #938 