### PR TITLE
Environments for context command

### DIFF
--- a/pype/cli.py
+++ b/pype/cli.py
@@ -109,6 +109,27 @@ def eventserver(debug,
 
 
 @main.command()
+@click.argument("output_json_path")
+@click.option("--project", help="Project name", default=None)
+@click.option("--asset", help="Asset name", default=None)
+@click.option("--task", help="Task name", default=None)
+@click.option("--app", help="Application name", default=None)
+def extractenvironments(output_json_path, project, asset, task, app):
+    """Extract environment variables for entered context to a json file.
+
+    Entered output filepath will be created if does not exists.
+
+    All context options must be passed otherwise only pype's global
+    environments will be extracted.
+
+    Context options are "project", "asset", "task", "app"
+    """
+    PypeCommands().extractenvironments(
+        output_json_path, project, asset, task, app
+    )
+
+
+@main.command()
 @click.argument("paths", nargs=-1)
 @click.option("-g", "--gui", is_flag=True, help="Run pyblish GUI")
 @click.option("-d", "--debug", is_flag=True, help="Print debug messages")

--- a/pype/cli.py
+++ b/pype/cli.py
@@ -124,7 +124,7 @@ def extractenvironments(output_json_path, project, asset, task, app):
 
     Context options are "project", "asset", "task", "app"
     """
-    PypeCommands().extractenvironments(
+    PypeCommands.extractenvironments(
         output_json_path, project, asset, task, app
     )
 

--- a/pype/pype_commands.py
+++ b/pype/pype_commands.py
@@ -2,6 +2,7 @@
 """Implementation of Pype commands."""
 import os
 import sys
+import json
 from pathlib import Path
 
 from pype.lib import PypeLogger
@@ -39,6 +40,22 @@ class PypeCommands:
     def launch_standalone_publisher():
         from pype.tools import standalonepublish
         standalonepublish.main()
+
+    @staticmethod
+    def extractenvironments(output_json_path, project, asset, task, app):
+        env = os.environ.copy()
+        if all((project, asset, task, app)):
+            from pype.api import get_app_environments_for_context
+            env = get_app_environments_for_context(
+                project, asset, task, app, env
+            )
+
+        output_dir = os.path.dirname(output_json_path)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        with open(output_json_path, "w") as file_stream:
+            json.dump(env, file_stream, indent=4)
 
     def publish(self, gui, paths):
         pass


### PR DESCRIPTION
## Description
We need to prepare environments for applications on farm which would require to import pype which is not possible at the moment and would require more changes (Issue https://github.com/pypeclub/pype/issues/1034). This is a temporary added command which can solve our current issue.

## Changes
- added `extractenvironments` to pype commands
    - 1 positional argument `output_json_path` where output will be stored
    - 4 options **project**, **asset**, **task**, **app** they define context for which environments will be prepared
    - if options are not entered then only pype's global environments are extracted