### PR TITLE
Unify the use of single and multi root templates

### DIFF
--- a/pype/settings/defaults/project_anatomy/roots.json
+++ b/pype/settings/defaults/project_anatomy/roots.json
@@ -1,5 +1,7 @@
 {
-    "windows": "C:/projects",
-    "darwin": "/Volumes/path",
-    "linux": "/mnt/share/projects"
+    "work": {
+        "windows": "C:/projects",
+        "darwin": "/Volumes/path",
+        "linux": "/mnt/share/projects"
+    }
 }

--- a/pype/settings/defaults/project_anatomy/templates.json
+++ b/pype/settings/defaults/project_anatomy/templates.json
@@ -4,23 +4,23 @@
     "frame_padding": 4,
     "frame": "{frame:0>{@frame_padding}}",
     "work": {
-        "folder": "{root}/{project[name]}/{hierarchy}/{asset}/work/{task}",
+        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/work/{task}",
         "file": "{project[code]}_{asset}_{task}_{@version}<_{comment}>.{ext}",
         "path": "{@folder}/{@file}"
     },
     "render": {
-        "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/render/{subset}/{@version}",
+        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/render/{subset}/{@version}",
         "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{ext}",
         "path": "{@folder}/{@file}"
     },
     "publish": {
-        "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/{@version}",
+        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/{@version}",
         "file": "{project[code]}_{asset}_{subset}_{@version}<_{output}><.{@frame}>.{ext}",
         "path": "{@folder}/{@file}",
         "thumbnail": "{thumbnail_root}/{project[name]}/{_id}_{thumbnail_type}.{ext}"
     },
     "master": {
-        "folder": "{root}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/master",
+        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/master",
         "file": "{project[code]}_{asset}_{subset}_master<_{output}><.{frame}>.{ext}",
         "path": "{@folder}/{@file}"
     },

--- a/pype/settings/lib.py
+++ b/pype/settings/lib.py
@@ -333,7 +333,14 @@ def get_default_anatomy_settings(clear_metadata=True):
     """Project anatomy data with applied studio's default project overrides."""
     default_values = get_default_settings()[PROJECT_ANATOMY_KEY]
     studio_values = get_studio_project_anatomy_overrides()
-    result = apply_overrides(default_values, studio_values)
+
+    # TODO uncomment and remove hotfix result when overrides of anatomy
+    #   are stored correctly.
+    # result = apply_overrides(default_values, studio_values)
+    result = copy.deepcopy(default_values)
+    if studio_values:
+        for key, value in studio_values.items():
+            result[key] = value
     if clear_metadata:
         clear_metadata_from_settings(result)
     return result
@@ -352,7 +359,13 @@ def get_anatomy_settings(project_name, clear_metadata=True):
         project_name
     )
 
-    result = apply_overrides(studio_overrides, project_overrides)
+    # TODO uncomment and remove hotfix result when overrides of anatomy
+    #   are stored correctly.
+    # result = apply_overrides(studio_overrides, project_overrides)
+    result = copy.deepcopy(studio_overrides)
+    if project_overrides:
+        for key, value in project_overrides.items():
+            result[key] = value
     if clear_metadata:
         clear_metadata_from_settings(result)
     return result

--- a/pype/tools/settings/settings/widgets/anatomy_types.py
+++ b/pype/tools/settings/settings/widgets/anatomy_types.py
@@ -264,15 +264,15 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
                 "multiplatform": True
             }
         }
-        multiroot_widget = ModifiableDict(
+        roots_widget = ModifiableDict(
             multiroot_data, self,
             as_widget=True, parent_widget=content_widget
         )
-        multiroot_widget.create_ui()
+        roots_widget.create_ui()
 
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
-        content_layout.addWidget(multiroot_widget)
+        content_layout.addWidget(roots_widget)
 
         body_widget.set_content_widget(content_widget)
         self.label_widget = body_widget.label_widget
@@ -282,8 +282,8 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         main_layout.addWidget(body_widget)
 
         self.body_widget = body_widget
-        self.multiroot_widget = multiroot_widget
-        multiroot_widget.value_changed.connect(self._on_value_change)
+        self.roots_widget = roots_widget
+        roots_widget.value_changed.connect(self._on_value_change)
 
     def update_default_values(self, parent_values):
         self._state = None
@@ -294,20 +294,22 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         else:
             value = NOT_SET
 
-        is_multiroot = False
+        self._has_studio_override = False
+        self._had_studio_override = False
+
+        is_multiroot = True
+        # Backward compatibility: Allow to switch to multiroot
         if isinstance(value, dict):
+            is_multiroot = False
             for _value in value.values():
                 if isinstance(_value, dict):
                     is_multiroot = True
                     break
 
-        self._has_studio_override = False
-        self._had_studio_override = False
-
-        if not is_multiroot and value is not NOT_SET:
+        if not is_multiroot:
             value = {"": value}
 
-        self.multiroot_widget.update_default_values(value)
+        self.roots_widget.update_default_values(value)
 
     def update_studio_values(self, parent_values):
         self._state = None
@@ -321,7 +323,7 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         self._has_studio_override = value is not NOT_SET
         self._had_studio_override = value is not NOT_SET
 
-        self.multiroot_widget.update_studio_values(value)
+        self.roots_widget.update_studio_values(value)
 
     def apply_overrides(self, parent_values):
         # Make sure this is set to False
@@ -334,10 +336,10 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
 
         self._is_overriden = value is not NOT_SET
         self._was_overriden = bool(self._is_overriden)
-        self.multiroot_widget.apply_overrides(value)
+        self.roots_widget.apply_overrides(value)
 
     def hierarchical_style_update(self):
-        self.multiroot_widget.hierarchical_style_update()
+        self.roots_widget.hierarchical_style_update()
         self.update_style()
 
     def update_style(self):
@@ -380,52 +382,52 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
 
     @property
     def child_has_studio_override(self):
-        return self.multiroot_widget.has_studio_override
+        return self.roots_widget.has_studio_override
 
     @property
     def child_modified(self):
-        return self.multiroot_widget.child_modified
+        return self.roots_widget.child_modified
 
     @property
     def child_overriden(self):
         return (
-            self.multiroot_widget.is_overriden
-            or self.multiroot_widget.child_overriden
+            self.roots_widget.is_overriden
+            or self.roots_widget.child_overriden
         )
 
     @property
     def child_invalid(self):
-        return self.multiroot_widget.child_invalid
+        return self.roots_widget.child_invalid
 
     def remove_overrides(self):
         self._is_overriden = False
         self._is_modified = False
 
-        self.multiroot_widget.remove_overrides()
+        self.roots_widget.remove_overrides()
 
     def reset_to_pype_default(self):
-        self.multiroot_widget.reset_to_pype_default()
+        self.roots_widget.reset_to_pype_default()
         self._has_studio_override = False
 
     def set_studio_default(self):
-        self.multiroot_widget.reset_to_pype_default()
+        self.roots_widget.reset_to_pype_default()
         self._has_studio_override = True
 
     def discard_changes(self):
         self._is_overriden = self._was_overriden
         self._is_modified = False
 
-        self.multiroot_widget.discard_changes()
+        self.roots_widget.discard_changes()
 
         self._is_modified = self.child_modified
         self._has_studio_override = self._had_studio_override
 
     def set_as_overriden(self):
         self._is_overriden = True
-        self.multiroot_widget.set_as_overriden()
+        self.roots_widget.set_as_overriden()
 
     def item_value(self):
-        return self.multiroot_widget.item_value()
+        return self.roots_widget.item_value()
 
     def config_value(self):
         return {self.key: self.item_value()}

--- a/pype/tools/settings/settings/widgets/anatomy_types.py
+++ b/pype/tools/settings/settings/widgets/anatomy_types.py
@@ -250,35 +250,12 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
 
         self.key = input_data["key"]
 
-        self._multiroot_state = None
-        self.default_is_multiroot = False
-        self.studio_is_multiroot = False
         self.was_multiroot = NOT_SET
 
     def create_ui(self, _label_widget=None):
-        checkbox_widget = QtWidgets.QWidget(self)
-        multiroot_label = QtWidgets.QLabel(
-            "Use multiple roots", checkbox_widget
-        )
-        multiroot_checkbox = QtWidgets.QCheckBox(checkbox_widget)
-
-        checkbox_layout = QtWidgets.QHBoxLayout(checkbox_widget)
-        checkbox_layout.addWidget(multiroot_label, 0)
-        checkbox_layout.addWidget(multiroot_checkbox, 1)
-
         body_widget = ExpandingWidget("Roots", self)
         content_widget = QtWidgets.QWidget(body_widget)
 
-        path_widget_data = {
-            "key": self.key,
-            "multipath": False,
-            "multiplatform": True
-        }
-        singleroot_widget = PathWidget(
-            path_widget_data, self,
-            as_widget=True, parent_widget=content_widget
-        )
-        singleroot_widget.create_ui()
         multiroot_data = {
             "key": self.key,
             "expandable": False,
@@ -295,8 +272,6 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
 
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
-        content_layout.addWidget(checkbox_widget)
-        content_layout.addWidget(singleroot_widget)
         content_layout.addWidget(multiroot_widget)
 
         body_widget.set_content_widget(content_widget)
@@ -307,24 +282,11 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         main_layout.addWidget(body_widget)
 
         self.body_widget = body_widget
-        self.multiroot_label = multiroot_label
-        self.multiroot_checkbox = multiroot_checkbox
-        self.singleroot_widget = singleroot_widget
         self.multiroot_widget = multiroot_widget
-
-        multiroot_checkbox.stateChanged.connect(self._on_multiroot_checkbox)
-        singleroot_widget.value_changed.connect(self._on_value_change)
         multiroot_widget.value_changed.connect(self._on_value_change)
-
-        self._on_multiroot_checkbox()
-
-    @property
-    def is_multiroot(self):
-        return self.multiroot_checkbox.isChecked()
 
     def update_default_values(self, parent_values):
         self._state = None
-        self._multiroot_state = None
         self._is_modified = False
 
         if isinstance(parent_values, dict):
@@ -339,28 +301,16 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
                     is_multiroot = True
                     break
 
-        self.default_is_multiroot = is_multiroot
-        self.was_multiroot = is_multiroot
-        self.set_multiroot(is_multiroot)
-
         self._has_studio_override = False
         self._had_studio_override = False
-        if is_multiroot:
-            for _value in value.values():
-                singleroot_value = _value
-                break
 
-            multiroot_value = value
-        else:
-            singleroot_value = value
-            multiroot_value = {"": value}
+        if not is_multiroot and value is not NOT_SET:
+            value = {"": value}
 
-        self.singleroot_widget.update_default_values(singleroot_value)
-        self.multiroot_widget.update_default_values(multiroot_value)
+        self.multiroot_widget.update_default_values(value)
 
     def update_studio_values(self, parent_values):
         self._state = None
-        self._multiroot_state = None
         self._is_modified = False
 
         if isinstance(parent_values, dict):
@@ -368,81 +318,29 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
         else:
             value = NOT_SET
 
-        if value is NOT_SET:
-            is_multiroot = self.default_is_multiroot
-            self.studio_is_multiroot = NOT_SET
-            self._has_studio_override = False
-            self._had_studio_override = False
-        else:
-            is_multiroot = False
-            if isinstance(value, dict):
-                for _value in value.values():
-                    if isinstance(_value, dict):
-                        is_multiroot = True
-                        break
-            self.studio_is_multiroot = is_multiroot
-            self._has_studio_override = True
-            self._had_studio_override = True
+        self._has_studio_override = value is not NOT_SET
+        self._had_studio_override = value is not NOT_SET
 
-        self.was_multiroot = is_multiroot
-        self.set_multiroot(is_multiroot)
-
-        if is_multiroot:
-            self.multiroot_widget.update_studio_values(value)
-        else:
-            self.singleroot_widget.update_studio_values(value)
+        self.multiroot_widget.update_studio_values(value)
 
     def apply_overrides(self, parent_values):
         # Make sure this is set to False
         self._state = None
-        self._multiroot_state = None
         self._is_modified = False
 
         value = NOT_SET
         if parent_values is not NOT_SET:
             value = parent_values.get(self.key, value)
 
-        if value is NOT_SET:
-            is_multiroot = self.studio_is_multiroot
-            if is_multiroot is NOT_SET:
-                is_multiroot = self.default_is_multiroot
-        else:
-            is_multiroot = False
-            if isinstance(value, dict):
-                for _value in value.values():
-                    if isinstance(_value, dict):
-                        is_multiroot = True
-                        break
-
-        self.was_multiroot = is_multiroot
-        self.set_multiroot(is_multiroot)
-
-        if is_multiroot:
-            self._is_overriden = value is not NOT_SET
-            self._was_overriden = bool(self._is_overriden)
-            self.multiroot_widget.apply_overrides(value)
-        else:
-            self._is_overriden = value is not NOT_SET
-            self._was_overriden = bool(self._is_overriden)
-            self.singleroot_widget.apply_overrides(value)
+        self._is_overriden = value is not NOT_SET
+        self._was_overriden = bool(self._is_overriden)
+        self.multiroot_widget.apply_overrides(value)
 
     def hierarchical_style_update(self):
-        self.singleroot_widget.hierarchical_style_update()
         self.multiroot_widget.hierarchical_style_update()
         self.update_style()
 
     def update_style(self):
-        multiroot_state = self.style_state(
-            self.has_studio_override,
-            False,
-            False,
-            self.was_multiroot != self.is_multiroot
-        )
-        if multiroot_state != self._multiroot_state:
-            self.multiroot_label.setProperty("state", multiroot_state)
-            self.multiroot_label.style().polish(self.multiroot_label)
-            self._multiroot_state = multiroot_state
-
         state = self.style_state(
             self.has_studio_override,
             self.child_invalid,
@@ -467,162 +365,67 @@ class RootsWidget(QtWidgets.QWidget, SettingObject):
 
         self._state = state
 
-    def _on_multiroot_checkbox(self):
-        self.set_multiroot()
-
     def _on_value_change(self, item=None):
         if self.ignore_value_changes:
-            return
-
-        if item is not None and (
-            (self.is_multiroot and item != self.multiroot_widget)
-            or (not self.is_multiroot and item != self.singleroot_widget)
-        ):
             return
 
         if self.is_group and self.is_overidable:
             self._is_overriden = True
 
-        self._is_modified = (
-            self.was_multiroot != self.is_multiroot
-            or self.child_modified
-        )
+        self._is_modified = bool(self.child_modified)
 
         self.update_style()
 
         self.value_changed.emit(self)
 
-    def _from_single_to_multi(self):
-        single_value = self.singleroot_widget.item_value()
-        mutli_value = self.multiroot_widget.item_value()
-        first_key = None
-        for key in mutli_value.keys():
-            first_key = key
-            break
-
-        if first_key is None:
-            first_key = ""
-
-        mutli_value[first_key] = single_value
-
-        self.multiroot_widget.set_value(mutli_value)
-
-    def _from_multi_to_single(self):
-        mutli_value = self.multiroot_widget.all_item_values()
-        for value in mutli_value.values():
-            single_value = value
-            break
-
-        self.singleroot_widget.set_value(single_value)
-
-    def set_multiroot(self, is_multiroot=None):
-        if is_multiroot is None:
-            is_multiroot = self.is_multiroot
-            if is_multiroot:
-                self._from_single_to_multi()
-            else:
-                self._from_multi_to_single()
-
-        if is_multiroot != self.is_multiroot:
-            self.multiroot_checkbox.setChecked(is_multiroot)
-
-        self.singleroot_widget.setVisible(not is_multiroot)
-        self.multiroot_widget.setVisible(is_multiroot)
-
-        self._on_value_change()
-
     @property
     def child_has_studio_override(self):
-        if self.is_multiroot:
-            return self.multiroot_widget.has_studio_override
-        else:
-            return self.singleroot_widget.has_studio_override
+        return self.multiroot_widget.has_studio_override
 
     @property
     def child_modified(self):
-        if self.is_multiroot:
-            return self.multiroot_widget.child_modified
-        else:
-            return self.singleroot_widget.child_modified
+        return self.multiroot_widget.child_modified
 
     @property
     def child_overriden(self):
-        if self.is_multiroot:
-            return (
-                self.multiroot_widget.is_overriden
-                or self.multiroot_widget.child_overriden
-            )
-        else:
-            return (
-                self.singleroot_widget.is_overriden
-                or self.singleroot_widget.child_overriden
-            )
+        return (
+            self.multiroot_widget.is_overriden
+            or self.multiroot_widget.child_overriden
+        )
 
     @property
     def child_invalid(self):
-        if self.is_multiroot:
-            return self.multiroot_widget.child_invalid
-        else:
-            return self.singleroot_widget.child_invalid
+        return self.multiroot_widget.child_invalid
 
     def remove_overrides(self):
         self._is_overriden = False
         self._is_modified = False
 
-        if self.studio_is_multiroot is NOT_SET:
-            self.set_multiroot(self.default_is_multiroot)
-        else:
-            self.set_multiroot(self.studio_is_multiroot)
-
-        if self.is_multiroot:
-            self.multiroot_widget.remove_overrides()
-        else:
-            self.singleroot_widget.remove_overrides()
+        self.multiroot_widget.remove_overrides()
 
     def reset_to_pype_default(self):
-        self.set_multiroot(self.default_is_multiroot)
-        if self.is_multiroot:
-            self.multiroot_widget.reset_to_pype_default()
-        else:
-            self.singleroot_widget.reset_to_pype_default()
+        self.multiroot_widget.reset_to_pype_default()
         self._has_studio_override = False
 
     def set_studio_default(self):
-        if self.is_multiroot:
-            self.multiroot_widget.reset_to_pype_default()
-        else:
-            self.singleroot_widget.reset_to_pype_default()
+        self.multiroot_widget.reset_to_pype_default()
         self._has_studio_override = True
 
     def discard_changes(self):
         self._is_overriden = self._was_overriden
         self._is_modified = False
-        if self._is_overriden:
-            self.set_multiroot(self.was_multiroot)
-        else:
-            if self.studio_is_multiroot is NOT_SET:
-                self.set_multiroot(self.default_is_multiroot)
-            else:
-                self.set_multiroot(self.studio_is_multiroot)
 
-        if self.is_multiroot:
-            self.multiroot_widget.discard_changes()
-        else:
-            self.singleroot_widget.discard_changes()
+        self.multiroot_widget.discard_changes()
 
         self._is_modified = self.child_modified
         self._has_studio_override = self._had_studio_override
 
     def set_as_overriden(self):
         self._is_overriden = True
-        self.singleroot_widget.set_as_overriden()
         self.multiroot_widget.set_as_overriden()
 
     def item_value(self):
-        if self.is_multiroot:
-            return self.multiroot_widget.item_value()
-        else:
-            return self.singleroot_widget.item_value()
+        return self.multiroot_widget.item_value()
 
     def config_value(self):
         return {self.key: self.item_value()}


### PR DESCRIPTION
PR resolves issue: https://github.com/pypeclub/pype/issues/1010

## Changes
- removed support to set singleroot through settings tool
- default project roots have multiroot roots with single root `"work"`
- added "kind" fix of anatomy overrides

## Note
- overrides are not applied correctly on whole Project category settings (not only anatomy) because settings are stored without override metadata which define which keys are replaced