### PR TITLE
Sync anatomy modifications

### DIFF
--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -2137,16 +2137,12 @@ class SyncToAvalonEvent(BaseEvent):
             parent_queue.put(parent_ent)
 
         # Prepare values to query
-        entity_ids_joined = ", ".join([
-            "\"{}\"".format(id) for id in cust_attrs_ftrack_ids
-        ])
         configuration_ids = set()
         for key in hier_cust_attrs_keys:
             configuration_ids.add(hier_attr_id_by_key[key])
 
-        attributes_joined = ", ".join([
-            "\"{}\"".format(conf_id) for conf_id in configuration_ids
-        ])
+        entity_ids_joined = self.join_query_keys(cust_attrs_ftrack_ids)
+        attributes_joined = self.join_query_keys(configuration_ids)
 
         queries = [{
             "action": "query",

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -33,6 +33,15 @@ class SyncToAvalonEvent(BaseEvent):
     ignore_ent_types = ["Milestone"]
     ignore_keys = ["statusid", "thumbid"]
 
+    cust_attr_query_keys = [
+        "id",
+        "key",
+        "entity_type",
+        "object_type_id",
+        "is_hierarchical",
+        "config",
+        "default"
+    ]
     project_query = (
         "select full_name, name, custom_attributes"
         ", project_schema._task_type_schema.types.name"
@@ -117,7 +126,7 @@ class SyncToAvalonEvent(BaseEvent):
     def avalon_cust_attrs(self):
         if self._avalon_cust_attrs is None:
             self._avalon_cust_attrs = avalon_sync.get_pype_attr(
-                self.process_session
+                self.process_session, query_keys=self.cust_attr_query_keys
             )
         return self._avalon_cust_attrs
 

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -1562,10 +1562,9 @@ class SyncToAvalonEvent(BaseEvent):
                 ).format(entity_type, ent_info["entityType"]))
                 continue
 
-            _entity_key = collections.OrderedDict({
-                "configuration_id": mongo_id_configuration_id,
-                "entity_id": ftrack_id
-            })
+            _entity_key = collections.OrderedDict()
+            _entity_key["configuration_id"] = mongo_id_configuration_id
+            _entity_key["entity_id"] = ftrack_id
 
             self.process_session.recorded_operations.push(
                 ftrack_api.operation.UpdateEntityOperation(

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -2169,31 +2169,9 @@ class SyncToAvalonEvent(BaseEvent):
             type_id = attr["type_id"]
             attr_id = attr["id"]
             cust_attr_type_name = attr_types_by_id[type_id]["name"]
-            convert_type = None
-            if cust_attr_type_name == "text":
-                convert_type = str
-
-            elif cust_attr_type_name == "boolean":
-                convert_type = bool
-
-            elif cust_attr_type_name in (
-                "date", "expression", "notificationtype", "dynamic enumerator"
-            ):
-                pass
-
-            else:
-                cust_attr_config = json.loads(attr["config"])
-                if cust_attr_type_name == "number":
-                    if cust_attr_config["isdecimal"]:
-                        convert_type = float
-                    else:
-                        convert_type = int
-
-                elif cust_attr_type_name == "enumerator":
-                    if cust_attr_config["multiSelect"]:
-                        convert_type = list
-                    else:
-                        convert_type = str
+            convert_type = avalon_sync.get_python_type_for_custom_attribute(
+                attr, cust_attr_type_name
+            )
 
             convert_types_by_id[attr_id] = convert_type
             entities_dict[ftrack_project_id]["hier_attrs"][key] = (

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -229,15 +229,6 @@ class SyncToAvalonEvent(BaseEvent):
 
         return self._changeability_by_mongo_id
 
-    @property
-    def avalon_custom_attributes(self):
-        """Return info about changeability of entity and it's parents."""
-        if self._avalon_custom_attributes is None:
-            self._avalon_custom_attributes = avalon_sync.get_pype_attr(
-                self.process_session
-            )
-        return self._avalon_custom_attributes
-
     def remove_cached_by_key(self, key, values):
         if self._avalon_ents is None:
             return
@@ -393,7 +384,6 @@ class SyncToAvalonEvent(BaseEvent):
         self._avalon_archived_by_id = None
         self._avalon_archived_by_name = None
 
-        self._avalon_custom_attributes = None
         self._ent_types_by_name = None
 
         self.ftrack_ents_by_id = {}
@@ -1238,7 +1228,7 @@ class SyncToAvalonEvent(BaseEvent):
 
     def get_cust_attr_values(self, entity, keys=None):
         output = {}
-        custom_attrs, hier_attrs = self.avalon_custom_attributes
+        custom_attrs, hier_attrs = self.avalon_cust_attrs
         not_processed_keys = True
         if keys:
             not_processed_keys = [k for k in keys]

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -131,6 +131,18 @@ class SyncToAvalonEvent(BaseEvent):
         return self._avalon_cust_attrs
 
     @property
+    def cust_attr_types_by_id(self):
+        if self._cust_attr_types_by_id is None:
+            cust_attr_types = self.process_session.query(
+                "select id, name from CustomAttributeType"
+            ).all()
+            self._cust_attr_types_by_id = {
+                cust_attr_type["id"]: cust_attr_type
+                for cust_attr_type in cust_attr_types
+            }
+        return self._cust_attr_types_by_id
+
+    @property
     def avalon_entities(self):
         if self._avalon_ents is None:
             self.dbcon.install()
@@ -382,6 +394,7 @@ class SyncToAvalonEvent(BaseEvent):
         self._cur_project = None
 
         self._avalon_cust_attrs = None
+        self._cust_attr_types_by_id = None
 
         self._avalon_ents = None
         self._avalon_ents_by_id = None

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -1259,12 +1259,16 @@ class SyncToAvalonEvent(BaseEvent):
                 output[key] = entity["custom_attributes"][key]
 
         hier_values = avalon_sync.get_hierarchical_attributes_values(
-            self.process_session, entity, hier_attrs
+            self.process_session,
+            entity,
+            hier_attrs,
+            self.cust_attr_types_by_id
         )
         for key, val in hier_values.items():
-            if key == CUST_ATTR_ID_KEY:
-                continue
             output[key] = val
+
+        # Make sure mongo id is not set
+        output.pop(CUST_ATTR_ID_KEY, None)
 
         return output
 

--- a/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/pype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -2018,7 +2018,7 @@ class SyncToAvalonEvent(BaseEvent):
             self.update_entities()
             return
 
-        cust_attrs, hier_attrs = self.avalon_cust_attrs
+        _, hier_attrs = self.avalon_cust_attrs
 
         # Hierarchical custom attributes preparation ***
         hier_attr_key_by_id = {

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -2143,11 +2143,22 @@ class SyncEntitiesFactory:
         final_doc_data = self.entities_dict[self.ft_project_id]["final_entity"]
         final_doc_tasks = final_doc_data["config"].pop("tasks")
         current_doc_tasks = self.avalon_project.get("config", {}).get("tasks")
-        # Update project's tasks if tasks are empty or are not same
-        if not final_doc_tasks:
+        # Update project's task types
+        if not current_doc_tasks:
             update_tasks = True
         else:
-            update_tasks = final_doc_tasks != current_doc_tasks
+            # Check if task types are same
+            update_tasks = False
+            for task_type in final_doc_tasks:
+                if task_type not in current_doc_tasks:
+                    update_tasks = True
+                    break
+
+            # Update new task types
+            #   - but keep data about existing types and only add new one
+            if update_tasks:
+                for task_type, type_data in current_doc_tasks.items():
+                    final_doc_tasks[task_type] = type_data
 
         changes = self.compare_dict(final_doc_data, self.avalon_project)
 

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -103,7 +103,7 @@ def get_pype_attr(session, split_hierarchical=True, query_keys=None):
         "select {}"
         " from CustomAttributeConfiguration"
         " where group.name in (\"avalon\", \"{}\")"
-    ).format(join_query_keys(query_keys), CUST_ATTR_GROUP)
+    ).format(", ".join(query_keys), CUST_ATTR_GROUP)
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:
         if split_hierarchical and cust_attr["is_hierarchical"]:

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -83,15 +83,23 @@ def check_regex(name, entity_type, in_schema=None, schema_patterns=None):
     return False
 
 
-def get_pype_attr(session, split_hierarchical=True):
+def get_pype_attr(session, split_hierarchical=True, query_keys=None):
     custom_attributes = []
     hier_custom_attributes = []
+    if not query_keys:
+        query_keys = [
+            "id",
+            "entity_type",
+            "object_type_id",
+            "is_hierarchical",
+            "default"
+        ]
     # TODO remove deprecated "avalon" group from query
     cust_attrs_query = (
-        "select id, entity_type, object_type_id, is_hierarchical, default"
+        "select {}"
         " from CustomAttributeConfiguration"
-        " where group.name in (\"avalon\", \"pype\")"
-    )
+        " where group.name in (\"avalon\", \"{}\")"
+    ).format(join_query_keys(query_keys), CUST_ATTR_GROUP)
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:
         if split_hierarchical and cust_attr["is_hierarchical"]:

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -120,6 +120,14 @@ def get_pype_attr(session, split_hierarchical=True, query_keys=None):
 
 
 def get_python_type_for_custom_attribute(cust_attr, cust_attr_type_name=None):
+    """Python type that should value of custom attribute have.
+
+    This function is mainly for number type which is always float from ftrack.
+
+    Returns:
+        type: Python type which call be called on object to convert the object
+            to the type or None if can't figure out.
+    """
     if cust_attr_type_name is None:
         cust_attr_type_name = cust_attr["type"]["name"]
 

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -194,12 +194,8 @@ def get_project_apps(in_app_list):
     missing_app_msg = "Missing definition of application"
     application_manager = ApplicationManager()
     for app_name in in_app_list:
-        app = application_manager.applications.get(app_name)
-        if app:
-            apps.append({
-                "name": app_name,
-                "label": app.full_label
-            })
+        if application_manager.applications.get(app_name):
+            apps.append({"name": app_name})
         else:
             warnings[missing_app_msg].append(app_name)
     return apps, warnings

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1427,8 +1427,13 @@ class SyncEntitiesFactory:
                         old_parent_name = self.entities_dict[
                             self.ft_project_id]["name"]
                     else:
-                        old_parent_name = self.avalon_ents_by_id[
-                            ftrack_parent_mongo_id]["name"]
+                        old_parent_name = "N/A"
+                        if ftrack_parent_mongo_id in self.avalon_ents_by_id:
+                            old_parent_name = (
+                                self.avalon_ents_by_id
+                                [ftrack_parent_mongo_id]
+                                ["name"]
+                            )
 
                     self.updates[avalon_id]["data"] = {
                         "visualParent": new_parent_id

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -321,6 +321,16 @@ def get_hierarchical_attributes(session, entity, attr_names, attr_defaults={}):
 class SyncEntitiesFactory:
     dbcon = AvalonMongoDB()
 
+    cust_attr_query_keys = [
+        "id",
+        "key",
+        "entity_type",
+        "object_type_id",
+        "is_hierarchical",
+        "config",
+        "default"
+    ]
+
     project_query = (
         "select full_name, name, custom_attributes"
         ", project_schema._task_type_schema.types.name"
@@ -866,7 +876,9 @@ class SyncEntitiesFactory:
     def set_cutom_attributes(self):
         self.log.debug("* Preparing custom attributes")
         # Get custom attributes and values
-        custom_attrs, hier_attrs = get_pype_attr(self.session)
+        custom_attrs, hier_attrs = get_pype_attr(
+            self.session, query_keys=self.cust_attr_query_keys
+        )
         ent_types = self.session.query("select id, name from ObjectType").all()
         ent_types_by_name = {
             ent_type["name"]: ent_type["id"] for ent_type in ent_types

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -119,6 +119,31 @@ def get_pype_attr(session, split_hierarchical=True, query_keys=None):
     return custom_attributes
 
 
+def get_python_type_for_custom_attribute(cust_attr, cust_attr_type_name=None):
+    if cust_attr_type_name is None:
+        cust_attr_type_name = cust_attr["type"]["name"]
+
+    if cust_attr_type_name == "text":
+        return str
+
+    if cust_attr_type_name == "boolean":
+        return bool
+
+    if cust_attr_type_name in ("number", "enumerator"):
+        cust_attr_config = json.loads(cust_attr["config"])
+        if cust_attr_type_name == "number":
+            if cust_attr_config["isdecimal"]:
+                return float
+            return int
+
+        if cust_attr_type_name == "enumerator":
+            if cust_attr_config["multiSelect"]:
+                return list
+            return str
+    # "date", "expression", "notificationtype", "dynamic enumerator"
+    return None
+
+
 def from_dict_to_set(data, is_project):
     """
         Converts 'data' into $set part of MongoDB update command.

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -83,6 +83,10 @@ def check_regex(name, entity_type, in_schema=None, schema_patterns=None):
     return False
 
 
+def join_query_keys(keys):
+    return ",".join(["\"{}\"".format(key) for key in keys])
+
+
 def get_pype_attr(session, split_hierarchical=True, query_keys=None):
     custom_attributes = []
     hier_custom_attributes = []

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1140,7 +1140,7 @@ class SyncEntitiesFactory:
                 proj_schema = entity["project_schema"]
                 task_types = proj_schema["_task_type_schema"]["types"]
                 proj_apps, warnings = get_project_apps(
-                    (data.get("applications") or [])
+                    data.pop("applications", [])
                 )
                 for msg, items in warnings.items():
                     if not msg or not items:

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -191,6 +191,9 @@ def get_project_apps(in_app_list):
     apps = []
     warnings = collections.defaultdict(list)
 
+    if not in_app_list:
+        return apps, warnings
+
     missing_app_msg = "Missing definition of application"
     application_manager = ApplicationManager()
     for app_name in in_app_list:


### PR DESCRIPTION
## Changes
- sync to avalon does not override task types but only add new one if are not available
- applications are poped from project's data
- applications have only `"name"` key as label is not used
- fixed bug with missing old parent document
- fixed value types of synchronized items on change and sync
- fixed a lot of found bugs or slow parts