### PR TITLE
Fix update of project's tasks on Ftrack sync

### DIFF
--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -2151,10 +2151,27 @@ class SyncEntitiesFactory:
             self.report_items["warning"][msg] = sub_msg
             self.log.warning(sub_msg)
 
-        return self.compare_dict(
-            self.entities_dict[self.ft_project_id]["final_entity"],
-            self.avalon_project
-        )
+        # Compare tasks from current project schema and previous project schema
+        final_doc_data = self.entities_dict[self.ft_project_id]["final_entity"]
+        final_doc_tasks = final_doc_data["config"].pop("tasks")
+        current_doc_tasks = self.avalon_project.get("config", {}).get("tasks")
+        # Update project's tasks if tasks are empty or are not same
+        if not final_doc_tasks:
+            update_tasks = True
+        else:
+            update_tasks = final_doc_tasks != current_doc_tasks
+
+        changes = self.compare_dict(final_doc_data, self.avalon_project)
+
+        # Put back tasks data to final entity object
+        final_doc_data["config"]["tasks"] = final_doc_tasks
+
+        # Add tasks updates if tasks changed
+        if update_tasks:
+            if "config" not in changes:
+                changes["config"] = {}
+            changes["config"]["tasks"] = final_doc_tasks
+        return changes
 
     def compare_dict(self, dict_new, dict_old, _ignore_keys=[]):
         """

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1701,9 +1701,18 @@ class SyncEntitiesFactory:
                         avalon_id
                     )
                 )
+            # Prepare task changes as they have to be stored as one key
+            final_doc = self.entities_dict[ftrack_id]["final_entity"]
+            final_doc_tasks = final_doc["data"].pop("tasks", None) or {}
+            current_doc_tasks = avalon_entity["data"].get("tasks") or {}
+            if not final_doc_tasks:
+                update_tasks = True
+            else:
+                update_tasks = final_doc_tasks != current_doc_tasks
+
             # check rest of data
             data_changes = self.compare_dict(
-                self.entities_dict[ftrack_id]["final_entity"],
+                final_doc,
                 avalon_entity,
                 ignore_keys[ftrack_id]
             )
@@ -1713,17 +1722,13 @@ class SyncEntitiesFactory:
                     self.updates[avalon_id]
                 )
 
-            # double check changes in tasks, some task could be renamed or
-            # deleted in Ftrack - not captured otherwise
-            final_entity = self.entities_dict[ftrack_id]["final_entity"]
-            if final_entity["data"].get("tasks", {}) != \
-                    avalon_entity["data"].get("tasks", {}):
+            # Add tasks back to final doc object
+            final_doc["data"]["tasks"] = final_doc_tasks
+            # Add tasks to updates if there are different
+            if update_tasks:
                 if "data" not in self.updates[avalon_id]:
                     self.updates[avalon_id]["data"] = {}
-
-                self.updates[avalon_id]["data"]["tasks"] = (
-                    final_entity["data"]["tasks"]
-                )
+                self.updates[avalon_id]["data"]["tasks"] = final_doc_tasks
 
     def synchronize(self):
         self.log.debug("* Synchronization begins")


### PR DESCRIPTION
## Issue
- during sync to avalon are project's tasks compared to previous state of project and pass only changes between them to be updated but tasks must be updated as one key and is not possible to pass only changes
    - due to this on each sync are task types chaning between 2 states

## Changes
- modification of any task type is always resolved as all task types must be updated

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/973|