### PR TITLE
Ensure "NUKE_TEMP_DIR" is not part of the Deadline job environment.

### DIFF
--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -224,11 +224,11 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         ]
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **api.Session)
-        # self.log.debug("enviro: {}".format(pprint(environment)))
+
         for path in os.environ:
             if path.lower().startswith('pype_'):
                 environment[path] = os.environ[path]
-            if path.lower().startswith('nuke_'):
+            if path.lower().startswith('nuke_') and path != "NUKE_TEMP_DIR":
                 environment[path] = os.environ[path]
             if 'license' in path.lower():
                 environment[path] = os.environ[path]


### PR DESCRIPTION
`NUKE_TEMP_DIR` is user dependent, so submitting to the farm generates errors because Nuke cant set the cache to this directory.