### PR TITLE
Extract review handle bizzar pixel aspect ratio

### DIFF
--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -874,12 +874,24 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 width_half_pad = int((output_width - width_scale) / 2)
                 height_scale = output_height
                 height_half_pad = 0
-            else:
-                self.log.debug("Input is heigher then output")
+
+            elif input_res_ratio > output_res_ratio:
+                self.log.debug(
+                    "Input's resolution ratio is higher then output's"
+                )
                 width_scale = output_width
                 width_half_pad = 0
                 height_scale = int(input_height * scale_factor_by_width)
                 height_half_pad = int((output_height - height_scale) / 2)
+
+            else:
+                self.log.debug(
+                    "Input's resolution ratio is same as output's"
+                )
+                width_scale = output_width
+                width_half_pad = 0
+                height_scale = output_height
+                height_half_pad = 0
 
             self.log.debug("width_scale: `{}`".format(width_scale))
             self.log.debug("width_half_pad: `{}`".format(width_half_pad))

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -893,6 +893,14 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 height_scale = output_height
                 height_half_pad = 0
 
+            if output_width < width_scale or output_height < height_scale:
+                width_scale = width_scale - round(abs(
+                    width_scale - (width_scale * pixel_aspect)
+                ))
+                height_scale = height_scale - round(abs(
+                    height_scale - (height_scale * pixel_aspect)
+                ))
+
             self.log.debug("width_scale: `{}`".format(width_scale))
             self.log.debug("width_half_pad: `{}`".format(width_half_pad))
             self.log.debug("height_scale: `{}`".format(height_scale))

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -881,7 +881,7 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 height_scale = output_height
                 height_half_pad = 0
 
-            elif input_res_ratio > output_res_ratio:
+            else:
                 # Modify height scale if input resolution ratio is smaller
                 self.log.debug(
                     "Input's resolution ratio is higher then output's"
@@ -890,16 +890,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 width_half_pad = 0
                 height_scale = int(input_height * scale_factor_by_width)
                 height_half_pad = int((output_height - height_scale) / 2)
-
-            else:
-                # Only scale to output's resolution if ratios are same
-                self.log.debug(
-                    "Input's resolution ratio is same as output's"
-                )
-                width_scale = output_width
-                width_half_pad = 0
-                height_scale = output_height
-                height_half_pad = 0
 
             # Lower scale if is bigger then output (edge case issue)
             # - lowered by one "point" of pixel aspec ratio size

--- a/pype/plugins/global/publish/extract_review.py
+++ b/pype/plugins/global/publish/extract_review.py
@@ -906,6 +906,17 @@ class ExtractReview(pyblish.api.InstancePlugin):
             # - this may happen when pixel aspect ratio is defined with more
             #   than 2 decimal places and ratios are not calculated "accurate"
             if output_width < width_scale or output_height < height_scale:
+                msg = (
+                    "Have to lower scale resolution because is bigger than"
+                    " output's resolution. Probably got invalid aspect ratio"
+                    " from `instance.data`. SCALE RESOLUTION: {}x{}"
+                    " || OUTPUT RESOLUTION {}x{} || PIXEL ASPECT RATIO: {}"
+                ).format(
+                    width_scale, height_scale,
+                    output_width, output_height,
+                    pixel_aspect
+                )
+                self.log.warning(msg)
                 width_scale = width_scale - round(abs(
                     width_scale - (width_scale * pixel_aspect)
                 ))


### PR DESCRIPTION
## Issue
~~- it is not handled when input and output resolution ratio is same just in different scale (INPUT: 200x320 -> OUTPUT: 100x160)~~
- it is possible that `instance.data` may contain not "ideal" pixel aspect ratio that may affect scale of an input to not allowed resolution compared to output resolution
    - it is not possible to use ffmpeg padding that has resolution smaller then input's resolution
    - this happens when pixel aspect number has more than 3 float points and resolution is bigger than 2K

## Changes
~~- just use output resolution without calculations when input and output resolution ratios are same for scale filter~~
- handle most of edge cases when scale resolution is bigger than output's resolution by subtracting one pixel aspect ratio "point"