### PR TITLE
Maya: Bugfix: superclass for CreateCameraRig

### DIFF
--- a/pype/plugins/maya/create/create_camera.py
+++ b/pype/plugins/maya/create/create_camera.py
@@ -26,7 +26,7 @@ class CreateCamera(plugin.Creator):
         self.data['bakeToWorldSpace'] = True
 
 
-class CreateCameraRig(avalon.maya.Creator):
+class CreateCameraRig(plugin.Creator):
     """Complex hierarchy with camera."""
 
     name = "camerarigMain"


### PR DESCRIPTION
Maya `CameraRig` Creator had old superclass causing syntax error and skipping loading of whole camera creator plugin.