### PR TITLE
nuke deadline submit with environ var from presets overrides

### DIFF
--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -29,6 +29,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
     deadline_pool_secondary = ""
     deadline_group = ""
     deadline_department = ""
+    env_overrides = {}
 
     def process(self, instance):
         instance.data["toBeRenderedOn"] = "deadline"
@@ -260,6 +261,11 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             clean_environment[key] = clean_path
 
         environment = clean_environment
+
+        # Finally override by preset's env vars
+        if self.env_overrides:
+            for key, value in self.env_overrides.items():
+                environment[key] = value
 
         payload["JobInfo"].update({
             "EnvironmentKeyValue%d" % index: "{key}={value}".format(


### PR DESCRIPTION
## description
At the moment we are not able to add any additional environment variables or override some we already have, but they need to be having different values for deadline workers. For example, if we want to have different licensing.

## required for testing:
Add this to your `pype-config\repos\pype-config\presets\plugins\nuke\publish.json`
```json 
{
    "NukeSubmitDeadline": {
        "env_overrides": {
            "TESTENV": "testenv value",
            "FTRACK_SERVER": "overriding this key with this value"
        }
    }
}
