### PR TITLE
Tools miss env groups in schema

### DIFF
--- a/pype/settings/defaults/system_settings/tools.json
+++ b/pype/settings/defaults/system_settings/tools.json
@@ -56,12 +56,20 @@
     },
     "vray": {
         "enabled": true,
-        "environment": {},
+        "environment": {
+            "__environment_keys__": {
+                "vray": []
+            }
+        },
         "variants": {}
     },
     "yeti": {
         "enabled": true,
-        "environment": {},
+        "environment": {
+            "__environment_keys__": {
+                "yeti": []
+            }
+        },
         "variants": {}
     },
     "other": {

--- a/pype/settings/entities/root_entities.py
+++ b/pype/settings/entities/root_entities.py
@@ -494,7 +494,7 @@ class SystemSettings(RootEntity):
 
         Implementation of abstract method.
         """
-        return DEFAULTS_DIR
+        return os.path.join(DEFAULTS_DIR, SYSTEM_SETTINGS_KEY)
 
     def _save_studio_values(self):
         settings_value = self.settings_value()

--- a/pype/settings/entities/schemas/system_schema/tool_settings/schema_vray.json
+++ b/pype/settings/entities/schemas/system_schema/tool_settings/schema_vray.json
@@ -13,7 +13,8 @@
         {
             "key": "environment",
             "label": "Environment",
-            "type": "raw-json"
+            "type": "raw-json",
+            "env_group_key": "vray"
         },
         {
             "type": "schema_template",

--- a/pype/settings/entities/schemas/system_schema/tool_settings/schema_yeti.json
+++ b/pype/settings/entities/schemas/system_schema/tool_settings/schema_yeti.json
@@ -13,7 +13,8 @@
         {
             "key": "environment",
             "label": "Environment",
-            "type": "raw-json"
+            "type": "raw-json",
+            "env_group_key": "yeti"
         },
         {
             "type": "schema_template",


### PR DESCRIPTION
## Issue
- environments for vray and yeti are stored only as dictionary without metadata of env group
- default system settings are not stored where should

## Changes
- added `"env_group_key"` attribute to their environments
- restored defaults to contain metadata
- changed directory of default folder for system settings