### PR TITLE
Prores ks in burnin script

### DIFF
--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -543,21 +543,22 @@ def burnins_from_data(
         ffmpeg_args = codec_data
 
     else:
-        codec_name = burnin._streams[0].get("codec_name")
+        ffprobe_data = burnin._streams[0]
+        codec_name = ffprobe_data.get("codec_name")
         if codec_name:
             ffmpeg_args.append("-codec:v {}".format(codec_name))
 
-        profile_name = burnin._streams[0].get("profile")
+        profile_name = ffprobe_data.get("profile")
         if profile_name:
             # lower profile name and repalce spaces with underscore
             profile_name = profile_name.replace(" ", "_").lower()
             ffmpeg_args.append("-profile:v {}".format(profile_name))
 
-        bit_rate = burnin._streams[0].get("bit_rate")
+        bit_rate = ffprobe_data.get("bit_rate")
         if bit_rate:
             ffmpeg_args.append("-b:v {}".format(bit_rate))
 
-        pix_fmt = burnin._streams[0].get("pix_fmt")
+        pix_fmt = ffprobe_data.get("pix_fmt")
         if pix_fmt:
             ffmpeg_args.append("-pix_fmt {}".format(pix_fmt))
 

--- a/pype/scripts/otio_burnin.py
+++ b/pype/scripts/otio_burnin.py
@@ -546,6 +546,14 @@ def burnins_from_data(
         ffprobe_data = burnin._streams[0]
         codec_name = ffprobe_data.get("codec_name")
         if codec_name:
+            if codec_name == "prores":
+                tags = ffprobe_data.get("tags") or {}
+                encoder = tags.get("encoder") or ""
+                if encoder.endswith("prores_ks"):
+                    codec_name = "prores_ks"
+
+                elif encoder.endswith("prores_aw"):
+                    codec_name = "prores_aw"
             ffmpeg_args.append("-codec:v {}".format(codec_name))
 
         profile_name = ffprobe_data.get("profile")


### PR DESCRIPTION
## Issue
- ffmpeg's output of any prores encoder (prores_ks, prores_aw, prores) is always codec name `prores` so burnin script can't 

## Changes
- ffmpeg stores encoder to output metadata tags so we can read them and define which is used
    - this works only if input is created by ffmpeg

### Note
- changes should affect only inputs that have codec name `prores` in metadata

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/960|