### PR TITLE
Settings raw-json value type

### DIFF
--- a/pype/settings/entities/input_entities.py
+++ b/pype/settings/entities/input_entities.py
@@ -380,12 +380,29 @@ class RawJsonEntity(InputEntity):
 
     def _item_initalization(self):
         # Schema must define if valid value is dict or list
-        self.valid_value_types = (list, dict)
-        self.value_on_not_set = {}
+        is_list = self.schema_data.get("is_list", False)
+        if is_list:
+            valid_value_types = (list, )
+            value_on_not_set = []
+        else:
+            valid_value_types = (dict, )
+            value_on_not_set = {}
+
+        self._is_list = is_list
+        self.valid_value_types = valid_value_types
+        self.value_on_not_set = value_on_not_set
 
         self.default_metadata = {}
         self.studio_override_metadata = {}
         self.project_override_metadata = {}
+
+    @property
+    def is_list(self):
+        return self._is_list
+
+    @property
+    def is_dict(self):
+        return not self._is_list
 
     def set(self, value):
         self._validate_value_type(value)

--- a/pype/settings/entities/schemas/README.md
+++ b/pype/settings/entities/schemas/README.md
@@ -235,13 +235,17 @@
 ### raw-json
 - a little bit enhanced text input for raw json
 - has validations of json format
-    - empty value is invalid value, always must be at least `{}` of `[]`
-
+    - empty value is invalid value, always must be json serializable
+    - valid value types are list `[]` and dictionary `{}`
+- schema also defines valid value type
+    - by default it is dictionary
+    - to be able use list it is required to define `is_list` to `true`
 ```
 {
     "type": "raw-json",
     "key": "profiles",
-    "label": "Extract Review profiles"
+    "label": "Extract Review profiles",
+    "is_list": true
 }
 ```
 

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -274,7 +274,8 @@
                 {
                     "type": "raw-json",
                     "key": "bake_attributes",
-                    "label": "Bake Attributes"
+                    "label": "Bake Attributes",
+                    "is_list": true
                 }
             ]
         },

--- a/pype/tools/settings/settings/widgets/item_widgets.py
+++ b/pype/tools/settings/settings/widgets/item_widgets.py
@@ -366,7 +366,7 @@ class NumberWidget(InputWidget):
 class RawJsonInput(QtWidgets.QPlainTextEdit):
     tab_length = 4
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, valid_type, *args, **kwargs):
         super(RawJsonInput, self).__init__(*args, **kwargs)
         self.setObjectName("RawJsonInput")
         self.setTabStopDistance(
@@ -374,6 +374,7 @@ class RawJsonInput(QtWidgets.QPlainTextEdit):
                 self.font()
             ).horizontalAdvance(" ") * self.tab_length
         )
+        self.valid_type = valid_type
 
     def sizeHint(self):
         document = self.document()
@@ -403,8 +404,8 @@ class RawJsonInput(QtWidgets.QPlainTextEdit):
 
     def has_invalid_value(self):
         try:
-            self.json_value()
-            return False
+            value = self.json_value()
+            return not isinstance(value, self.valid_type)
         except Exception:
             return True
 
@@ -415,7 +416,11 @@ class RawJsonInput(QtWidgets.QPlainTextEdit):
 
 class RawJsonWidget(InputWidget):
     def _add_inputs_to_layout(self):
-        self.input_field = RawJsonInput(self.content_widget)
+        if self.entity.is_list:
+            valid_type = list
+        else:
+            valid_type = dict
+        self.input_field = RawJsonInput(valid_type, self.content_widget)
         self.input_field.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum,
             QtWidgets.QSizePolicy.MinimumExpanding


### PR DESCRIPTION
## Changes
- settings item `raw-json` can define if value is dictionary or list
- added `"is_list"` key to schema which can be `true` or `false` by default is `false`
    - raw json can have 2 value types `dict` and `list` and in most of cases is used `dict` so it seemed to me that it is better to define one of them with boolean value
- modified already existing schema using raw json as list