### PR TITLE
Optionally add task to subset name

### DIFF
--- a/pype/api.py
+++ b/pype/api.py
@@ -20,6 +20,9 @@ from pypeapp.lib.mongo import (
 from . import resources
 
 from .plugin import (
+    PypeCreatorMixin,
+    Creator,
+
     Extractor,
 
     ValidatePipelineOrder,
@@ -67,6 +70,8 @@ __all__ = [
     "resources",
 
     # plugin classes
+    "PypeCreatorMixin",
+    "Creator",
     "Extractor",
     # ordering
     "ValidatePipelineOrder",

--- a/pype/hosts/blender/plugin.py
+++ b/pype/hosts/blender/plugin.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional
 import bpy
 
 from avalon import api
+import avalon.blender
+from pype.api import PypeCreatorMixin
 
 VALID_EXTENSIONS = [".blend", ".json"]
 
@@ -98,6 +100,10 @@ def get_local_collection_with_name(name):
         if collection.name == name and collection.library is None:
             return collection
     return None
+
+
+class Creator(PypeCreatorMixin, avalon.blender.Creator):
+    pass
 
 
 class AssetLoader(api.Loader):

--- a/pype/hosts/harmony/plugin.py
+++ b/pype/hosts/harmony/plugin.py
@@ -1,0 +1,6 @@
+from avalon import harmony
+from pype.api import PypeCreatorMixin
+
+
+class Creator(PypeCreatorMixin, harmony.Creator):
+    pass

--- a/pype/hosts/houdini/plugin.py
+++ b/pype/hosts/houdini/plugin.py
@@ -1,0 +1,6 @@
+from avalon import houdini
+from pype.api import PypeCreatorMixin
+
+
+class Creator(PypeCreatorMixin, houdini.Creator):
+    pass

--- a/pype/hosts/maya/plugin.py
+++ b/pype/hosts/maya/plugin.py
@@ -1,5 +1,7 @@
 from avalon import api
 from avalon.vendor import qargparse
+import avalon.maya
+from pype.api import PypeCreatorMixin
 
 
 def get_reference_node_parents(ref):
@@ -24,6 +26,10 @@ def get_reference_node_parents(ref):
                                      referenceNode=True,
                                      parent=True)
     return parents
+
+
+class Creator(PypeCreatorMixin, avalon.maya.Creator):
+    pass
 
 
 class ReferenceLoader(api.Loader):

--- a/pype/hosts/nuke/plugin.py
+++ b/pype/hosts/nuke/plugin.py
@@ -1,9 +1,13 @@
 import re
 import avalon.api
 import avalon.nuke
-from pype.api import config
+from pype.api import (
+    config,
+    PypeCreatorMixin
+)
 
-class PypeCreator(avalon.nuke.pipeline.Creator):
+
+class PypeCreator(PypeCreatorMixin, avalon.nuke.pipeline.Creator):
     """Pype Nuke Creator class wrapper
     """
     def __init__(self, *args, **kwargs):

--- a/pype/hosts/resolve/plugin.py
+++ b/pype/hosts/resolve/plugin.py
@@ -3,6 +3,7 @@ from avalon import api
 from pype.hosts import resolve
 from avalon.vendor import qargparse
 from pype.api import config
+import pype.api
 
 from Qt import QtWidgets, QtCore
 
@@ -251,7 +252,7 @@ class SequenceLoader(api.Loader):
         pass
 
 
-class Creator(api.Creator):
+class Creator(pype.api.Creator):
     """Creator class wrapper
     """
     marker_color = "Purple"

--- a/pype/hosts/tvpaint/plugin.py
+++ b/pype/hosts/tvpaint/plugin.py
@@ -1,0 +1,6 @@
+from pype.api import PypeCreatorMixin
+from avalon.tvpaint import pipeline
+
+
+class Creator(PypeCreatorMixin, pipeline.Creator):
+    pass

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -46,7 +46,7 @@ from .path_tools import (
     get_paths_from_environ,
     get_ffmpeg_tool_path
 )
-from .
+
 from .ffmpeg_utils import ffprobe_streams
 
 from .packaging import make_workload_package

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -26,6 +26,8 @@ from .applications import (
     _subprocess
 )
 
+from .profiles_filtering import filter_profiles
+
 from .plugin_tools import (
     filter_pyblish_plugins,
     source_hash,
@@ -44,7 +46,7 @@ from .path_tools import (
     get_paths_from_environ,
     get_ffmpeg_tool_path
 )
-
+from .
 from .ffmpeg_utils import ffprobe_streams
 
 from .packaging import make_workload_package
@@ -68,6 +70,8 @@ __all__ = [
     "ApplicationLaunchFailed",
     "launch_application",
     "ApplicationAction",
+
+    "filter_profiles",
 
     "filter_pyblish_plugins",
     "get_unique_layer_name",

--- a/pype/lib/profiles_filtering.py
+++ b/pype/lib/profiles_filtering.py
@@ -1,0 +1,211 @@
+import re
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def compile_list_of_regexes(in_list):
+    """Convert strings in entered list to compiled regex objects."""
+    regexes = list()
+    if not in_list:
+        return regexes
+
+    for item in in_list:
+        if not item:
+            continue
+        try:
+            regexes.append(re.compile(item))
+        except TypeError:
+            print((
+                "Invalid type \"{}\" value \"{}\"."
+                " Expected string based object. Skipping."
+            ).format(str(type(item)), str(item)))
+    return regexes
+
+
+def _profile_exclusion(matching_profiles, logger):
+    """Find out most matching profile byt host, task and family match.
+
+    Profiles are selectively filtered. Each item in passed argument must
+    contain tuple of (profile, profile's score) where score is list of
+    booleans. Each boolean represents existence of filter for specific key.
+    Profiles are looped in sequence. In each sequence are profiles split into
+    true_list and false_list. For next sequence loop are used profiles in
+    true_list if there are any profiles else false_list is used.
+
+    Filtering ends when only one profile left in true_list. Or when all
+    existence booleans loops passed, in that case first profile from remainded
+    profiles is returned.
+
+    Args:
+        matching_profiles (list): Profiles with same scores. Each item is tuple
+            with (profile, profile values)
+
+    Returns:
+        dict: Most matching profile.
+    """
+
+    logger.info(
+        "Search for first most matching profile in match order:"
+        " Host name -> Task name -> Family."
+    )
+
+    if not matching_profiles:
+        return None
+
+    if len(matching_profiles) == 1:
+        return matching_profiles[0][0]
+
+    scores_len = len(matching_profiles[0][1])
+    for idx in range(scores_len):
+        profiles_true = []
+        profiles_false = []
+        for profile, score in matching_profiles:
+            if score[idx]:
+                profiles_true.append((profile, score))
+            else:
+                profiles_false.append((profile, score))
+
+        if profiles_true:
+            matching_profiles = profiles_true
+        else:
+            matching_profiles = profiles_false
+
+        if len(matching_profiles) == 1:
+            return matching_profiles[0][0]
+
+    return matching_profiles[0][0]
+
+
+def validate_value_by_regexes(value, in_list):
+    """Validates in any regex from list match entered value.
+
+    Args:
+        value (str): String where regexes is checked.
+        in_list (list): List with regexes.
+
+    Returns:
+        int: Returns `0` when list is not set, is empty or contain "*".
+            Returns `1` when any regex match value and returns `-1`
+            when none of regexes match entered value.
+    """
+    if not in_list:
+        return 0
+
+    if not isinstance(in_list, (list, tuple, set)):
+        in_list = [in_list]
+
+    if "*" in in_list:
+        return 0
+
+    # If value is not set and in list has specific values then resolve value
+    #   as not matching.
+    if not value:
+        return -1
+
+    regexes = compile_list_of_regexes(in_list)
+    for regex in regexes:
+        if re.match(regex, value):
+            return 1
+    return -1
+
+
+def filter_profiles(profiles_data, key_values, keys_order=None, logger=None):
+    """ Filter profiles by entered key -> values.
+
+    Profile if marked with score for each key/value from `key_values` with
+    points -1, 0 or 1.
+    - if profile contain the key and profile's value contain value from
+        `key_values` then profile gets 1 point
+    - if profile does not contain the key or profile's value is empty or
+        contain "*" then got 0 point
+    - if profile contain the key, profile's value is not empty and does not
+        contain "*" and value from `key_values` is not available in the value
+        then got -1 point
+
+    If profile gets -1 point at any time then is skipped and not used for
+    output. Profile with higher score is returned. If there are multiple
+    profiles with same score then first in order is used (order of profiles
+    matter).
+
+    Args:
+        profiles_data (list): Profile definitions as dictionaries.
+        key_values (dict): Mapping of Key <-> Value. Key is checked if is
+            available in profile and if Value is matching it's values.
+        keys_order (list, tuple): Order of keys from `key_values` which matters
+            only when multiple profiles have same score.
+        logger (logging.Logger): Optionally can be passed different logger.
+
+    Returns:
+        dict/None: Return most matching profile or None if none of profiles
+            match at least one criteria.
+    """
+    if not profiles_data:
+        return None
+
+    if not logger:
+        logger = log
+
+    if not keys_order:
+        keys_order = tuple(key_values.keys())
+    else:
+        _keys_order = list(keys_order)
+        # Make all keys from `key_values` are passed
+        for key in key_values.keys():
+            if key not in _keys_order:
+                _keys_order.append(key)
+        keys_order = tuple(_keys_order)
+
+    matching_profiles = None
+    highest_profile_points = -1
+    # Each profile get 1 point for each matching filter. Profile with most
+    # points is returned. For cases when more than one profile will match
+    # are also stored ordered lists of matching values.
+    for profile in profiles_data:
+        profile_points = 0
+        profile_scores = []
+
+        for key in keys_order:
+            value = key_values[key]
+            match = validate_value_by_regexes(value, profile.get(key))
+            if match == -1:
+                profile_value = profile.get(key) or []
+                logger.debug(
+                    "\"{}\" not found in {}".format(key, profile_value)
+                )
+                profile_points = -1
+                break
+
+            profile_points += match
+            profile_scores.append(bool(match))
+
+        if (
+            profile_points < 0
+            or profile_points < highest_profile_points
+        ):
+            continue
+
+        if profile_points > highest_profile_points:
+            matching_profiles = []
+            highest_profile_points = profile_points
+
+        if profile_points == highest_profile_points:
+            matching_profiles.append((profile, profile_scores))
+
+    log_parts = " | ".join([
+        "{}: \"{}\"".format(*item)
+        for item in key_values.items()
+    ])
+
+    if not matching_profiles:
+        logger.warning(
+            "None of profiles match your setup. {}".format(log_parts)
+        )
+        return None
+
+    if len(matching_profiles) > 1:
+        logger.warning(
+            "More than one profile match your setup. {}".format(log_parts)
+        )
+
+    return _profile_exclusion(matching_profiles, logger)

--- a/pype/plugin.py
+++ b/pype/plugin.py
@@ -70,7 +70,7 @@ class PypeCreatorMixin:
             config.get_presets(project_name)
             .get("tools", {})
             .get("creator_subset_name_profiles")
-        ) or {}
+        ) or []
         filtering_criteria = {
             "families": family,
             "hosts": host_name,

--- a/pype/plugin.py
+++ b/pype/plugin.py
@@ -1,9 +1,10 @@
-import tempfile
 import os
-import pyblish.api
-
-from pype.api import config
 import inspect
+import tempfile
+import pyblish.api
+import avalon.api
+from pype.api import config
+from pype.lib import filter_profiles
 
 ValidatePipelineOrder = pyblish.api.ValidatorOrder + 0.05
 ValidateContentsOrder = pyblish.api.ValidatorOrder + 0.1
@@ -35,6 +36,92 @@ def imprint_attributes(plugin):
         else:
             setattr(plugin, option, value)
             print("setting {}: {} on {}".format(option, value, plugin_name))
+
+
+class TaskNotSetError(KeyError):
+    def __init__(self, msg=None):
+        if not msg:
+            msg = "Creator's subset name template requires task name."
+        super(TaskNotSetError, self).__init__(msg)
+
+
+class PypeCreatorMixin:
+    """Helper to override avalon's default class methods.
+
+    Mixin class must be used as first in inheritance order to override methods.
+    """
+    default_tempate = "{family}{Variant}"
+
+    @classmethod
+    def get_subset_name(
+        cls, variant, task_name, asset_id, project_name, host_name=None
+    ):
+        if not cls.family:
+            return ""
+
+        if not host_name:
+            host_name = os.environ["AVALON_APP"]
+
+        # Use only last part of class family value split by dot (`.`)
+        family = cls.family.rsplit(".", 1)[-1]
+
+        # Get settings
+        profiles = (
+            config.get_presets(project_name)
+            .get("tools", {})
+            .get("creator_subset_name_profiles")
+        ) or {}
+        filtering_criteria = {
+            "families": family,
+            "hosts": host_name,
+            "tasks": task_name
+        }
+
+        matching_profile = filter_profiles(profiles, filtering_criteria)
+        template = None
+        if matching_profile:
+            template = matching_profile["template"]
+
+        # Make sure template is set (matching may have empty string)
+        if not template:
+            template = cls.default_tempate
+
+        # Simple check of task name existence for template with {task} in
+        #   - missing task should be possible only in Standalone publisher
+        if not task_name and "{task" in template.lower():
+            raise TaskNotSetError()
+
+        fill_pairs = (
+            ("variant", variant),
+            ("family", family),
+            ("task", task_name)
+        )
+        fill_data = {}
+        for key, value in fill_pairs:
+            # Handle cases when value is `None` (standalone publisher)
+            if value is None:
+                continue
+            # Keep value as it is
+            fill_data[key] = value
+            # Both key and value are with upper case
+            fill_data[key.upper()] = value.upper()
+
+            # Capitalize only first char of value
+            # - conditions are because of possible index errors
+            capitalized = ""
+            if value:
+                # Upper first character
+                capitalized += value[0].upper()
+                # Append rest of string if there is any
+                if len(value) > 1:
+                    capitalized += value[1:]
+            fill_data[key.capitalize()] = capitalized
+
+        return template.format(**fill_data)
+
+
+class Creator(PypeCreatorMixin, avalon.api.Creator):
+    pass
 
 
 class ContextPlugin(pyblish.api.ContextPlugin):

--- a/pype/plugins/aftereffects/create/create_render.py
+++ b/pype/plugins/aftereffects/create/create_render.py
@@ -1,4 +1,4 @@
-from avalon import api
+import pype.api
 from avalon.vendor import Qt
 from avalon import aftereffects
 
@@ -7,7 +7,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class CreateRender(api.Creator):
+class CreateRender(pype.api.Creator):
     """Render folder for publish."""
 
     name = "renderDefault"

--- a/pype/plugins/blender/create/create_action.py
+++ b/pype/plugins/blender/create/create_action.py
@@ -3,11 +3,11 @@
 import bpy
 
 from avalon import api
-from avalon.blender import Creator, lib
+from avalon.blender import lib
 import pype.hosts.blender.plugin
 
 
-class CreateAction(Creator):
+class CreateAction(pype.hosts.blender.plugin.Creator):
     """Action output for character rigs"""
 
     name = "actionMain"

--- a/pype/plugins/blender/create/create_animation.py
+++ b/pype/plugins/blender/create/create_animation.py
@@ -6,7 +6,7 @@ from avalon import api, blender
 import pype.hosts.blender.plugin
 
 
-class CreateAnimation(blender.Creator):
+class CreateAnimation(pype.hosts.blender.plugin.Creator):
     """Animation output for character rigs"""
 
     name = "animationMain"

--- a/pype/plugins/blender/create/create_camera.py
+++ b/pype/plugins/blender/create/create_camera.py
@@ -3,11 +3,11 @@
 import bpy
 
 from avalon import api
-from avalon.blender import Creator, lib
+from avalon.blender import lib
 import pype.hosts.blender.plugin
 
 
-class CreateCamera(Creator):
+class CreateCamera(pype.hosts.blender.plugin.Creator):
     """Polygonal static geometry"""
 
     name = "cameraMain"

--- a/pype/plugins/blender/create/create_layout.py
+++ b/pype/plugins/blender/create/create_layout.py
@@ -3,11 +3,11 @@
 import bpy
 
 from avalon import api
-from avalon.blender import Creator, lib
+from avalon.blender import lib
 import pype.hosts.blender.plugin
 
 
-class CreateLayout(Creator):
+class CreateLayout(pype.hosts.blender.plugin.Creator):
     """Layout output for character rigs"""
 
     name = "layoutMain"

--- a/pype/plugins/blender/create/create_model.py
+++ b/pype/plugins/blender/create/create_model.py
@@ -3,11 +3,11 @@
 import bpy
 
 from avalon import api
-from avalon.blender import Creator, lib
+from avalon.blender import lib
 import pype.hosts.blender.plugin
 
 
-class CreateModel(Creator):
+class CreateModel(pype.hosts.blender.plugin.Creator):
     """Polygonal static geometry"""
 
     name = "modelMain"

--- a/pype/plugins/blender/create/create_rig.py
+++ b/pype/plugins/blender/create/create_rig.py
@@ -3,11 +3,11 @@
 import bpy
 
 from avalon import api
-from avalon.blender import Creator, lib
+from avalon.blender import lib
 import pype.hosts.blender.plugin
 
 
-class CreateRig(Creator):
+class CreateRig(pype.hosts.blender.plugin.Creator):
     """Artist-friendly rig with controls to direct motion"""
 
     name = "rigMain"

--- a/pype/plugins/blender/create/create_setdress.py
+++ b/pype/plugins/blender/create/create_setdress.py
@@ -3,7 +3,8 @@ import bpy
 from avalon import api, blender
 import pype.hosts.blender.plugin
 
-class CreateSetDress(blender.Creator):
+
+class CreateSetDress(pype.hosts.blender.plugin.Creator):
     """A grouped package of loaded content"""
 
     name = "setdressMain"

--- a/pype/plugins/harmony/create/create_farm_render.py
+++ b/pype/plugins/harmony/create/create_farm_render.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Create Composite node for render on farm."""
 from avalon import harmony
+from pype.hosts.harmony.api import plugin
 
 
-class CreateFarmRender(harmony.Creator):
+class CreateFarmRender(plugin.Creator):
     """Composite node for publishing renders."""
 
     name = "renderDefault"

--- a/pype/plugins/harmony/create/create_render.py
+++ b/pype/plugins/harmony/create/create_render.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Create render node."""
 from avalon import harmony
+from pype.hosts.harmony.api import plugin
 
 
-class CreateRender(harmony.Creator):
+class CreateRender(plugin.Creator):
     """Composite node for publishing renders."""
 
     name = "renderDefault"

--- a/pype/plugins/harmony/create/create_template.py
+++ b/pype/plugins/harmony/create/create_template.py
@@ -1,7 +1,8 @@
 from avalon import harmony
+from pype.hosts.harmony.api import plugin
 
 
-class CreateTemplate(harmony.Creator):
+class CreateTemplate(plugin.Creator):
     """Composite node for publishing to templates."""
 
     name = "templateDefault"

--- a/pype/plugins/houdini/create/create_alembic_camera.py
+++ b/pype/plugins/houdini/create/create_alembic_camera.py
@@ -1,7 +1,7 @@
-from avalon import houdini
+from pype.hosts.houdini import plugin
 
 
-class CreateAlembicCamera(houdini.Creator):
+class CreateAlembicCamera(plugin.Creator):
     """Single baked camera from Alembic ROP"""
 
     name = "camera"

--- a/pype/plugins/houdini/create/create_pointcache.py
+++ b/pype/plugins/houdini/create/create_pointcache.py
@@ -1,7 +1,7 @@
-from avalon import houdini
+from pype.hosts.houdini import plugin
 
 
-class CreatePointCache(houdini.Creator):
+class CreatePointCache(plugin.Creator):
     """Alembic ROP to pointcache"""
 
     name = "pointcache"

--- a/pype/plugins/houdini/create/create_vbd_cache.py
+++ b/pype/plugins/houdini/create/create_vbd_cache.py
@@ -1,7 +1,7 @@
-from avalon import houdini
+from pype.hosts.houdini import plugin
 
 
-class CreateVDBCache(houdini.Creator):
+class CreateVDBCache(plugin.Creator):
     """OpenVDB from Geometry ROP"""
 
     name = "vbdcache"

--- a/pype/plugins/maya/create/create_animation.py
+++ b/pype/plugins/maya/create/create_animation.py
@@ -1,8 +1,10 @@
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateAnimation(avalon.maya.Creator):
+class CreateAnimation(plugin.Creator):
     """Animation output for character rigs"""
 
     name = "animationDefault"

--- a/pype/plugins/maya/create/create_ass.py
+++ b/pype/plugins/maya/create/create_ass.py
@@ -1,12 +1,14 @@
 from collections import OrderedDict
 
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 from maya import cmds
 
 
-class CreateAss(avalon.maya.Creator):
+class CreateAss(plugin.Creator):
     """Arnold Archive"""
 
     name = "ass"

--- a/pype/plugins/maya/create/create_assembly.py
+++ b/pype/plugins/maya/create/create_assembly.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateAssembly(avalon.maya.Creator):
+class CreateAssembly(plugin.Creator):
     """A grouped package of loaded content"""
 
     name = "assembly"

--- a/pype/plugins/maya/create/create_camera.py
+++ b/pype/plugins/maya/create/create_camera.py
@@ -1,8 +1,10 @@
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateCamera(avalon.maya.Creator):
+class CreateCamera(plugin.Creator):
     """Single baked camera"""
 
     name = "cameraMain"

--- a/pype/plugins/maya/create/create_layout.py
+++ b/pype/plugins/maya/create/create_layout.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateLayout(avalon.maya.Creator):
+class CreateLayout(plugin.Creator):
     """A grouped package of loaded content"""
 
     name = "layoutMain"

--- a/pype/plugins/maya/create/create_look.py
+++ b/pype/plugins/maya/create/create_look.py
@@ -1,8 +1,10 @@
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateLook(avalon.maya.Creator):
+class CreateLook(plugin.Creator):
     """Shader connections defining shape look"""
 
     name = "look"

--- a/pype/plugins/maya/create/create_mayaascii.py
+++ b/pype/plugins/maya/create/create_mayaascii.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateMayaAscii(avalon.maya.Creator):
+class CreateMayaAscii(plugin.Creator):
     """Raw Maya Ascii file export"""
 
     name = "mayaAscii"

--- a/pype/plugins/maya/create/create_model.py
+++ b/pype/plugins/maya/create/create_model.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateModel(avalon.maya.Creator):
+class CreateModel(plugin.Creator):
     """Polygonal static geometry"""
 
     name = "modelMain"

--- a/pype/plugins/maya/create/create_pointcache.py
+++ b/pype/plugins/maya/create/create_pointcache.py
@@ -1,8 +1,10 @@
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreatePointCache(avalon.maya.Creator):
+class CreatePointCache(plugin.Creator):
     """Alembic pointcache for animated data"""
 
     name = "pointcache"

--- a/pype/plugins/maya/create/create_render.py
+++ b/pype/plugins/maya/create/create_render.py
@@ -8,11 +8,13 @@ import requests
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup
 
-from pype.hosts.maya import lib
-import avalon.maya
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateRender(avalon.maya.Creator):
+class CreateRender(plugin.Creator):
     """Create *render* instance.
 
     Render instances are not actually published, they hold options for

--- a/pype/plugins/maya/create/create_rendersetup.py
+++ b/pype/plugins/maya/create/create_rendersetup.py
@@ -1,9 +1,11 @@
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 from maya import cmds
 
 
-class CreateRenderSetup(avalon.maya.Creator):
+class CreateRenderSetup(plugin.Creator):
     """Create rendersetup template json data"""
 
     name = "rendersetup"

--- a/pype/plugins/maya/create/create_review.py
+++ b/pype/plugins/maya/create/create_review.py
@@ -1,9 +1,11 @@
 from collections import OrderedDict
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateReview(avalon.maya.Creator):
+class CreateReview(plugin.Creator):
     """Single baked camera"""
 
     name = "reviewDefault"

--- a/pype/plugins/maya/create/create_rig.py
+++ b/pype/plugins/maya/create/create_rig.py
@@ -1,10 +1,12 @@
 from maya import cmds
 
-from pype.hosts.maya import lib
-import avalon.maya
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateRig(avalon.maya.Creator):
+class CreateRig(plugin.Creator):
     """Artist-friendly rig with controls to direct motion"""
 
     name = "rigDefault"

--- a/pype/plugins/maya/create/create_setdress.py
+++ b/pype/plugins/maya/create/create_setdress.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateSetDress(avalon.maya.Creator):
+class CreateSetDress(plugin.Creator):
     """A grouped package of loaded content"""
 
     name = "setdressMain"

--- a/pype/plugins/maya/create/create_unreal_staticmesh.py
+++ b/pype/plugins/maya/create/create_unreal_staticmesh.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateUnrealStaticMesh(avalon.maya.Creator):
+class CreateUnrealStaticMesh(plugin.Creator):
     name = "staticMeshMain"
     label = "Unreal - Static Mesh"
     family = "unrealStaticMesh"

--- a/pype/plugins/maya/create/create_vrayproxy.py
+++ b/pype/plugins/maya/create/create_vrayproxy.py
@@ -1,7 +1,7 @@
-import avalon.maya
+from pype.hosts.maya import plugin
 
 
-class CreateVrayProxy(avalon.maya.Creator):
+class CreateVrayProxy(plugin.Creator):
     """Alembic pointcache for animated data"""
 
     name = "vrayproxy"

--- a/pype/plugins/maya/create/create_vrayscene.py
+++ b/pype/plugins/maya/create/create_vrayscene.py
@@ -8,11 +8,13 @@ import requests
 from maya import cmds
 import maya.app.renderSetup.model.renderSetup as renderSetup
 
-from pype.hosts.maya import lib
-import avalon.maya
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateVRayScene(avalon.maya.Creator):
+class CreateVRayScene(plugin.Creator):
     """Create Vray Scene."""
 
     label = "VRay Scene"

--- a/pype/plugins/maya/create/create_yeti_cache.py
+++ b/pype/plugins/maya/create/create_yeti_cache.py
@@ -1,10 +1,12 @@
 from collections import OrderedDict
 
-import avalon.maya
-from pype.hosts.maya import lib
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateYetiCache(avalon.maya.Creator):
+class CreateYetiCache(plugin.Creator):
     """Output for procedural plugin nodes of Yeti """
 
     name = "yetiDefault"

--- a/pype/plugins/maya/create/create_yeti_rig.py
+++ b/pype/plugins/maya/create/create_yeti_rig.py
@@ -1,10 +1,12 @@
 from maya import cmds
 
-from pype.hosts.maya import lib
-import avalon.maya
+from pype.hosts.maya import (
+    lib,
+    plugin
+)
 
 
-class CreateYetiRig(avalon.maya.Creator):
+class CreateYetiRig(plugin.Creator):
     """Output for procedural plugin nodes ( Yeti / XGen / etc)"""
 
     label = "Yeti Rig"

--- a/pype/plugins/nuke/create/create_backdrop.py
+++ b/pype/plugins/nuke/create/create_backdrop.py
@@ -1,9 +1,9 @@
-import avalon.nuke
 from avalon.nuke import lib as anlib
+from pype.hosts.nuke import plugin
 import nuke
 
 
-class CreateBackdrop(avalon.nuke.Creator):
+class CreateBackdrop(plugin.Creator):
     """Add Publishable Backdrop"""
 
     name = "nukenodes"

--- a/pype/plugins/nuke/create/create_camera.py
+++ b/pype/plugins/nuke/create/create_camera.py
@@ -1,9 +1,9 @@
-import avalon.nuke
 from avalon.nuke import lib as anlib
+from pype.hosts.nuke import plugin
 import nuke
 
 
-class CreateCamera(avalon.nuke.Creator):
+class CreateCamera(plugin.Creator):
     """Add Publishable Backdrop"""
 
     name = "camera"

--- a/pype/plugins/nuke/create/create_gizmo.py
+++ b/pype/plugins/nuke/create/create_gizmo.py
@@ -1,9 +1,9 @@
-import avalon.nuke
 from avalon.nuke import lib as anlib
+from pype.hosts.nuke import plugin
 import nuke
 
 
-class CreateGizmo(avalon.nuke.Creator):
+class CreateGizmo(plugin.Creator):
     """Add Publishable "gizmo" group
 
     The name is symbolically gizmo as presumably

--- a/pype/plugins/nuke/create/create_read.py
+++ b/pype/plugins/nuke/create/create_read.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-import avalon.api
 import avalon.nuke
 from pype import api as pype
+from pype.hosts.nuke import plugin
 
 import nuke
 
 
-class CrateRead(avalon.nuke.Creator):
+class CrateRead(plugin.Creator):
     # change this to template preset
     name = "ReadCopy"
     label = "Create Read Copy"

--- a/pype/plugins/photoshop/create/create_image.py
+++ b/pype/plugins/photoshop/create/create_image.py
@@ -1,9 +1,9 @@
-from avalon import api
+import pype.api
 from avalon.vendor import Qt
 from avalon import photoshop
 
 
-class CreateImage(api.Creator):
+class CreateImage(pype.api.Creator):
     """Image folder for publish."""
 
     name = "imageDefault"

--- a/pype/plugins/tvpaint/create/create_render_layer.py
+++ b/pype/plugins/tvpaint/create/create_render_layer.py
@@ -1,7 +1,8 @@
 from avalon.tvpaint import pipeline, lib
+from pype.hosts.tvpaint.api import plugin
 
 
-class CreateRenderlayer(pipeline.Creator):
+class CreateRenderlayer(plugin.Creator):
     """Mark layer group as one instance."""
     name = "render_layer"
     label = "RenderLayer"

--- a/pype/plugins/tvpaint/create/create_render_pass.py
+++ b/pype/plugins/tvpaint/create/create_render_pass.py
@@ -1,7 +1,8 @@
 from avalon.tvpaint import pipeline, lib
+from pype.hosts.tvpaint.api import plugin
 
 
-class CreateRenderPass(pipeline.Creator):
+class CreateRenderPass(plugin.Creator):
     """Render pass is combination of one or more layers from same group.
 
     Requirement to create Render Pass is to have already created beauty

--- a/pype/plugins/tvpaint/create/create_review.py
+++ b/pype/plugins/tvpaint/create/create_review.py
@@ -1,7 +1,8 @@
 from avalon.tvpaint import pipeline
+from pype.hosts.tvpaint.api import plugin
 
 
-class CreateReview(pipeline.Creator):
+class CreateReview(plugin.Creator):
     """Review for global review of all layers."""
     name = "review"
     label = "Review"

--- a/pype/tools/standalonepublish/__init__.py
+++ b/pype/tools/standalonepublish/__init__.py
@@ -1,8 +1,6 @@
 from .app import (
-    show,
-    cli
+    Window
 )
 __all__ = [
-    "show",
-    "cli"
+    "Window"
 ]

--- a/pype/tools/standalonepublish/__main__.py
+++ b/pype/tools/standalonepublish/__main__.py
@@ -1,14 +1,16 @@
 import os
 import sys
-import app
 import ctypes
 import signal
+import app
 from Qt import QtWidgets, QtGui
 from avalon import style
 from pype.api import resources
+from pype.tools.standalonepublish.widgets.constants import HOST_NAME
 
 
 if __name__ == "__main__":
+    os.environ["AVALON_APP"] = HOST_NAME
 
     # Allow to change icon of running process in windows taskbar
     if os.name == "nt":

--- a/pype/tools/standalonepublish/app.py
+++ b/pype/tools/standalonepublish/app.py
@@ -62,6 +62,8 @@ class Window(QtWidgets.QDialog):
 
         # signals
         widget_assets.selection_changed.connect(self.on_asset_changed)
+        widget_assets.task_changed.connect(self._on_task_change)
+        widget_assets.project_changed.connect(self.on_project_change)
         widget_family.stateChanged.connect(self.set_valid_family)
 
         self.widget_assets = widget_assets
@@ -116,6 +118,9 @@ class Window(QtWidgets.QDialog):
             parents.append(parent['name'])
         return parents
 
+    def on_project_change(self, project_name):
+        self.widget_family.refresh()
+
     def on_asset_changed(self):
         '''Callback on asset selection changed
 
@@ -134,6 +139,9 @@ class Window(QtWidgets.QDialog):
             self.valid_parent = False
             self.widget_family.change_asset(None)
         self.widget_family.on_data_changed()
+
+    def _on_task_change(self):
+        self.widget_family.on_task_change()
 
     def keyPressEvent(self, event):
         ''' Handling Ctrl+V KeyPress event

--- a/pype/tools/standalonepublish/widgets/constants.py
+++ b/pype/tools/standalonepublish/widgets/constants.py
@@ -1,0 +1,1 @@
+HOST_NAME = "standalonepublisher"

--- a/pype/tools/standalonepublish/widgets/widget_components.py
+++ b/pype/tools/standalonepublish/widgets/widget_components.py
@@ -7,6 +7,7 @@ import string
 
 from Qt import QtWidgets, QtCore
 from . import DropDataFrame
+from .constants import HOST_NAME
 from avalon import io
 from pype.api import execute, Logger
 
@@ -177,8 +178,8 @@ def set_context(project, asset, task):
 
     io.Session["current_dir"] = os.path.normpath(os.getcwd())
 
-    os.environ["AVALON_APP"] = "standalonepublish"
-    io.Session["AVALON_APP"] = "standalonepublish"
+    os.environ["AVALON_APP"] = HOST_NAME
+    io.Session["AVALON_APP"] = HOST_NAME
 
     io.uninstall()
 

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from Qt import QtWidgets, QtCore

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -1,10 +1,16 @@
-from collections import namedtuple
+import os
+import re
 
 from Qt import QtWidgets, QtCore
 from . import HelpRole, FamilyRole, ExistsRole, PluginRole, PluginKeyRole
 from . import FamilyDescriptionWidget
 
-from pype.api import config
+from pype.api import (
+    config,
+    Creator
+)
+from pype.plugin import TaskNotSetError
+from avalon.tools.creator.app import SubsetAllowedSymbols
 
 
 class FamilyWidget(QtWidgets.QWidget):
@@ -122,6 +128,9 @@ class FamilyWidget(QtWidgets.QWidget):
         }
         return data
 
+    def on_task_change(self):
+        self.on_data_changed()
+
     def change_asset(self, name):
         if name is None:
             name = self.NOT_SELECTED
@@ -167,65 +176,113 @@ class FamilyWidget(QtWidgets.QWidget):
 
     def _on_data_changed(self):
         asset_name = self.asset_name
-        subset_name = self.input_subset.text()
+        user_input_text = self.input_subset.text()
         item = self.list_families.currentItem()
 
         if item is None:
             return
 
-        assets = None
+        asset_doc = None
         if asset_name != self.NOT_SELECTED:
             # Get the assets from the database which match with the name
-            assets_db = self.dbcon.find(
-                filter={"type": "asset"},
-                projection={"name": 1}
+            asset_doc = self.dbcon.find_one(
+                {
+                    "type": "asset",
+                    "name": asset_name
+                },
+                {"_id": 1}
             )
-            assets = [
-                asset for asset in assets_db if asset_name in asset["name"]
-            ]
 
         # Get plugin and family
         plugin = item.data(PluginRole)
-        if plugin is None:
+
+        # Early exit if no asset name
+        if not asset_name.strip():
+            self._build_menu([])
+            item.setData(ExistsRole, False)
+            print("Asset name is required ..")
+            self.stateChanged.emit(False)
             return
 
-        family = plugin.family.rsplit(".", 1)[-1]
+        # Get the asset from the database which match with the name
+        asset_doc = self.dbcon.find_one(
+            {"name": asset_name, "type": "asset"},
+            projection={"_id": 1}
+        )
+        # Get plugin
+        plugin = item.data(PluginRole)
+        if asset_doc and plugin:
+            project_name = self.dbcon.Session["AVALON_PROJECT"]
+            asset_id = asset_doc["_id"]
+            task_name = self.dbcon.Session["AVALON_TASK"]
 
-        # Update the result
-        if subset_name:
-            subset_name = subset_name[0].upper() + subset_name[1:]
-        self.input_result.setText("{}{}".format(family, subset_name))
+            # Calculate subset name with Creator plugin
+            try:
+                subset_name = plugin.get_subset_name(
+                    user_input_text, task_name, asset_id, project_name
+                )
+                # Force replacement of prohibited symbols
+                # QUESTION should Creator care about this and here should be
+                #   only validated with schema regex?
+                subset_name = re.sub(
+                    "[^{}]+".format(SubsetAllowedSymbols),
+                    "",
+                    subset_name
+                )
+                self.input_result.setText(subset_name)
 
-        if assets:
+            except TaskNotSetError:
+                subset_name = ""
+                self.input_result.setText("Select task please")
+
             # Get all subsets of the current asset
-            asset_ids = [asset["_id"] for asset in assets]
-            subsets = self.dbcon.find(filter={"type": "subset",
-                                      "name": {"$regex": "{}*".format(family),
-                                               "$options": "i"},
-                                      "parent": {"$in": asset_ids}}) or []
+            subset_docs = self.dbcon.find(
+                {
+                    "type": "subset",
+                    "parent": asset_id
+                },
+                {"name": 1}
+            )
+            existing_subset_names = set(subset_docs.distinct("name"))
 
-            # Get all subsets' their subset name, "Default", "High", "Low"
-            existed_subsets = [sub["name"].split(family)[-1]
-                               for sub in subsets]
+            # Defaults to dropdown
+            defaults = []
+            # Check if Creator plugin has set defaults
+            if (
+                plugin.defaults
+                and isinstance(plugin.defaults, (list, tuple, set))
+            ):
+                defaults = list(plugin.defaults)
 
-            if plugin.defaults and isinstance(plugin.defaults, list):
-                defaults = plugin.defaults[:] + [self.Separator]
-                lowered = [d.lower() for d in plugin.defaults]
-                for sub in [s for s in existed_subsets
-                            if s.lower() not in lowered]:
-                    defaults.append(sub)
-            else:
-                defaults = existed_subsets
+            # Replace
+            compare_regex = re.compile(
+                subset_name.replace(user_input_text, "(.+)")
+            )
+            subset_hints = set()
+            if user_input_text:
+                for _name in existing_subset_names:
+                    _result = compare_regex.search(_name)
+                    if _result:
+                        subset_hints |= set(_result.groups())
 
+            subset_hints = subset_hints - set(defaults)
+            if subset_hints:
+                if defaults:
+                    defaults.append(self.Separator)
+                defaults.extend(subset_hints)
             self._build_menu(defaults)
 
             item.setData(ExistsRole, True)
+
         else:
+            subset_name = user_input_text
             self._build_menu([])
             item.setData(ExistsRole, False)
-            if asset_name != self.NOT_SELECTED:
-                # TODO add logging into standalone_publish
-                print("'%s' not found .." % asset_name)
+
+            if not plugin:
+                print("No registered families ..")
+            else:
+                print("Asset '%s' not found .." % asset_name)
 
         self.on_version_refresh()
 
@@ -248,30 +305,46 @@ class FamilyWidget(QtWidgets.QWidget):
         subset_name = self.input_result.text()
         version = 1
 
+        asset_doc = None
+        subset_doc = None
+        versions = None
         if (
             asset_name != self.NOT_SELECTED and
             subset_name.strip() != ''
         ):
-            asset = self.dbcon.find_one({
-                'type': 'asset',
-                'name': asset_name
-            })
-            subset = self.dbcon.find_one({
-                'type': 'subset',
-                'parent': asset['_id'],
-                'name': subset_name
-            })
-            if subset:
-                versions = self.dbcon.find({
+            asset_doc = self.dbcon.find_one(
+                {
+                    'type': 'asset',
+                    'name': asset_name
+                },
+                {"_id": 1}
+            )
+
+        if asset_doc:
+            subset_doc = self.dbcon.find_one(
+                {
+                    'type': 'subset',
+                    'parent': asset_doc['_id'],
+                    'name': subset_name
+                },
+                {"_id": 1}
+            )
+
+        if subset_doc:
+            versions = self.dbcon.find(
+                {
                     'type': 'version',
-                    'parent': subset['_id']
-                })
-                if versions:
-                    versions = sorted(
-                        [v for v in versions],
-                        key=lambda ver: ver['name']
-                    )
-                    version = int(versions[-1]['name']) + 1
+                    'parent': subset_doc['_id']
+                },
+                {"name": 1}
+            ).distinct("name")
+
+        if versions:
+            versions = sorted(
+                [v for v in versions],
+                key=lambda ver: ver['name']
+            )
+            version = int(versions[-1]['name']) + 1
 
         self.version_spinbox.setValue(version)
 
@@ -284,7 +357,10 @@ class FamilyWidget(QtWidgets.QWidget):
         self.schedule(self._on_data_changed, 500, channel="gui")
 
     def on_selection_changed(self, *args):
-        plugin = self.list_families.currentItem().data(PluginRole)
+        item = self.list_families.currentItem()
+        if not item:
+            return
+        plugin = item.data(PluginRole)
         if plugin is None:
             return
 
@@ -308,11 +384,20 @@ class FamilyWidget(QtWidgets.QWidget):
         """
 
     def refresh(self):
-        has_families = False
-        presets = config.get_presets().get('standalone_publish', {})
+        self.list_families.clear()
 
-        for key, creator in presets.get('families', {}).items():
-            creator = namedtuple("Creator", creator.keys())(*creator.values())
+        has_families = False
+        project_name = self.dbcon.Session.get("AVALON_PROJECT")
+        if not project_name:
+            return
+
+        creators_data = (
+            config.get_presets(project_name)
+            .get("standalone_publish", {})
+            .get("families", {})
+        )
+        for key, creator_data in creators_data.items():
+            creator = type(key, (Creator, ), creator_data)
 
             label = creator.label or creator.family
             item = QtWidgets.QListWidgetItem(label)


### PR DESCRIPTION
## Changes
- added ability to change template of subset name for specific creators by settings
- templates are resolved by profiled filtering similar to ExtractReview profiles
    - available filtering keys are `families`, `hosts` and `task names`
- result is template with formattable keys `family`, `task` and `user_input`
    - Example template `"{family}{user_input}"`

## Code changes
### avalon-core
- subset template for creator api is defined by `Creator` class with method `get_subset_name`
- this approach is used in Creator tool

### pype
- in pype is defined `PypeCreatorMixin` which should be used as main inherit class (mixin overrides `get_subset_name`)
    - this is because we have to propagate only this method to all creator plugins in pype but they may already inherit from avalon's host creator
    - added Creator class for each pype host if is using avalon host Creator
- modified standalone publisher to be able use this feature and modified to care about tasks
- added profile filtering function to pype.lib
- filter for creators are in project settings under Creator tool
    - has defaults that should work the same way as before

### pype-config
- added defaults

## Test
- [x] check creator tool in blender
- [ ] check creator tool in harmony
- [x] check creator tool in maya
- [x] check creator tool in nuke
- [x] check creator tool in photoshop
- [x] check creator tool in aftereffects
- [ ] check creator tool in houdini
- [ ] check creator tool in tvpaint

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/289|
|pype-config|https://github.com/pypeclub/pype-config/pull/101|

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1068|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/288|