### PR TITLE
Collect audio for farm reviews.

### DIFF
--- a/pype/plugins/global/publish/collect_audio.py
+++ b/pype/plugins/global/publish/collect_audio.py
@@ -1,0 +1,47 @@
+import os
+
+import pyblish.api
+from pype import api as pype_api
+from avalon import api, io
+
+
+class CollectAudio(pyblish.api.ContextPlugin):
+    """Finds asset audio based on plugin settings."""
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Audio"
+
+    subset_name = "audioMain"
+
+    def process(self, context):
+        version = pype_api.get_latest_version(
+            api.Session["AVALON_ASSET"], self.subset_name
+        )
+
+        if version is None:
+            self.log.warning(
+                "No audio version found on subset name: \"{}\"".format(
+                    self.subset_name
+                )
+            )
+            return
+
+        representation = io.find_one(
+            {"type": "representation", "parent": version["_id"], "name": "wav"}
+        )
+
+        if representation is None:
+            msg = (
+                "No audio \"wav\" representation found on subset name: \"{}\""
+            )
+            self.log.warning(msg.format(self.subset_name))
+            return
+
+        path = api.get_representation_path(representation)
+
+        if not os.path.exists(path):
+            self.log.warning("No file found at: \"{}\"".format(path))
+            return
+
+        self.log.info("Using audio file: \"{}\"".format(path))
+        context.data["audioFile"] = path

--- a/pype/plugins/global/publish/collect_audio.py
+++ b/pype/plugins/global/publish/collect_audio.py
@@ -12,6 +12,7 @@ class CollectAudio(pyblish.api.ContextPlugin):
     label = "Collect Audio"
 
     subset_name = "audioMain"
+    hosts = ["nuke"]
 
     def process(self, context):
         version = pype_api.get_latest_version(


### PR DESCRIPTION
**Motivation**

Audio is not added to our Nuke reviews.

**Implementation**

The collection will search for a subset called "audioMain" by default but this is a plugin attribute, so can be configured per studio.
On the subset a representation is hardcoded to "wav", which is more universally compliant, but we could make this a plugin attribute if a use-case is found.

If version, representation or file is not found, it'll only warn the user rather than fail.