### PR TITLE
Fix Ftrack custom attribute update

### DIFF
--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -1815,7 +1815,7 @@ class SyncToAvalonEvent(BaseEvent):
 
             # Ftrack's entity_type does not have defined custom attributes
             if ent_cust_attrs is None:
-                continue
+                ent_cust_attrs = []
 
             for key, values in ent_info["changes"].items():
                 if key in hier_attrs_keys:


### PR DESCRIPTION
## Issue
- object types without any specific custom attributes skip value changes of custom attributes even if happened on hierarchical custom attribute

## Changes
- custom attribute update is not skipped until will check that modified values may be from hierarchical custom attribtes
- hierarchical custom attributes are not queried by configuration key but by configuration id
    - configuration key may be same as there may be hierarchical and non hierarchical custom attribute with same key

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/982|