### PR TITLE
Fix versions variable usage in standalone publisher

### DIFF
--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -340,11 +340,8 @@ class FamilyWidget(QtWidgets.QWidget):
             ).distinct("name")
 
         if versions:
-            versions = sorted(
-                [v for v in versions],
-                key=lambda ver: ver['name']
-            )
-            version = int(versions[-1]['name']) + 1
+            versions = sorted(versions)
+            version = int(versions[-1]) + 1
 
         self.version_spinbox.setValue(version)
 


### PR DESCRIPTION
## Changes
- fixed usage of `versions` variable in standalone publisher where were expected version documents but now it is only list of version names

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1090|