### PR TITLE
Fix single frame Sequence in TVPaint

### DIFF
--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -146,6 +146,10 @@ class ExtractSequence(pyblish.api.Extractor):
             os.path.basename(filepath)
             for filepath in output_files_by_frame.values()
         ]
+        # Sequence of one frame
+        if len(repre_files) == 1:
+            repre_files = repre_files[0]
+
         new_repre = {
             "name": ext,
             "ext": ext,


### PR DESCRIPTION
## Issue
- sequence of single frame crash on intagration

## Changes
- tvpaint extract sequence convert single frame sequence to single file

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/953|