### PR TITLE
Avoid dot in repre extension

### DIFF
--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -334,6 +334,17 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
 
             sequence_repre = isinstance(files, list)
             repre_context = None
+
+            ext = repre["ext"]
+            if ext.startswith("."):
+                self.log.warning((
+                    "Implementaion warning: <\"{}\">"
+                    " Representation's extension stored under \"ext\" key "
+                    " started with dot (\"{}\")."
+                ).format(repre["name"], ext))
+                ext = ext[1:]
+            repre["ext"] = ext
+            
             if sequence_repre:
                 self.log.debug(
                     "files: {}".format(files))

--- a/pype/plugins/global/publish/integrate_new.py
+++ b/pype/plugins/global/publish/integrate_new.py
@@ -344,7 +344,7 @@ class IntegrateAssetNew(pyblish.api.InstancePlugin):
                 ).format(repre["name"], ext))
                 ext = ext[1:]
             repre["ext"] = ext
-            
+
             if sequence_repre:
                 self.log.debug(
                     "files: {}".format(files))


### PR DESCRIPTION
## Issue
- representation's extension may containt dot which will break anatomy's templates


## Changes
- added autofix of extension to integrate new with warning message