### PR TITLE
Maya: Looks - disable hardlinks

### DIFF
--- a/pype/plugins/maya/publish/extract_look.py
+++ b/pype/plugins/maya/publish/extract_look.py
@@ -199,7 +199,7 @@ class ExtractLook(pype.api.Extractor):
             # further and until then, we disable creation of
             # hardlinks here.
             mode = COPY
-            
+
             if mode == COPY:
                 transfers.append((source, destination))
                 self.log.info('copying')

--- a/pype/plugins/maya/publish/extract_look.py
+++ b/pype/plugins/maya/publish/extract_look.py
@@ -192,6 +192,14 @@ class ExtractLook(pype.api.Extractor):
             if forceCopy:
                 mode = COPY
 
+            # fixme: This is temporary hack to disable hardlink.
+            # There is issue in some cases where hardlinks
+            # don't work with maketx tool, blocking files and
+            # breaking integration. This must be investigated
+            # further and until then, we disable creation of
+            # hardlinks here.
+            mode = COPY
+            
             if mode == COPY:
                 transfers.append((source, destination))
                 self.log.info('copying')


### PR DESCRIPTION
## Problem

This temporarily disables creation of hardlinks in Look extractor as it is causing problems with IO blocks with maketx tool during integration. Need to investigate further.