### PR TITLE
Nuke: deadline submit limiting group filter

### DIFF
--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -371,7 +371,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         will add the appropriate limit group to the payload jobinfo attributes.
 
         Returning:
-            str: captured groups devided by comma and no space
+            list: captured groups list
         """
         captured_groups = []
         for lg_name, list_node_class in self.deadline_limit_groups.items():

--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -365,13 +365,21 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         a list of plugin's node class names. Thus, when a plugin uses more
         than one node, these will be captured and the triggered process
         will add the appropriate limit group to the payload jobinfo attributes.
+
+        Returning:
+            str: captured groups devided by comma and no space
         """
         captured_groups = []
         for lg_name, list_node_class in self.deadline_limit_groups.items():
             for node_class in list_node_class:
                 for node in nuke.allNodes(recurseGroups=True):
+                    # ignore all nodes not member of defined class
                     if node.Class() not in node_class:
                         continue
+                    # ignore all disabled nodes
+                    if node["disable"].value():
+                        continue
+                    # add group name if not already added
                     if lg_name not in captured_groups:
                         captured_groups.append(lg_name)
 

--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -147,6 +147,10 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
         if not priority:
             priority = self.deadline_priority
 
+        # resolve any limit groups
+        limit_groups = self.get_limit_groups()
+        self.log.info("Limit groups: `{}`".format(limit_groups))
+
         payload = {
             "JobInfo": {
                 # Top-level group name
@@ -181,7 +185,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                 "OutputFilename0": output_filename_0.replace("\\", "/"),
 
                 # limiting groups
-                "LimitGroups": self.get_limiting_group_filter()
+                "LimitGroups": ",".join(limit_groups)
 
             },
             "PluginInfo": {
@@ -357,7 +361,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             instance.data["expectedFiles"].append(
                 os.path.join(dir, (file % i)).replace("\\", "/"))
 
-    def get_limiting_group_filter(self):
+    def get_limit_groups(self):
         """Search for limit group nodes and return group name.
 
         Limit groups will be defined as pairs in Nuke deadline submitter
@@ -383,4 +387,4 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
                     if lg_name not in captured_groups:
                         captured_groups.append(lg_name)
 
-        return ",".join(captured_groups)
+        return captured_groups


### PR DESCRIPTION
## Description 
Implementation of the Limits group attribute for submission in the JobInfo Payload attributes.
This feature will secure better handling the nuke plugin licensing when, for example, an user machines are working with Neat Video demo plugin and Render farm workers in a limited number of all workers are fully licensed.

Limit groups will be defined as pairs in Nuke deadline submitter presents where the key will be name of limit group and value will be a list of plugin's node class names. Thus, when a plugin uses more than one node, these will be captured and the triggered process will add the appropriate limit group to the payload jobinfo attributes.

# Testing requirements:
1. go to Deadline Monitor and open Limit panel
![image](https://user-images.githubusercontent.com/40640033/111808960-c9803900-88d4-11eb-955e-d335df2ca7d1.png)

2. crate testing license limit groups
![image](https://user-images.githubusercontent.com/40640033/111809119-ef0d4280-88d4-11eb-8d04-b90908e1d857.png)

3. Add following lines to your `pype-config\presets\plugins\nuke\publish.json`

```json
}
    "NukeSubmitDeadline": {
        "deadline_priority": 50,
        "deadline_pool": "",
        "deadline_pool_secondary": "",
        "deadline_chunk_size": 1,
        "deadline_limit_groups": {
            "test_group": ["Dissolve"],
            "test2_group": ["Noise"]
        }
    }
}
```

4. add Noise node to scene (or to inside any of Group node). Add Dissolve node to scene. Or remove one of the node.