### PR TITLE
Missing gobal environments

### DIFF
--- a/pype/settings/defaults/system_settings/general.json
+++ b/pype/settings/defaults/system_settings/general.json
@@ -23,15 +23,11 @@
             "darwin": "{VIRTUAL_ENV}/bin/python"
         },
         "PYPE_OCIO_CONFIG": "{STUDIO_SOFT}/OpenColorIO-Configs",
-        "PYBLISH_GUI": "pyblish_pype",
-        "QT_AUTO_SCREEN_SCALE_FACTOR": "1",
         "__environment_keys__": {
             "global": [
                 "FFMPEG_PATH",
                 "PYPE_PYTHON_EXE",
-                "PYPE_OCIO_CONFIG",
-                "PYBLISH_GUI",
-                "QT_AUTO_SCREEN_SCALE_FACTOR"
+                "PYPE_OCIO_CONFIG"
             ]
         }
     }

--- a/pype/settings/defaults/system_settings/general.json
+++ b/pype/settings/defaults/system_settings/general.json
@@ -17,16 +17,10 @@
             "darwin": "{PYPE_ROOT}/vendor/bin/ffmpeg_exec/darwin/bin",
             "linux": ":{PYPE_ROOT}/vendor/bin/ffmpeg_exec/linux"
         },
-        "PYPE_PYTHON_EXE": {
-            "windows": "{VIRTUAL_ENV}/Scripts/python.exe",
-            "linux": "{VIRTUAL_ENV}/Scripts/python",
-            "darwin": "{VIRTUAL_ENV}/bin/python"
-        },
         "PYPE_OCIO_CONFIG": "{STUDIO_SOFT}/OpenColorIO-Configs",
         "__environment_keys__": {
             "global": [
                 "FFMPEG_PATH",
-                "PYPE_PYTHON_EXE",
                 "PYPE_OCIO_CONFIG"
             ]
         }

--- a/start.py
+++ b/start.py
@@ -119,6 +119,26 @@ bootstrap = BootstrapRepos()
 silent_commands = ["run", "igniter", "standalonepublisher"]
 
 
+def set_pype_global_environments() -> None:
+    """Set global pype's environments."""
+    import acre
+
+    from pype.settings import get_environments
+
+    all_env = get_environments()
+
+    # TODO Global environments will be stored in "general" settings so loading
+    #   will be modified and can be done in igniter.
+    env = acre.merge(all_env["global"], dict(os.environ))
+    os.environ.clear()
+    os.environ.update(env)
+
+    # Hardcoded default values
+    os.environ["PYBLISH_GUI"] = "pyblish_pype"
+    # Change scale factor only if is not set
+    if "QT_AUTO_SCREEN_SCALE_FACTOR" not in os.environ:
+        os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+
 
 def run(arguments: list, env: dict = None) -> int:
     """Use correct executable to run stuff.
@@ -591,9 +611,11 @@ def boot():
     from pype.lib import terminal as t
     from pype.version import __version__
     print(">>> loading environments ...")
-    # Must happen before `set_modules_environments`
+    # Avalon environments must be set before avalon module is imported
     print("  - for Avalon ...")
     set_avalon_environments()
+    print("  - global Pype ...")
+    set_pype_global_environments()
     print("  - for modules ...")
     set_modules_environments()
 

--- a/start.py
+++ b/start.py
@@ -112,45 +112,12 @@ if getattr(sys, 'frozen', False):
     os.environ["PYTHONPATH"] = os.pathsep.join(paths)
 
 from igniter import BootstrapRepos  # noqa: E402
-from igniter.tools import load_environments, get_pype_path_from_db  # noqa
+from igniter.tools import get_pype_path_from_db  # noqa
 from igniter.bootstrap_repos import PypeVersion  # noqa: E402
 
 bootstrap = BootstrapRepos()
 silent_commands = ["run", "igniter", "standalonepublisher"]
 
-
-def set_environments() -> None:
-    """Set loaded environments.
-
-    .. todo:
-        better handling of environments
-
-    """
-    try:
-        import acre
-    except ImportError:
-        if getattr(sys, 'frozen', False):
-            sys.path.append(os.path.join(
-                os.path.dirname(sys.executable),
-                "dependencies"
-            ))
-            try:
-                import acre
-            except ImportError as e:
-                # giving up
-                print("!!! cannot import acre")
-                print(f"{e}")
-                sys.exit(1)
-    try:
-        env = load_environments(["global"])
-    except OSError as e:
-        print(f"!!! {e}")
-        sys.exit(1)
-
-    # acre must be available here
-    env = acre.merge(env, dict(os.environ))  # noqa
-    os.environ.clear()
-    os.environ.update(env)
 
 
 def run(arguments: list, env: dict = None) -> int:
@@ -572,9 +539,6 @@ def boot():
         os.environ["PYPE_ROOT"] = os.path.dirname(sys.executable)
     else:
         os.environ["PYPE_ROOT"] = os.path.dirname(__file__)
-
-    # No environment loading from settings until Pype version is established.
-    # set_environments()
 
     # Get Pype path from database and set it to environment so Pype can
     # find its versions there and bootstrap them.


### PR DESCRIPTION
## Issue
- Global environments are not set on start of pype.

## Changes
- removed `set_environments` from start.py as is not used
- added `set_pype_global_environments` to start.py where are set environments from `"global"` environment group and few hardcoded values
    - those hardcoded environment keys were removed from defaults settings
- env variable `PYPE_PYTHON_EXE` was removed from default global environments

## Note
- this will be changed in future anyway as what is not stored under `"global"` environment group will be stored in general settings