### PR TITLE
Maya copy mel

### DIFF
--- a/pype/hosts/maya/api/__init__.py
+++ b/pype/hosts/maya/api/__init__.py
@@ -12,6 +12,7 @@ from avalon.tools import workfiles
 from pyblish import api as pyblish
 from pype.lib import any_outdated
 import pype.hosts.maya
+from pype.hosts.maya.lib import copy_workspace_mel
 from . import menu, lib
 
 log = logging.getLogger("pype.hosts.maya")
@@ -46,6 +47,7 @@ def install():
     avalon.on("new", on_new)
     avalon.before("save", on_before_save)
     avalon.on("taskChanged", on_task_changed)
+    avalon.on("before.workfile.save", before_workfile_save)
 
     log.info("Setting default family states for loader..")
     avalon.data["familiesStateToggled"] = ["imagesequence"]
@@ -203,3 +205,11 @@ def on_task_changed(*args):
         "Context was changed",
         ("Context was changed to {}".format(avalon.Session["AVALON_ASSET"])),
     )
+
+
+def before_workfile_save(workfile_path):
+    if not workfile_path:
+        return
+
+    workdir = os.path.dirname(workfile_path)
+    copy_workspace_mel(workdir)

--- a/pype/hosts/maya/hooks/pre_copy_mel.py
+++ b/pype/hosts/maya/hooks/pre_copy_mel.py
@@ -1,0 +1,18 @@
+from pype.lib import PreLaunchHook
+from pype.hosts.maya.lib import copy_workspace_mel
+
+
+class PreCopyMel(PreLaunchHook):
+    """Copy workspace.mel to workdir.
+
+    Hook `GlobalHostDataHook` must be executed before this hook.
+    """
+    app_groups = ["maya"]
+
+    def execute(self):
+        workdir = self.launch_context.env.get("AVALON_WORKDIR")
+        if not workdir:
+            self.log.warning("BUG: Workdir is not filled.")
+            return
+
+        copy_workspace_mel(workdir)

--- a/pype/hosts/maya/lib.py
+++ b/pype/hosts/maya/lib.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+
+
+def copy_workspace_mel(workdir):
+    # Check that source mel exists
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    src_filepath = os.path.join(current_dir, "resources", "workspace.mel")
+    if not os.path.exists(src_filepath):
+        print("Source mel file does not exist. {}".format(src_filepath))
+        return
+
+    # Skip if workspace.mel already exists
+    dst_filepath = os.path.join(workdir, "workspace.mel")
+    if os.path.exists(dst_filepath):
+        return
+
+    # Create workdir if does not exists yet
+    if not os.path.exists(workdir):
+        os.makedirs(workdir)
+
+    # Copy file
+    print("Copying workspace mel \"{}\" -> \"{}\"".format(
+        src_filepath, dst_filepath
+    ))
+    shutil.copy(src_filepath, dst_filepath)

--- a/pype/tools/workfiles/app.py
+++ b/pype/tools/workfiles/app.py
@@ -695,10 +695,14 @@ class FilesWidget(QtWidgets.QWidget):
 
         file_path = os.path.join(self.root, work_file)
 
+        pipeline.emit("before.workfile.save", file_path)
+
         self._enter_session()   # Make sure we are in the right session
         self.host.save_file(file_path)
 
         self.set_asset_task(self._asset, self._task)
+
+        pipeline.emit("after.workfile.save", file_path)
 
         self.workfile_created.emit(file_path)
 


### PR DESCRIPTION
## Issue
- Pype used `[copy]` key from application toml's but tomls are not used anymore
    - as far as I know it was used only in Maya and in specific occations

## Changes
- workfiles tool emmits signal `'before.workfile.save'` and `'after.workfile.save'`
- pype's maya host has new `lib.py` outside `/api` folder where is function `copy_workspace_mel`
- added prelaunch hook to maya which use `copy_workspace_mel` to copy workspace.mel before host start
- maya implementation capture `'before.workfile.save'` signal and use `copy_workspace_mel` to copy workspace.mel in callback