### PR TITLE
Fix Ftrack custom attribute update

### DIFF
--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -1817,7 +1817,7 @@ class SyncToAvalonEvent(BaseEvent):
 
             # Ftrack's entity_type does not have defined custom attributes
             if ent_cust_attrs is None:
-                continue
+                ent_cust_attrs = []
 
             for key, values in ent_info["changes"].items():
                 if key in hier_attrs_keys:

--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -1969,11 +1969,20 @@ class SyncToAvalonEvent(BaseEvent):
         cust_attrs, hier_attrs = self.avalon_cust_attrs
 
         # Hierarchical custom attributes preparation ***
+        hier_attr_key_by_id = {
+            attr["id"]: attr["key"]
+            for attr in hier_attrs
+        }
+        hier_attr_id_by_key = {
+            key: attr_id
+            for attr_id, key in hier_attr_key_by_id.items()
+        }
+
         if all_keys:
             hier_cust_attrs_keys = [
-                attr["key"] for attr in hier_attrs if (
-                    not attr["key"].startswith("avalon_")
-                )
+                key
+                for key in hier_attr_id_by_key.keys()
+                if not key.startswith("avalon_")
             ]
 
         mongo_ftrack_mapping = {}
@@ -2079,15 +2088,19 @@ class SyncToAvalonEvent(BaseEvent):
         entity_ids_joined = ", ".join([
             "\"{}\"".format(id) for id in cust_attrs_ftrack_ids
         ])
+        configuration_ids = set()
+        for key in hier_cust_attrs_keys:
+            configuration_ids.add(hier_attr_id_by_key[key])
+
         attributes_joined = ", ".join([
-            "\"{}\"".format(name) for name in hier_cust_attrs_keys
+            "\"{}\"".format(conf_id) for conf_id in configuration_ids
         ])
 
         queries = [{
             "action": "query",
             "expression": (
                 "select value, entity_id from CustomAttributeValue "
-                "where entity_id in ({}) and configuration.key in ({})"
+                "where entity_id in ({}) and configuration_id in ({})"
             ).format(entity_ids_joined, attributes_joined)
         }]
 
@@ -2112,7 +2125,7 @@ class SyncToAvalonEvent(BaseEvent):
             if value["value"] is None:
                 continue
             entity_id = value["entity_id"]
-            key = value["configuration"]["key"]
+            key = hier_attr_key_by_id[value["configuration_id"]]
             entities_dict[entity_id]["hier_attrs"][key] = value["value"]
 
         # Get dictionary with not None hierarchical values to pull to childs


### PR DESCRIPTION
## Issue
- object types without any specific custom attributes skip value changes of custom attributes even if happened on hierarchical custom attribute

## Changes
- custom attribute update is not skipped until will check that modified values may be from hierarchical custom attribtes
- hierarchical custom attributes are not queried by configuration key but by configuration id
    - configuration key may be same as there may be hierarchical and non hierarchical custom attribute with same key

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/983|