### PR TITLE
Fix resolving of  schema dir

### DIFF
--- a/pype/lib/log.py
+++ b/pype/lib/log.py
@@ -201,8 +201,11 @@ class PypeLogger:
     # Information about mongo url
     log_mongo_url = None
     log_mongo_url_components = None
-    log_database_name = None
-    log_collection_name = None
+
+    # Database name in Mongo
+    log_database_name = "pype"
+    # Collection name under database in Mongo
+    log_collection_name = "logs"
 
     # PYPE_DEBUG
     pype_debug = 0
@@ -348,24 +351,13 @@ class PypeLogger:
         cls.pype_debug = int(os.getenv("PYPE_DEBUG") or "0")
 
         # Mongo URL where logs will be stored
-        cls.log_mongo_url = (
-            os.environ.get("PYPE_LOG_MONGO_URL")
-            or os.environ.get("PYPE_MONGO")
-        )
+        cls.log_mongo_url = os.environ.get("PYPE_MONGO")
+
         if not cls.log_mongo_url:
             cls.use_mongo_logging = False
         else:
             # Decompose url
             cls.log_mongo_url_components = decompose_url(cls.log_mongo_url)
-
-        # Database name in Mongo
-        cls.log_database_name = (
-            os.environ.get("PYPE_LOG_MONGO_DB") or "pype"
-        )
-        # Collection name under database in Mongo
-        cls.log_collection_name = (
-            os.environ.get("PYPE_LOG_MONGO_COL") or "logs"
-        )
 
         # Mark as initialized
         cls.initialized = True

--- a/pype/modules/avalon_apps/avalon_app.py
+++ b/pype/modules/avalon_apps/avalon_app.py
@@ -38,11 +38,6 @@ class AvalonModule(PypeModule, ITrayModule, IRestApi):
         self.avalon_mongo_url = avalon_mongo_url
         self.avalon_mongo_timeout = avalon_mongo_timeout
 
-        self.schema_path = os.path.join(
-            os.path.dirname(pype.PACKAGE_DIR),
-            "schema"
-        )
-
         # Tray attributes
         self.libraryloader = None
         self.rest_api_obj = None
@@ -50,23 +45,11 @@ class AvalonModule(PypeModule, ITrayModule, IRestApi):
     def get_global_environments(self):
         """Avalon global environments for pype implementation."""
         return {
-            # 100% hardcoded
-            "AVALON_SCHEMA": self.schema_path,
-            "AVALON_CONFIG": "pype",
-            "AVALON_LABEL": "Pype",
-
-            # Modifiable by settings
-            # - mongo ulr for avalon projects
-            "AVALON_MONGO": self.avalon_mongo_url,
             # TODO thumbnails root should be multiplafrom
             # - thumbnails root
             "AVALON_THUMBNAIL_ROOT": self.thumbnail_root,
             # - mongo timeout in ms
             "AVALON_TIMEOUT": str(self.avalon_mongo_timeout),
-
-            # May be modifiable?
-            # - mongo database name where projects are stored
-            "AVALON_DB": "avalon"
         }
 
     def tray_init(self):

--- a/pype/settings/defaults/system_settings/modules.json
+++ b/pype/settings/defaults/system_settings/modules.json
@@ -1,13 +1,11 @@
 {
     "avalon": {
-        "AVALON_MONGO": "",
         "AVALON_TIMEOUT": 1000,
         "AVALON_THUMBNAIL_ROOT": {
             "windows": "",
             "darwin": "",
             "linux": ""
-        },
-        "AVALON_DB_DATA": "{PYPE_SETUP_PATH}/../mongo_db_data"
+        }
     },
     "ftrack": {
         "enabled": true,

--- a/pype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/pype/settings/entities/schemas/system_schema/schema_modules.json
@@ -12,12 +12,6 @@
             "collapsible": true,
             "children": [
                 {
-                    "type": "text",
-                    "key": "AVALON_MONGO",
-                    "label": "Avalon Mongo URL",
-                    "placeholder": "Pype Mongo is used if not filled."
-                },
-                {
                     "type": "number",
                     "key": "AVALON_TIMEOUT",
                     "minimum": 0,
@@ -29,11 +23,6 @@
                     "key": "AVALON_THUMBNAIL_ROOT",
                     "multiplatform": true,
                     "multipath": false
-                },
-                {
-                    "type": "text",
-                    "key": "AVALON_DB_DATA",
-                    "label": "Avalon Mongo Data Location"
                 }
             ]
         },

--- a/start.py
+++ b/start.py
@@ -176,7 +176,7 @@ def run(arguments: list, env: dict = None) -> int:
 
 
 def set_avalon_environments():
-    """ Set avalon specific environments.
+    """Set avalon specific environments.
 
     These are non modifiable environments for avalon workflow that must be set
     before avalon module is imported because avalon works with globals set with

--- a/start.py
+++ b/start.py
@@ -175,6 +175,38 @@ def run(arguments: list, env: dict = None) -> int:
     return p.returncode
 
 
+def set_avalon_environments():
+    """ Set avalon specific environments.
+
+    These are non modifiable environments for avalon workflow that must be set
+    before avalon module is imported because avalon works with globals set with
+    environment variables.
+    """
+    from pype import PACKAGE_DIR
+
+    # Path to pype's schema
+    schema_path = os.path.join(
+        os.path.dirname(PACKAGE_DIR),
+        "schema"
+    )
+    # Avalon mongo URL
+    avalon_mongo_url = (
+        os.environ.get("AVALON_MONGO")
+        or os.environ["PYPE_MONGO"]
+    )
+    os.environ.update({
+        # Mongo url (use same as pype has)
+        "AVALON_MONGO": avalon_mongo_url,
+
+        "AVALON_SCHEMA": schema_path,
+        # Mongo DB name where avalon docs are stored
+        "AVALON_DB": "avalon",
+        # Name of config
+        "AVALON_CONFIG": "pype",
+        "AVALON_LABEL": "Pype"
+    })
+
+
 def set_modules_environments():
     """Set global environments for pype modules.
 
@@ -548,6 +580,8 @@ def boot():
     from pype.lib import terminal as t
     from pype.version import __version__
     print(">>> loading environments ...")
+    # Must happen before `set_modules_environments`
+    set_avalon_environments()
     set_modules_environments()
 
     assert version_path, "Version path not defined."


### PR DESCRIPTION
## Issue description
- avalon module use global variables that are set with values from environments on import but avalon environments may not be set at the moment yet because they are set with Avalon Module
- the problem is avalon schema (AVALON_SCHEMA env) and avalon's mongo db (AVALON_MONGO, AVALON_TIMEOUT, AVALON_DB envs) these are problem only if `AvalonMongoDB` object is created and used before variables are set

## Suggested solution
- set the environments earlier in `start.py` before avalon is imported (before pype's module manager is used)

## Changes
- moved non modifiable environments out of Pype's Avalon module to start.py this way we should be 99% sure that they are set before avalon is imported
- removed keys `AVALON_MONGO` and `AVALON_DB_DATA` from settings

Resolves: https://github.com/pypeclub/pype/issues/1069