### PR TITLE
Create project structure action fix multiroot

### DIFF
--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -90,6 +90,7 @@ class CreateProjectFolders(BaseAction):
             self.create_ftrack_entities(basic_paths, project)
 
         except Exception as exc:
+            self.log.warning("Creating of structure crashed.", exc_info=True)
             session.rollback()
             return {
                 "success": False,

--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -233,11 +233,14 @@ class CreateProjectFolders(BaseAction):
             full_paths = self.compute_paths(basic_paths, project_root)
             # Create folders
             for path in full_paths:
-                if os.path.exists(path):
-                    continue
                 full_path = path.format(project_root=project_root)
-                self.log.debug("Creating folder: {}".format(full_path))
-                os.makedirs(full_path)
+                if os.path.exists(full_path):
+                    self.log.debug(
+                        "Folder already exists: {}".format(full_path)
+                    )
+                else:
+                    self.log.debug("Creating folder: {}".format(full_path))
+                    os.makedirs(full_path)
 
 
 def register(session, plugins_presets={}):

--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -85,8 +85,7 @@ class CreateProjectFolders(BaseAction):
         try:
             # Get paths based on presets
             basic_paths = self.get_path_items(project_folder_presets)
-            anatomy = Anatomy(project["full_name"])
-            self.create_folders(basic_paths, entity, project, anatomy)
+            self.create_folders(basic_paths, project)
             self.create_ftrack_entities(basic_paths, project)
 
         except Exception as exc:
@@ -220,7 +219,8 @@ class CreateProjectFolders(BaseAction):
             output.append(os.path.normpath(os.path.sep.join(clean_items)))
         return output
 
-    def create_folders(self, basic_paths, entity, project, anatomy):
+    def create_folders(self, basic_paths, project):
+        anatomy = Anatomy(project["full_name"])
         roots_paths = []
         if isinstance(anatomy.roots, dict):
             for root in anatomy.roots:

--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -223,7 +223,7 @@ class CreateProjectFolders(BaseAction):
         anatomy = Anatomy(project["full_name"])
         roots_paths = []
         if isinstance(anatomy.roots, dict):
-            for root in anatomy.roots:
+            for root in anatomy.roots.values():
                 roots_paths.append(root.value)
         else:
             roots_paths.append(anatomy.roots.value)

--- a/pype/modules/ftrack/actions/action_create_project_structure.py
+++ b/pype/modules/ftrack/actions/action_create_project_structure.py
@@ -235,7 +235,9 @@ class CreateProjectFolders(BaseAction):
             for path in full_paths:
                 if os.path.exists(path):
                     continue
-                os.makedirs(path.format(project_root=project_root))
+                full_path = path.format(project_root=project_root)
+                self.log.debug("Creating folder: {}".format(full_path))
+                os.makedirs(full_path)
 
 
 def register(session, plugins_presets={}):


### PR DESCRIPTION
## Issue
- ftrack action `CreateProjectFolders` is using root keys instead of root paths to create project folders
- lack of process logs

## Changes
- create project folders is using root paths instead of keys
- added few logs

## Note
- action will create defined folders in each project's root

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/968|