### PR TITLE
Removed Python 3 syntax from settings entities

### DIFF
--- a/pype/settings/entities/exceptions.py
+++ b/pype/settings/entities/exceptions.py
@@ -71,7 +71,9 @@ class SchemaTemplateMissingKeys(Exception):
         self.missing_keys = missing_keys
         self.required_keys = required_keys
         if template_name:
-            msg = f"Schema template \"{template_name}\" require more keys.\n"
+            msg = "Schema template \"{}\" require more keys.\n".format(
+                template_name
+            )
         else:
             msg = ""
         msg += "Required keys: {}\nMissing keys: {}".format(
@@ -82,5 +84,5 @@ class SchemaTemplateMissingKeys(Exception):
 
     def join_keys(self, keys):
         return ", ".join([
-            f"\"{key}\"" for key in keys
+            "\"{}\"".format(key) for key in keys
         ])

--- a/pype/settings/entities/lib.py
+++ b/pype/settings/entities/lib.py
@@ -252,9 +252,9 @@ def gui_schema(subfolder, main_schema_name):
                 try:
                     schema_data = json.load(json_stream)
                 except Exception as exc:
-                    raise Exception((
-                        f"Unable to parse JSON file {filepath}\n{exc}"
-                    )) from exc
+                    raise ValueError((
+                        "Unable to parse JSON file {}\n{}"
+                    ).format(filepath, str(exc)))
             if isinstance(schema_data, list):
                 loaded_schema_templates[basename] = schema_data
             else:


### PR DESCRIPTION
## Issue
- settings entities code contained python 3 syntax which was copied from GUI (PR https://github.com/pypeclub/pype/pull/1001)

## Changes
- replaced Python 3 syntax with Python 2 compatible