### PR TITLE
Nuke: adding preset for a Read node name to all img and mov Loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ node_modules/
 package-lock.json
 
 pype/premiere/ppro/js/debug.log
+
+/.vscode/

--- a/pype/plugins/nuke/load/load_image.py
+++ b/pype/plugins/nuke/load/load_image.py
@@ -33,6 +33,9 @@ class LoadImage(api.Loader):
         )
     ]
 
+    # presets
+    name_expression = "{class_name}_{ext}"
+
     def load(self, context, name, namespace, options):
         from avalon.nuke import (
             containerise,
@@ -73,10 +76,16 @@ class LoadImage(api.Loader):
                 frame,
                 format(frame_number, "0{}".format(padding)))
 
-        read_name = "Read_{0}_{1}_{2}".format(
-            repr_cont["asset"],
-            repr_cont["subset"],
-            repr_cont["representation"])
+        name_data = {
+            "asset": repr_cont["asset"],
+            "subset": repr_cont["subset"],
+            "representation": context["representation"]["name"],
+            "ext": repr_cont["representation"],
+            "id": context["representation"]["_id"],
+            "class_name": self.__class__.__name__
+        }
+
+        read_name = self.name_expression.format(**name_data)
 
         # Create the Loader with the filename path set
         with viewer_update_and_undo_stop():

--- a/pype/plugins/nuke/load/load_mov.py
+++ b/pype/plugins/nuke/load/load_mov.py
@@ -80,6 +80,9 @@ class LoadMov(api.Loader):
     icon = "code-fork"
     color = "orange"
 
+    # presets
+    name_expression = "{class_name}_{ext}"
+
     def loader_shift(self, node, frame, relative=True):
         """Shift global in time by i preserving duration
 
@@ -152,10 +155,16 @@ class LoadMov(api.Loader):
 
         file = file.replace("\\", "/")
 
-        read_name = "Read_{0}_{1}_{2}".format(
-            repr_cont["asset"],
-            repr_cont["subset"],
-            repr_cont["representation"])
+        name_data = {
+            "asset": repr_cont["asset"],
+            "subset": repr_cont["subset"],
+            "representation": context["representation"]["name"],
+            "ext": repr_cont["representation"],
+            "id": context["representation"]["_id"],
+            "class_name": self.__class__.__name__
+        }
+
+        read_name = self.name_expression.format(**name_data)
 
         # Create the Loader with the filename path set
         with viewer_update_and_undo_stop():

--- a/pype/plugins/nuke/load/load_sequence.py
+++ b/pype/plugins/nuke/load/load_sequence.py
@@ -80,6 +80,9 @@ class LoadSequence(api.Loader):
     icon = "file-video-o"
     color = "white"
 
+    # presets
+    name_expression = "{class_name}_{ext}"
+
     @staticmethod
     def fix_hashes_in_path(file, repr_cont):
         if "#" not in file:
@@ -137,10 +140,16 @@ class LoadSequence(api.Loader):
 
         file = self.fix_hashes_in_path(file, repr_cont).replace("\\", "/")
 
-        read_name = "Read_{0}_{1}_{2}".format(
-            repr_cont["asset"],
-            repr_cont["subset"],
-            context["representation"]["name"])
+        name_data = {
+            "asset": repr_cont["asset"],
+            "subset": repr_cont["subset"],
+            "representation": context["representation"]["name"],
+            "ext": repr_cont["representation"],
+            "id": context["representation"]["_id"],
+            "class_name": self.__class__.__name__
+        }
+
+        read_name = self.name_expression.format(**name_data)
 
         # Create the Loader with the filename path set
         with viewer_update_and_undo_stop():


### PR DESCRIPTION
### Description:
Some clients were demanding control over nuke node name formatting

### Available keys for name formatting expression
`asset` = assert name in the context
`subset` = subset name in the context
`representation` = name of the representation in the context
`ext` = extension of the representation in the context
`id` = ID hash of the representation in the context
`class_name` = actual plugin name

### Testing requirements:
Add following code to your `pype-config\presets\plugins\nuke\load.json`

```json
{
    "LoadSequence": {
        "name_expression": "Read_{ext}"
    }
}