### PR TITLE
Get creator by name fix

### DIFF
--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -13,7 +13,8 @@ from .avalon_context import (
     get_hierarchy,
     get_linked_assets,
     get_latest_version,
-    BuildWorkfile
+    BuildWorkfile,
+    get_creator_by_name
 )
 
 from .hooks import PypeHook, execute_hook
@@ -59,6 +60,7 @@ __all__ = [
     "get_linked_assets",
     "get_latest_version",
     "BuildWorkfile",
+    "get_creator_by_name",
 
     "PypeHook",
     "execute_hook",

--- a/pype/lib/avalon_context.py
+++ b/pype/lib/avalon_context.py
@@ -868,3 +868,30 @@ class BuildWorkfile:
             )
 
         return output
+
+
+def get_creator_by_name(creator_name, case_sensitive=False):
+    """Find creator plugin by name.
+
+    Args:
+        creator_name (str): Name of creator class that should be returned.
+        case_sensitive (bool): Match of creator plugin name is case sensitive.
+            Set to `False` by default.
+
+    Returns:
+        Creator: Return first matching plugin or `None`.
+    """
+    # Lower input creator name if is not case sensitive
+    if not case_sensitive:
+        creator_name = creator_name.lower()
+
+    for creator_plugin in avalon.api.discover(avalon.api.Creator):
+        _creator_name = creator_plugin.__name__
+
+        # Lower creator plugin name if is not case sensitive
+        if not case_sensitive:
+            _creator_name = _creator_name.lower()
+
+        if _creator_name == creator_name:
+            return creator_plugin
+    return None

--- a/pype/plugins/blender/load/load_layout.py
+++ b/pype/plugins/blender/load/load_layout.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional
 from avalon import api, blender, pipeline
 import bpy
 import pype.hosts.blender.plugin as plugin
+from pype.lib import get_creator_by_name
 
 
 class BlendLayoutLoader(plugin.AssetLoader):
@@ -23,6 +24,9 @@ class BlendLayoutLoader(plugin.AssetLoader):
     label = "Link Layout"
     icon = "code-fork"
     color = "orange"
+
+    animation_creator_name = "CreateAnimation"
+    setdress_creator_name = "CreateSetDress"
 
     def _remove(self, objects, obj_container):
         for obj in list(objects):
@@ -428,6 +432,12 @@ class UnrealLayoutLoader(plugin.AssetLoader):
 
             objects_to_transform = []
 
+            creator_plugin = get_creator_by_name(self.animation_creator_name)
+            if not creator_plugin:
+                raise ValueError("Creator plugin \"{}\" was not found.".format(
+                    self.animation_creator_name
+                ))
+
             if family == 'rig':
                 for o in objects:
                     if o.type == 'ARMATURE':
@@ -436,9 +446,9 @@ class UnrealLayoutLoader(plugin.AssetLoader):
                         o.select_set(True)
                         asset = api.Session["AVALON_ASSET"]
                         c = api.create(
+                            creator_plugin,
                             name="animation_" + element_collection.name,
                             asset=asset,
-                            family="animation",
                             options={"useSelection": True},
                             data={"dependencies": representation})
                         scene.collection.children.unlink(c)
@@ -505,10 +515,15 @@ class UnrealLayoutLoader(plugin.AssetLoader):
 
         # Create a setdress subset to contain all the animation for all
         # the rigs in the layout
+        creator_plugin = get_creator_by_name(self.setdress_creator_name)
+        if not creator_plugin:
+            raise ValueError("Creator plugin \"{}\" was not found.".format(
+                self.setdress_creator_name
+            ))
         parent = api.create(
+            creator_plugin,
             name="animation",
             asset=api.Session["AVALON_ASSET"],
-            family="setdress",
             options={"useSelection": True},
             data={"dependencies": str(context["representation"]["_id"])})
 
@@ -606,10 +621,16 @@ class UnrealLayoutLoader(plugin.AssetLoader):
 
         bpy.data.collections.remove(obj_container)
 
+        creator_plugin = get_creator_by_name(self.setdress_creator_name)
+        if not creator_plugin:
+            raise ValueError("Creator plugin \"{}\" was not found.".format(
+                self.setdress_creator_name
+            ))
+
         parent = api.create(
+            creator_plugin,
             name="animation",
             asset=api.Session["AVALON_ASSET"],
-            family="setdress",
             options={"useSelection": True},
             data={"dependencies": str(representation["_id"])})
 

--- a/pype/plugins/maya/load/load_reference.py
+++ b/pype/plugins/maya/load/load_reference.py
@@ -3,6 +3,7 @@ from avalon import api, maya
 from maya import cmds
 import os
 from pype.api import config
+from pype.lib import get_creator_by_name
 
 
 class ReferenceLoader(pype.hosts.maya.plugin.ReferenceLoader):
@@ -24,6 +25,9 @@ class ReferenceLoader(pype.hosts.maya.plugin.ReferenceLoader):
     order = -10
     icon = "code-fork"
     color = "orange"
+
+    # Name of creator class that will be used to create animation instance
+    animation_creator_name = "CreateAnimation"
 
     def process_reference(self, context, name, namespace, options):
         import maya.cmds as cmds
@@ -135,10 +139,13 @@ class ReferenceLoader(pype.hosts.maya.plugin.ReferenceLoader):
         self.log.info("Creating subset: {}".format(namespace))
 
         # Create the animation instance
+        creator_plugin = get_creator_by_name(self.animation_creator_name)
         with maya.maintained_selection():
             cmds.select([output, controls] + roots, noExpand=True)
-            api.create(name=namespace,
-                       asset=asset,
-                       family="animation",
-                       options={"useSelection": True},
-                       data={"dependencies": dependency})
+            api.create(
+                creator_plugin,
+                name=namespace,
+                asset=asset,
+                options={"useSelection": True},
+                data={"dependencies": dependency}
+            )


### PR DESCRIPTION
## Issue
- Maya's Referrence loader and Blender's Layout loader are creating instances during loading and are expecting that `avalon.api.create` can work with only family which is not possible since [PR in avalon-core](https://github.com/pypeclub/avalon-core/pull/231)

## Suggested solution
- implemented function `get_creator_by_name` that returns creator plugin but it's name
- loaders have defined creator name that will be used to create new instances and use `get_creator_by_name` to use it

## Note
The function `get_creator_by_name` returns `None` if none of registered creator plugins match to entered name and loaders will raise an error if that happens. Should the error be raised? Should be raise inside the loader or inside `get_creator_by_name`?

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/980|