### PR TITLE
Fix entity move under project

### DIFF
--- a/pype/modules/ftrack/events/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/events/event_sync_to_avalon.py
@@ -1679,15 +1679,15 @@ class SyncToAvalonEvent(BaseEvent):
                     self.updates[mongo_id]["data"] = {}
 
                 vis_par_id = None
+                ent_path_items = [self.cur_project["full_name"]]
                 if par_av_ent["type"].lower() != "project":
                     vis_par_id = par_av_ent["_id"]
+                    ent_path_items.extend(par_av_ent["data"]["parents"])
+                    ent_path_items.append(par_av_ent["name"])
+
                 self.updates[mongo_id]["data"]["visualParent"] = vis_par_id
                 self.moved_in_avalon.append(mongo_id)
 
-                # TODO logging
-                ent_path_items = [self.cur_project["full_name"]]
-                ent_path_items.extend(par_av_ent["data"]["parents"])
-                ent_path_items.append(par_av_ent["name"])
                 ent_path_items.append(avalon_ent["name"])
                 ent_path = "/".join(ent_path_items)
                 self.log.debug((


### PR DESCRIPTION
## Issue
- event sync to avalon can't handle moved entity under project entity when calculating parent hierachy

## Changes
- event check if parent is project

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1041|