### PR TITLE
Harmony - add regex search to filter allowed task names for collectin…

### DIFF
--- a/pype/plugins/harmony/publish/collect_palettes.py
+++ b/pype/plugins/harmony/publish/collect_palettes.py
@@ -2,6 +2,7 @@
 """Collect palettes from Harmony."""
 import os
 import json
+import re
 
 import pyblish.api
 from avalon import harmony
@@ -13,7 +14,8 @@ class CollectPalettes(pyblish.api.ContextPlugin):
     label = "Palettes"
     order = pyblish.api.CollectorOrder + 0.003
     hosts = ["harmony"]
-    allowed_tasks = []  # list of task names where collecting should happen
+    # list of regexes for task names where collecting should happen
+    allowed_tasks = []
 
     def process(self, context):
         """Collector entry point."""
@@ -25,9 +27,9 @@ class CollectPalettes(pyblish.api.ContextPlugin):
 
         # skip collecting if not in allowed task
         if self.allowed_tasks:
-            self.allowed_tasks = [task.lower() for task in self.allowed_tasks]
-            if context.data["anatomyData"]["task"].lower() \
-                    not in self.allowed_tasks:
+            task_name = context.data["anatomyData"]["task"].lower()
+            if (not any([re.search(pattern, task_name)
+                         for pattern in self.allowed_tasks])):
                 return
 
         for name, id in palettes.items():


### PR DESCRIPTION
Uses regex 'search' for filtering for allowed tasks in collecting palettes.

For '3_templates', '5_templates' pattern `[templates]` in `pype-config/presets/plugins/harmony` should be sufficient

(Original state: change of task name to not matching in presets resulted in not collecting palettes.)

3.0 variant pypeclub/pype#1048