### PR TITLE
PSD Bulk export of ANIM group

### DIFF
--- a/pype/plugins/standalonepublisher/publish/collect_context.py
+++ b/pype/plugins/standalonepublisher/publish/collect_context.py
@@ -89,15 +89,15 @@ class CollectContextDataSAPublish(pyblish.api.ContextPlugin):
                 files = [files]
 
             self.log.debug(f"_ files: {files}")
-            for index, f in enumerate(files):
+            for index, _file in enumerate(files):
                 index += 1
                 # copy dictionaries
                 in_data_copy = copy.deepcopy(in_data_copy)
-                repr_new = copy.deepcopy(repr)
+                new_repre = copy.deepcopy(repre)
 
-                repr_new["files"] = f
-                repr_new["name"] = ext
-                in_data_copy["representations"] = [repr_new]
+                new_repre["files"] = _file
+                new_repre["name"] = ext
+                in_data_copy["representations"] = [new_repre]
 
                 # create subset Name
                 new_subset = f"{ext}{index}{subset}"

--- a/pype/plugins/standalonepublisher/publish/extract_bg_for_compositing.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_for_compositing.py
@@ -52,7 +52,11 @@ class ExtractBGForComp(pype.api.Extractor):
 
         for repre in tuple(repres):
             # Skip all files without .psd extension
-            if repre["ext"] != ".psd":
+            repre_ext = repre["ext"].lower()
+            if repre_ext.startswith("."):
+                repre_ext = repre_ext[1:]
+
+            if repre_ext != "psd":
                 continue
 
             # Prepare publish dir for transfers

--- a/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
@@ -61,7 +61,11 @@ class ExtractBGMainGroups(pype.api.Extractor):
 
         for repre in tuple(repres):
             # Skip all files without .psd extension
-            if repre["ext"] != ".psd":
+            repre_ext = repre["ext"].lower()
+            if repre_ext.startswith("."):
+                repre_ext = repre_ext[1:]
+
+            if repre_ext != "psd":
                 continue
 
             # Prepare json filepath where extracted metadata are stored

--- a/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
@@ -101,8 +101,9 @@ class ExtractBGMainGroups(pype.api.Extractor):
             "__schema_version__": 1,
             "children": []
         }
-        transfers = []
         output_ext = ".png"
+
+        to_export = []
         for layer_idx, layer in enumerate(psd_object):
             layer_name = layer.name.replace(" ", "_")
             if (
@@ -125,15 +126,16 @@ class ExtractBGMainGroups(pype.api.Extractor):
                 "name": layer.name,
                 "filename": filename
             })
+            to_export.append((layer, filename))
 
+        transfers = []
+        for layer, filename in to_export:
             output_filepath = os.path.join(output_dir, filename)
             dst_filepath = os.path.join(publish_dir, filename)
             transfers.append((output_filepath, dst_filepath))
 
             pil_object = layer.composite(viewport=psd_object.viewbox)
             pil_object.save(output_filepath, "PNG")
-
-            json_data["children"].append(layer_data)
 
         return json_data, transfers
 

--- a/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
@@ -102,6 +102,7 @@ class ExtractBGMainGroups(pype.api.Extractor):
             "children": []
         }
         transfers = []
+        output_ext = ".png"
         for layer_idx, layer in enumerate(psd_object):
             layer_name = layer.name.replace(" ", "_")
             if (
@@ -117,12 +118,13 @@ class ExtractBGMainGroups(pype.api.Extractor):
                 ).format(layer.name))
                 continue
 
-            filename = "{:0>2}_{}.png".format(layer_idx, layer_name)
-            layer_data = {
+            filebase = "{:0>2}_{}".format(layer_idx, layer_name)
+            filename = filebase + output_ext
+            json_data["children"].append({
                 "index": layer_idx,
                 "name": layer.name,
                 "filename": filename
-            }
+            })
 
             output_filepath = os.path.join(output_dir, filename)
             dst_filepath = os.path.join(publish_dir, filename)

--- a/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
+++ b/pype/plugins/standalonepublisher/publish/extract_bg_main_groups.py
@@ -120,6 +120,31 @@ class ExtractBGMainGroups(pype.api.Extractor):
                 continue
 
             filebase = "{:0>2}_{}".format(layer_idx, layer_name)
+            if layer_name.lower() == "anim":
+                if not layer.is_group:
+                    self.log.warning("ANIM layer is not a group layer.")
+                    continue
+
+                children = []
+                for anim_idx, anim_layer in enumerate(layer):
+                    anim_layer_name = anim_layer.name.replace(" ", "_")
+                    filename = "{}_{:0>2}_{}{}".format(
+                        filebase, anim_idx, anim_layer_name, output_ext
+                    )
+                    children.append({
+                        "index": anim_idx,
+                        "name": anim_layer.name,
+                        "filename": filename
+                    })
+                    to_export.append((anim_layer, filename))
+
+                json_data["children"].append({
+                    "index": layer_idx,
+                    "name": layer.name,
+                    "children": children
+                })
+                continue
+
             filename = filebase + output_ext
             json_data["children"].append({
                 "index": layer_idx,

--- a/pype/plugins/standalonepublisher/publish/extract_images_from_psd.py
+++ b/pype/plugins/standalonepublisher/publish/extract_images_from_psd.py
@@ -46,7 +46,11 @@ class ExtractImagesFromPSD(pype.api.Extractor):
 
         for repre in tuple(repres):
             # Skip all files without .psd extension
-            if repre["ext"] != ".psd":
+            repre_ext = repre["ext"].lower()
+            if repre_ext.startswith("."):
+                repre_ext = repre_ext[1:]
+
+            if repre_ext != "psd":
                 continue
 
             # TODO add check of list of "files" value


### PR DESCRIPTION
## Changes
- PSD bulk export has small modification when exports **ANIM** group in BG Layout extractor
    - ANIM group is not exported as one output but similar to export to compositing where it's subgroups are exported as separated outputs and are stored the same way

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/965|