### PR TITLE
Project list import fix

### DIFF
--- a/pype/modules/sync_server/tray/app.py
+++ b/pype/modules/sync_server/tray/app.py
@@ -1,9 +1,11 @@
 from Qt import QtWidgets, QtCore, QtGui
 from Qt.QtCore import Qt
-from pype.tools.settings.settings.widgets.base import ProjectListWidget
 import attr
 import os
-from pype.tools.settings.settings import style
+from pype.tools.settings import (
+    ProjectListWidget,
+    style
+)
 from avalon.tools.delegates import PrettyTimeDelegate, pretty_timestamp
 
 from pype.lib import PypeLogger

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -32,5 +32,6 @@ def main(user_role=None):
 __all__ = (
     "style",
     "MainWidget",
+    "ProjectListWidget",
     "main"
 )

--- a/pype/tools/settings/__init__.py
+++ b/pype/tools/settings/__init__.py
@@ -1,7 +1,11 @@
 import sys
 from Qt import QtWidgets, QtGui
 
-from .settings import style, MainWidget
+from .settings import (
+    style,
+    MainWidget,
+    ProjectListWidget
+)
 
 
 def main(user_role=None):

--- a/pype/tools/settings/settings/__init__.py
+++ b/pype/tools/settings/settings/__init__.py
@@ -1,8 +1,12 @@
 from . import style
-from .widgets import MainWidget
+from .widgets import (
+    MainWidget,
+    ProjectListWidget
+)
 
 
 __all__ = (
     "style",
-    "MainWidget"
+    "MainWidget",
+    "ProjectListWidget"
 )

--- a/pype/tools/settings/settings/widgets/__init__.py
+++ b/pype/tools/settings/settings/widgets/__init__.py
@@ -1,9 +1,11 @@
 from .window import MainWidget
+from .categories import ProjectListWidget
 from . import item_types
 from . import anatomy_types
 
 __all__ = [
     "MainWidget",
+    "ProjectListWidget",
     "item_types",
     "anatomy_types"
 ]


### PR DESCRIPTION
## Changes
- propagated `ProjectListWidget` in settings tool to setting `__init__.py`
- sync server is importing from settings tool not from direct submodule