### PR TITLE
TVPaint thumbnail extract fix

### DIFF
--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -172,10 +172,13 @@ class ExtractSequence(pyblish.api.Extractor):
         if not thumbnail_fullpath:
             return
 
+        thumbnail_ext = os.path.splitext(
+            thumbnail_fullpath
+        )[1].replace(".", "")
         # Create thumbnail representation
         thumbnail_repre = {
             "name": "thumbnail",
-            "ext": ext,
+            "ext": thumbnail_ext,
             "outputName": "thumb",
             "files": os.path.basename(thumbnail_fullpath),
             "stagingDir": output_dir,

--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -49,6 +49,8 @@ class ExtractSequence(pyblish.api.Extractor):
         "renderPass": "\"PNG\"",
         "renderLayer": "\"PNG\"",
     }
+    default_thumbnail_save_mode = "\"JPG\""
+    thumbnail_save_mode_for_family = {}
 
     def process(self, instance):
         self.log.info(
@@ -120,9 +122,12 @@ class ExtractSequence(pyblish.api.Extractor):
 
         thumbnail_filename = "thumbnail"
 
+        thumbnail_save_mode = self.thumbnail_save_mode_for_family.get(
+            family_lowered, self.default_thumbnail_save_mode
+        )
         # Render output
         output_files_by_frame = self.render(
-            save_mode, filename_template, output_dir,
+            thumbnail_save_mode, filename_template, output_dir,
             filtered_layers, frame_start, frame_end, thumbnail_filename
         )
         thumbnail_fullpath = output_files_by_frame.pop(

--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -179,6 +179,7 @@ class ExtractSequence(pyblish.api.Extractor):
         thumbnail_repre = {
             "name": "thumbnail",
             "ext": ext,
+            "outputName": "thumb",
             "files": os.path.basename(thumbnail_fullpath),
             "stagingDir": output_dir,
             "tags": ["thumbnail"]

--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -49,8 +49,6 @@ class ExtractSequence(pyblish.api.Extractor):
         "renderPass": "\"PNG\"",
         "renderLayer": "\"PNG\"",
     }
-    default_thumbnail_save_mode = "\"JPG\""
-    thumbnail_save_mode_for_family = {}
 
     def process(self, instance):
         self.log.info(
@@ -122,12 +120,9 @@ class ExtractSequence(pyblish.api.Extractor):
 
         thumbnail_filename = "thumbnail"
 
-        thumbnail_save_mode = self.thumbnail_save_mode_for_family.get(
-            family_lowered, self.default_thumbnail_save_mode
-        )
         # Render output
         output_files_by_frame = self.render(
-            thumbnail_save_mode, filename_template, output_dir,
+            save_mode, filename_template, output_dir,
             filtered_layers, frame_start, frame_end, thumbnail_filename
         )
         thumbnail_fullpath = output_files_by_frame.pop(
@@ -312,11 +307,11 @@ class ExtractSequence(pyblish.api.Extractor):
         if thumbnail_filename:
             basename, ext = os.path.splitext(thumbnail_filename)
             if not ext:
-                ext = ".png"
+                ext = ".jpeg"
             thumbnail_fullpath = "/".join([output_dir, basename + ext])
             all_output_files[thumbnail_filename] = thumbnail_fullpath
             # Force save mode to png for thumbnail
-            george_script_lines.append("tv_SaveMode \"PNG\"")
+            george_script_lines.append("tv_SaveMode \"JPG\"")
             # Go to frame
             george_script_lines.append("tv_layerImage {}".format(first_frame))
             # Store image to output

--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -21,6 +21,7 @@ class ExtractSequence(pyblish.api.Extractor):
         "flc": ".fli",
         "gif": ".gif",
         "ilbm": ".iff",
+        "jpg": ".jpg",
         "jpeg": ".jpg",
         "pcx": ".pcx",
         "png": ".png",
@@ -36,6 +37,7 @@ class ExtractSequence(pyblish.api.Extractor):
         "bmp",
         "dpx",
         "ilbm",
+        "jpg",
         "jpeg",
         "png",
         "sun",
@@ -307,7 +309,7 @@ class ExtractSequence(pyblish.api.Extractor):
         if thumbnail_filename:
             basename, ext = os.path.splitext(thumbnail_filename)
             if not ext:
-                ext = ".jpeg"
+                ext = ".jpg"
             thumbnail_fullpath = "/".join([output_dir, basename + ext])
             all_output_files[thumbnail_filename] = thumbnail_fullpath
             # Force save mode to png for thumbnail


### PR DESCRIPTION
## Issue
Published thumbnail from TVPaint has similar filename as sequence frames which cause issues when loading to TVPaint as the sequence start a frame earlier and containt the thumbnail as first frame (even if does not contain frame number in).

## Changes
- added `"outputName"` to thumbnail representation so published filename should be different than sequence frames

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1031|