### PR TITLE
Get creator by name fix

### DIFF
--- a/pype/hosts/maya/plugins/load/load_reference.py
+++ b/pype/hosts/maya/plugins/load/load_reference.py
@@ -3,6 +3,7 @@ from avalon import api, maya
 from maya import cmds
 import os
 from pype.api import get_project_settings
+from pype.lib import get_creator_by_name
 
 
 class ReferenceLoader(pype.hosts.maya.api.plugin.ReferenceLoader):
@@ -24,6 +25,9 @@ class ReferenceLoader(pype.hosts.maya.api.plugin.ReferenceLoader):
     order = -10
     icon = "code-fork"
     color = "orange"
+
+    # Name of creator class that will be used to create animation instance
+    animation_creator_name = "CreateAnimation"
 
     def process_reference(self, context, name, namespace, options):
         import maya.cmds as cmds
@@ -135,10 +139,13 @@ class ReferenceLoader(pype.hosts.maya.api.plugin.ReferenceLoader):
         self.log.info("Creating subset: {}".format(namespace))
 
         # Create the animation instance
+        creator_plugin = get_creator_by_name(self.animation_creator_name)
         with maya.maintained_selection():
             cmds.select([output, controls] + roots, noExpand=True)
-            api.create(name=namespace,
-                       asset=asset,
-                       family="animation",
-                       options={"useSelection": True},
-                       data={"dependencies": dependency})
+            api.create(
+                creator_plugin,
+                name=namespace,
+                asset=asset,
+                options={"useSelection": True},
+                data={"dependencies": dependency}
+            )

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -59,7 +59,9 @@ from .avalon_context import (
     save_workfile_data_to_doc,
     get_workfile_doc,
 
-    BuildWorkfile
+    BuildWorkfile,
+
+    get_creator_by_name
 )
 
 from .applications import (
@@ -140,6 +142,8 @@ __all__ = [
     "get_workfile_doc",
 
     "BuildWorkfile",
+
+    "get_creator_by_name",
 
     "ApplicationLaunchFailed",
     "ApplictionExecutableNotFound",

--- a/pype/lib/avalon_context.py
+++ b/pype/lib/avalon_context.py
@@ -1119,3 +1119,30 @@ class BuildWorkfile:
             )
 
         return output
+
+
+def get_creator_by_name(creator_name, case_sensitive=False):
+    """Find creator plugin by name.
+
+    Args:
+        creator_name (str): Name of creator class that should be returned.
+        case_sensitive (bool): Match of creator plugin name is case sensitive.
+            Set to `False` by default.
+
+    Returns:
+        Creator: Return first matching plugin or `None`.
+    """
+    # Lower input creator name if is not case sensitive
+    if not case_sensitive:
+        creator_name = creator_name.lower()
+
+    for creator_plugin in avalon.api.discover(avalon.api.Creator):
+        _creator_name = creator_plugin.__name__
+
+        # Lower creator plugin name if is not case sensitive
+        if not case_sensitive:
+            _creator_name = _creator_name.lower()
+
+        if _creator_name == creator_name:
+            return creator_plugin
+    return None


### PR DESCRIPTION
## Issue
- Maya's Referrence loader and Blender's Layout loader are creating instances during loading and are expecting that `avalon.api.create` can work with only family which is not possible since [PR in avalon-core](https://github.com/pypeclub/avalon-core/pull/231)

## Suggested solution
- implemented function `get_creator_by_name` that returns creator plugin but it's name
- loaders have defined creator name that will be used to create new instances and use `get_creator_by_name` to use it

## Note
The function `get_creator_by_name` returns `None` if none of registered creator plugins match to entered name and loaders will raise an error if that happens. Should the error be raised? Should be raise inside the loader or inside `get_creator_by_name`?

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/979|