### PR TITLE
Collect instance data fix subset query

### DIFF
--- a/pype/plugins/global/publish/collect_anatomy_instance_data.py
+++ b/pype/plugins/global/publish/collect_anatomy_instance_data.py
@@ -149,10 +149,12 @@ class CollectAnatomyInstanceData(pyblish.api.ContextPlugin):
                 "name": subset_name
             })
 
-        subset_docs = list(io.find({
-            "type": "subset",
-            "$or": subset_filters
-        }))
+        subset_docs = []
+        if subset_filters:
+            subset_docs = list(io.find({
+                "type": "subset",
+                "$or": subset_filters
+            }))
 
         subset_ids = [
             subset_doc["_id"]


### PR DESCRIPTION
## Issue
- Collect Anatomy instance data will crash if there are no instances to process (with wierd error)

## Changes
- do not query subset documents if subset filters are empty

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1083|