### PR TITLE
bug: pype root determination when running from sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,20 +208,9 @@ install it to user data directory (on Windows to `%LOCALAPPDATA%\pypeclub\pype`,
 ### From sources
 Pype can be run directly from sources by activating virtual environment:
 
-**On Windows:**
-```powershell
-.\venv\Scripts\Activate.ps1
-```
-and running:
-```powershell
-python start.py tray
-```
-**On macOS/Linux:**
 ```sh
-source ./venv/bin/activate
-python start.py tray
+poetry run python start.py tray
 ```
-
 
 This will use current Pype version with sources. You can override this with `--use-version=x.x.x` and
 then Pype will try to find locally installed specified version (present in user data directory).

--- a/start.py
+++ b/start.py
@@ -111,6 +111,7 @@ if getattr(sys, 'frozen', False):
     paths.append(frozen_libs)
     os.environ["PYTHONPATH"] = os.pathsep.join(paths)
 
+import igniter  # noqa: E402
 from igniter import BootstrapRepos  # noqa: E402
 from igniter.tools import get_pype_path_from_db  # noqa
 from igniter.bootstrap_repos import PypeVersion  # noqa: E402
@@ -469,7 +470,9 @@ def _bootstrap_from_code(use_version):
         assert local_version
     else:
         pype_root = os.path.normpath(
-            os.path.dirname(os.path.realpath(__file__)))
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.realpath(igniter.__file__))))
         # get current version of Pype
         local_version = bootstrap.get_local_live_version()
 

--- a/test_localsystem.txt
+++ b/test_localsystem.txt
@@ -1,1 +1,0 @@
-I have run


### PR DESCRIPTION
## Bug fix:

When running Pype from sources using manually activated venv pype root was not correctly determined. Also `README.md`  was obsolete in a way how to run Pype from sources. This PR is fixing this.