### PR TITLE
Fix order of wrappers in settings gui

### DIFF
--- a/pype/tools/settings/settings/widgets/item_widgets.py
+++ b/pype/tools/settings/settings/widgets/item_widgets.py
@@ -39,6 +39,7 @@ class DictImmutableKeysWidget(BaseWidget):
 
         self.widget_mapping = {}
         self.wrapper_widgets_by_id = {}
+        self._added_wrapper_ids = set()
         self._prepare_entity_layouts(
             self.entity.gui_layout, self.content_widget
         )
@@ -72,7 +73,6 @@ class DictImmutableKeysWidget(BaseWidget):
 
             self.widget_mapping[wrapper.id] = widget
             self.wrapper_widgets_by_id[wrapper.id] = wrapper
-            self.add_widget_to_layout(wrapper)
             self._prepare_entity_layouts(child["children"], wrapper)
 
     def _ui_item_without_label(self):
@@ -151,6 +151,9 @@ class DictImmutableKeysWidget(BaseWidget):
         wrapper = self.widget_mapping[map_id]
         if wrapper is not self.content_widget:
             wrapper.add_widget_to_layout(widget, label)
+            if wrapper.id not in self._added_wrapper_ids:
+                self.add_widget_to_layout(wrapper)
+                self._added_wrapper_ids.add(wrapper.id)
             return
 
         row = self.content_layout.rowCount()

--- a/pype/tools/settings/settings/widgets/item_widgets.py
+++ b/pype/tools/settings/settings/widgets/item_widgets.py
@@ -37,7 +37,7 @@ class DictImmutableKeysWidget(BaseWidget):
                     self.entity.checkbox_key
                 )
 
-        self.widget_mapping = {}
+        self._parent_widget_by_entity_id = {}
         self._added_wrapper_ids = set()
         self._prepare_entity_layouts(
             self.entity.gui_layout, self.content_widget
@@ -56,7 +56,7 @@ class DictImmutableKeysWidget(BaseWidget):
         for child in children:
             if not isinstance(child, dict):
                 if child is not self.checkbox_child:
-                    self.widget_mapping[child.id] = widget
+                    self._parent_widget_by_entity_id[child.id] = widget
                 continue
 
             if child["type"] == "collapsible-wrap":
@@ -70,7 +70,8 @@ class DictImmutableKeysWidget(BaseWidget):
                     "Unknown Wrapper type \"{}\"".format(child["type"])
                 )
 
-            self.widget_mapping[wrapper.id] = widget
+            self._parent_widget_by_entity_id[wrapper.id] = widget
+
             self._prepare_entity_layouts(child["children"], wrapper)
 
     def _ui_item_without_label(self):
@@ -146,7 +147,7 @@ class DictImmutableKeysWidget(BaseWidget):
         else:
             map_id = widget.entity.id
 
-        wrapper = self.widget_mapping[map_id]
+        wrapper = self._parent_widget_by_entity_id[map_id]
         if wrapper is not self.content_widget:
             wrapper.add_widget_to_layout(widget, label)
             if wrapper.id not in self._added_wrapper_ids:

--- a/pype/tools/settings/settings/widgets/item_widgets.py
+++ b/pype/tools/settings/settings/widgets/item_widgets.py
@@ -38,7 +38,6 @@ class DictImmutableKeysWidget(BaseWidget):
                 )
 
         self.widget_mapping = {}
-        self.wrapper_widgets_by_id = {}
         self._added_wrapper_ids = set()
         self._prepare_entity_layouts(
             self.entity.gui_layout, self.content_widget
@@ -72,7 +71,6 @@ class DictImmutableKeysWidget(BaseWidget):
                 )
 
             self.widget_mapping[wrapper.id] = widget
-            self.wrapper_widgets_by_id[wrapper.id] = wrapper
             self._prepare_entity_layouts(child["children"], wrapper)
 
     def _ui_item_without_label(self):


### PR DESCRIPTION
## Issue
Wrappers in settings gui break order of children in schemas. Wrappers are always added to ui layout at first place.

## Changes
- wrappers are added to layout when it's first children ui is created so ordering now match schema