### PR TITLE
Reset loader's asset selection on context change

### DIFF
--- a/pype/hosts/maya/api/__init__.py
+++ b/pype/hosts/maya/api/__init__.py
@@ -7,7 +7,7 @@ from maya import utils, cmds
 from avalon import api as avalon
 from avalon import pipeline
 from avalon.maya import suspended_refresh
-from avalon.maya.pipeline import IS_HEADLESS, _on_task_changed
+from avalon.maya.pipeline import IS_HEADLESS
 from avalon.tools import workfiles
 from pyblish import api as pyblish
 from pype.lib import any_outdated
@@ -45,9 +45,7 @@ def install():
     avalon.on("open", on_open)
     avalon.on("new", on_new)
     avalon.before("save", on_before_save)
-
-    log.info("Overriding existing event 'taskChanged'")
-    override_event("taskChanged", on_task_changed)
+    avalon.on("taskChanged", on_task_changed)
 
     log.info("Setting default family states for loader..")
     avalon.data["familiesStateToggled"] = ["imagesequence"]
@@ -59,24 +57,6 @@ def uninstall():
     avalon.deregister_plugin_path(avalon.Creator, CREATE_PATH)
 
     menu.uninstall()
-
-
-def override_event(event, callback):
-    """
-    Override existing event callback
-    Args:
-        event (str): name of the event
-        callback (function): callback to be triggered
-
-    Returns:
-        None
-
-    """
-
-    ref = weakref.WeakSet()
-    ref.add(callback)
-
-    pipeline._registered_event_handlers[event] = ref
 
 
 def on_init(_):
@@ -215,7 +195,6 @@ def on_new(_):
 def on_task_changed(*args):
     """Wrapped function of app initialize and maya's on task changed"""
     # Run
-    _on_task_changed()
     with suspended_refresh():
         lib.set_context_settings()
         lib.update_content_on_context_change()

--- a/pype/hosts/maya/api/lib.py
+++ b/pype/hosts/maya/api/lib.py
@@ -2677,7 +2677,7 @@ def update_content_on_context_change():
 
 def show_message(title, msg):
     from avalon.vendor.Qt import QtWidgets
-    from ...widgets import message_window
+    from pype.widgets import message_window
 
     # Find maya main window
     top_level_widgets = {w.objectName(): w for w in


### PR DESCRIPTION
**Changes in this PR are not the same as in Pype 2 PR!**

## Changes
- `override_event` function was removed
- event `"taskChanged"` is not overriden but is pype's callback
    - from pype's callback was removed avalon's callback which is not overriden so is not required to be called in pype

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/299|

|:black_flag: |Pype 2.x PR|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1106|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/298|