### PR TITLE
Maya: Alembic only set attributes that exists.

### DIFF
--- a/pype/hosts/maya/plugin.py
+++ b/pype/hosts/maya/plugin.py
@@ -220,8 +220,7 @@ class ReferenceLoader(api.Loader):
                 "{}:*".format(members[0].split(":")[0]), type="AlembicNode"
             )
             if alembic_nodes:
-                for attr in alembic_attrs:
-                    value = alembic_data[attr]
+                for attr, value in alembic_data.items():
                     cmds.setAttr("{}.{}".format(alembic_nodes[0], attr), value)
 
         # Fix PLN-40 for older containers created with Avalon that had the


### PR DESCRIPTION
When referencing a static alembic the alembic node is not created. When updating this, the code was hardcoded to set certain attributes rather than setting attributes that exists.