### PR TITLE
PS - added support for .psb in workfiles

### DIFF
--- a/pype/plugins/photoshop/publish/collect_workfile.py
+++ b/pype/plugins/photoshop/publish/collect_workfile.py
@@ -31,9 +31,10 @@ class CollectWorkfile(pyblish.api.ContextPlugin):
         })
 
         # creating representation
+        _, ext = os.path.splitext(file_path)
         instance.data["representations"].append({
-            "name": "psd",
-            "ext": "psd",
+            "name": ext[1:],
+            "ext": ext[1:],
             "files": base_name,
             "stagingDir": staging_dir,
         })

--- a/pype/plugins/photoshop/publish/increment_workfile.py
+++ b/pype/plugins/photoshop/publish/increment_workfile.py
@@ -1,3 +1,4 @@
+import os
 import pyblish.api
 from pype.action import get_errored_plugins_from_data
 from pype.lib import version_up
@@ -25,6 +26,7 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
             )
 
         scene_path = version_up(instance.context.data["currentFile"])
-        photoshop.stub().saveAs(scene_path, 'psd', True)
+        _, ext = os.path.splitext(scene_path)
+        photoshop.stub().saveAs(scene_path, ext[1:], True)
 
         self.log.info("Incremented workfile to: {}".format(scene_path))


### PR DESCRIPTION
Allows saving workfile as .psb, publish it as psb representation

(Currently .psb could be opened, but not saved as or published.)

Requires:
pypeclub/avalon-core#290