### PR TITLE
Reset loader's asset selection on context change

### DIFF
--- a/pype/hosts/maya/__init__.py
+++ b/pype/hosts/maya/__init__.py
@@ -45,7 +45,7 @@ def install():
     avalon.before("save", on_before_save)
 
     log.info("Overriding existing event 'taskChanged'")
-    override_event("taskChanged", on_task_changed)
+    override_task_change_event()
 
     log.info("Setting default family states for loader..")
     avalon.data["familiesStateToggled"] = ["imagesequence"]
@@ -59,22 +59,19 @@ def uninstall():
     menu.uninstall()
 
 
-def override_event(event, callback):
-    """
-    Override existing event callback
-    Args:
-        event (str): name of the event
-        callback (function): callback to be triggered
+def override_task_change_event():
+    """Override taskChanged event callback in avalon's maya implementation."""
 
-    Returns:
-        None
+    event_name = "taskChanged"
+    callbacks = pipeline._registered_event_handlers.get(event_name)
+    if callbacks:
+        # Remove callback from `avalon.maya.pipeline`
+        from avalon.maya.pipeline import _on_task_changed
 
-    """
-
-    ref = weakref.WeakSet()
-    ref.add(callback)
-
-    pipeline._registered_event_handlers[event] = ref
+        if _on_task_changed in callbacks:
+            callbacks.remove(_on_task_changed)
+    # Register pype's callback
+    avalon.on(event_name, on_task_changed)
 
 
 def on_init(_):


### PR DESCRIPTION
## Changes
Overrides of taskChanged event is not radical but explicit. All `"taskChanged"` callbacks were removed on override event in maya's implementation which is not wanted.
- `override_event` function was removed
- added `override_task_change_event` which removes task change callback from maya's implementation in avalon
    - this explicit replacement give ability to register different callbacks for `"taskChanged"` event (e.g. in Loader tool)

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/298|

|:black_flag: |Pype 3.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1107|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/299|

Resolves: https://github.com/pypeclub/pype/issues/1074