### PR TITLE
Application executable check is less strict

### DIFF
--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -227,7 +227,7 @@ class ApplicationExecutable:
         self.default_launch_args = default_launch_args
 
     def __iter__(self):
-        yield distutils.spawn.find_executable(self.executable_path)
+        yield self._realpath()
         for arg in self.default_launch_args:
             yield arg
 
@@ -237,10 +237,23 @@ class ApplicationExecutable:
     def as_args(self):
         return list(self)
 
+    def _realpath(self):
+        """Check if path is valid executable path."""
+        # Check for executable in PATH
+        result = distutils.spawn.find_executable(self.executable_path)
+        if result is not None:
+            return result
+
+        # This is not 100% validation but it is better than remove ability to
+        #   launch .bat, .sh or extentionless files
+        if os.path.exists(self.executable_path):
+            return self.executable_path
+        return None
+
     def exists(self):
         if not self.executable_path:
             return False
-        return bool(distutils.spawn.find_executable(self.executable_path))
+        return bool(self._realpath())
 
 
 class Application:


### PR DESCRIPTION
## Issue
Check of executable existence is based on function `distutils.spawn.find_executable` which does not allow .bat, .sh, etc. files. This function was used to be able determine if executable is realy executable or helps to find entered executable in `"PATH"`.

## Changes
- executable path is still checked with `distutils.spawn.find_executable`. But if result of the function is None and executable path exist, it is used as it is.