### PR TITLE
Harmony missing module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ install_requires = [
     "Qt",
     "speedcopy",
     "googleapiclient",
-    "httplib2"
+    "httplib2",
+    # Harmony implementation
+    "filecmp"
 ]
 
 includes = []


### PR DESCRIPTION
## Issue
Harmony implementation is using python module `filecmp` which is not available in current build of pype (probably because cx_freeze does not resolve it as used module)

## Changes
- added `filecmp` to required modules in setup.py