### PR TITLE
Settings schemas cleanup

### DIFF
--- a/pype/settings/defaults/project_settings/ftrack.json
+++ b/pype/settings/defaults/project_settings/ftrack.json
@@ -1,6 +1,4 @@
 {
-    "ftrack_actions_path": [],
-    "ftrack_events_path": [],
     "events": {
         "sync_to_avalon": {
             "enabled": true,

--- a/pype/settings/entities/dict_immutable_keys_entity.py
+++ b/pype/settings/entities/dict_immutable_keys_entity.py
@@ -10,6 +10,7 @@ from pype.settings.constants import (
     M_OVERRIDEN_KEY
 )
 from . import (
+    BaseItemEntity,
     ItemEntity,
     BoolEntity,
     GUIEntity
@@ -75,6 +76,15 @@ class DictImmutableKeysEntity(ItemEntity):
 
     def schema_validations(self):
         """Validation of schema data."""
+        children_keys = set()
+        for child_entity in self.children:
+            if not isinstance(child_entity, BaseItemEntity):
+                continue
+            elif child_entity.key not in children_keys:
+                children_keys.add(child_entity.key)
+            else:
+                raise SchemaDuplicatedKeys(self.path, child_entity.key)
+
         if self.checkbox_key:
             checkbox_child = self.non_gui_children.get(self.checkbox_key)
             if not checkbox_child:
@@ -134,8 +144,6 @@ class DictImmutableKeysEntity(ItemEntity):
             if isinstance(child_obj, GUIEntity):
                 continue
 
-            if child_obj.key in self.non_gui_children:
-                raise SchemaDuplicatedKeys("", child_obj.key)
             self.non_gui_children[child_obj.key] = child_obj
 
         if not first:

--- a/pype/settings/entities/item_entities.py
+++ b/pype/settings/entities/item_entities.py
@@ -10,7 +10,7 @@ from .base_entity import ItemEntity
 
 
 class PathEntity(ItemEntity):
-    schema_types = ["path-widget", "path-item"]
+    schema_types = ["path"]
     platforms = ("windows", "darwin", "linux")
     platform_labels_mapping = {
         "windows": "Windows",

--- a/pype/settings/entities/schemas/README.md
+++ b/pype/settings/entities/schemas/README.md
@@ -47,7 +47,7 @@
         "key": "{host_name}_environments",
         "env_group_key": "{host_name}"
     }, {
-        "type": "path-widget",
+        "type": "path",
         "key": "{host_name}_executables",
         "label": "{host_label} - Full paths to executables",
         "multiplatform": "{multipath_executables}",
@@ -361,7 +361,7 @@
 
 ```
 {
-    "type": "path-widget",
+    "type": "path",
     "key": "ffmpeg_path",
     "label": "FFmpeg path",
     "multiplatform": true,

--- a/pype/settings/entities/schemas/projects_schema/schema_main.json
+++ b/pype/settings/entities/schemas/projects_schema/schema_main.json
@@ -15,7 +15,7 @@
                     "is_group": true,
                     "expandable": false,
                     "object_type": {
-                        "type": "path-widget",
+                        "type": "path",
                         "multiplatform": true
                     }
                 },

--- a/pype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/pype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -6,28 +6,6 @@
     "is_file": true,
     "children": [
         {
-            "type": "splitter"
-        },
-        {
-            "type": "label",
-            "label": "Additional Ftrack paths"
-        },
-        {
-            "type": "list",
-            "key": "ftrack_actions_path",
-            "label": "Action paths",
-            "object_type": "text"
-        },
-        {
-            "type": "list",
-            "key": "ftrack_events_path",
-            "label": "Event paths",
-            "object_type": "text"
-        },
-        {
-            "type": "splitter"
-        },
-        {
             "type": "dict",
             "key": "events",
             "label": "Server Actions/Events",

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_imageio.json
@@ -39,7 +39,7 @@
                                     ]
                                 },
                                 {
-                                    "type": "path-widget",
+                                    "type": "path",
                                     "key": "ocioconfigpath",
                                     "label": "Custom OCIO path",
                                     "multiplatform": true,
@@ -175,7 +175,7 @@
                                     ]
                                 },
                                 {
-                                    "type": "path-widget",
+                                    "type": "path",
                                     "key": "customOCIOConfigPath",
                                     "label": "Custom OCIO config path",
                                     "multiplatform": true,

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -93,7 +93,7 @@
                             "label": "Path to material file defining list of material names to check. This is material name per line simple text file.<br/>It will be checked against named group <b>shader</b> in your <em>Validation regex</em>.<p>For example: <br/> <code>^.*(?P=&lt;shader&gt;.+)_GEO</code></p>"
                         },
                         {
-                            "type": "path-widget",
+                            "type": "path",
                             "key": "material_file",
                             "label": "Material File",
                             "multiplatform": true,

--- a/pype/settings/entities/schemas/system_schema/example_schema.json
+++ b/pype/settings/entities/schemas/system_schema/example_schema.json
@@ -298,28 +298,28 @@
                     }
                 },
                 {
-                    "type": "path-widget",
+                    "type": "path",
                     "key": "single_path_input",
                     "label": "Single path input",
                     "multiplatform": false,
                     "multipath": false
                 },
                 {
-                    "type": "path-widget",
+                    "type": "path",
                     "key": "multi_path_input",
                     "label": "Multi path input",
                     "multiplatform": false,
                     "multipath": true
                 },
                 {
-                    "type": "path-widget",
+                    "type": "path",
                     "key": "single_os_specific_path_input",
                     "label": "Single OS specific path input",
                     "multiplatform": true,
                     "multipath": false
                 },
                 {
-                    "type": "path-widget",
+                    "type": "path",
                     "key": "multi_os_specific_path_input",
                     "label": "Multi OS specific path input",
                     "multiplatform": true,

--- a/pype/settings/entities/schemas/system_schema/example_template.json
+++ b/pype/settings/entities/schemas/system_schema/example_template.json
@@ -11,7 +11,7 @@
         "env_group_key": "{host_name}"
     },
     {
-        "type": "path-widget",
+        "type": "path",
         "key": "{host_name}_executables",
         "label": "{host_label} - Full paths to executables",
         "multiplatform": "{multipath_executables}",

--- a/pype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
@@ -39,7 +39,7 @@
                 "roles": ["developer"]
             },
             {
-                "type": "path-widget",
+                "type": "path",
                 "key": "executables",
                 "label": "Executables",
                 "multiplatform": "{multiplatform}",

--- a/pype/settings/entities/schemas/system_schema/schema_general.json
+++ b/pype/settings/entities/schemas/system_schema/schema_general.json
@@ -20,14 +20,14 @@
         },
         {
             "key": "project_plugins",
-            "type": "path-widget",
+            "type": "path",
             "label": "Additional Project Plugins Path",
             "multiplatform": true,
             "multipath": false
         },
         {
             "key": "studio_soft",
-            "type": "path-widget",
+            "type": "path",
             "label": "Studio Software Location",
             "multiplatform": true,
             "multipath": false

--- a/pype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/pype/settings/entities/schemas/system_schema/schema_modules.json
@@ -18,7 +18,7 @@
                     "label": "Avalon Mongo Timeout (ms)"
                 },
                 {
-                    "type": "path-widget",
+                    "type": "path",
                     "label": "Thumbnail Storage Location",
                     "key": "AVALON_THUMBNAIL_ROOT",
                     "multiplatform": true,


### PR DESCRIPTION
## Description
Modifying schemas of settings schema usage that are not used or invalid. Most of these are discovered during preparing script of converting pype-config -> settings.

## Changes
- renamed `"path-widget"` type to `"path"`
- `"path"` entity's widget have ability to have set `use_label_wrap`
- Ftrack removed items for additional paths to user/server actions/events from project settings