### PR TITLE
TVPaint frame offset

### DIFF
--- a/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/pype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -157,8 +157,8 @@ class ExtractSequence(pyblish.api.Extractor):
             "ext": ext,
             "files": repre_files,
             "stagingDir": output_dir,
-            "frameStart": frame_start,
-            "frameEnd": frame_end,
+            "frameStart": frame_start + 1,
+            "frameEnd": frame_end + 1,
             "tags": tags
         }
         self.log.debug("Creating new representation: {}".format(new_repre))


### PR DESCRIPTION
## Description
- output frame range is offset by 1 frame compared to TVPaint timeline that is probably because of TVPaint's frame indexing of bug of frame collecting

## Changes
- easies fix was to modify output frameStart and frameEnd values by one (before TVPaint's extraction will do what should do)

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1057|