### PR TITLE
Harmony - use regex search for filtering allowed tasks in collecting …

### DIFF
--- a/pype/hosts/harmony/plugins/publish/collect_palettes.py
+++ b/pype/hosts/harmony/plugins/publish/collect_palettes.py
@@ -2,6 +2,7 @@
 """Collect palettes from Harmony."""
 import os
 import json
+import re
 
 import pyblish.api
 from avalon import harmony
@@ -11,8 +12,10 @@ class CollectPalettes(pyblish.api.ContextPlugin):
     """Gather palettes from scene when publishing templates."""
 
     label = "Palettes"
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder + 0.003
     hosts = ["harmony"]
+    # list of regexes for task names where collecting should happen
+    allowed_tasks = []
 
     def process(self, context):
         """Collector entry point."""
@@ -21,6 +24,13 @@ class CollectPalettes(pyblish.api.ContextPlugin):
             {
                 "function": f"PypeHarmony.Publish.{self_name}.getPalettes",
             })["result"]
+
+        # skip collecting if not in allowed task
+        if self.allowed_tasks:
+            task_name = context.data["anatomyData"]["task"].lower()
+            if (not any([re.search(pattern, task_name)
+                         for pattern in self.allowed_tasks])):
+                return
 
         for name, id in palettes.items():
             instance = context.create_instance(name)


### PR DESCRIPTION
2.x variant pypeclub/pype#1047

Uses regex 'search' for filtering for allowed tasks in collecting palettes.

For '3_templates', '5_templates' pattern 'templates in pype-config/presets/plugins/harmony should be sufficient

(Original state: change of task name to not matching in presets resulted in not collecting palettes.)