### PR TITLE
fix(nuke): reverse search to make it more versatile

### DIFF
--- a/pype/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/pype/plugins/nuke/publish/submit_nuke_deadline.py
@@ -378,7 +378,7 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin):
             for node_class in list_node_class:
                 for node in nuke.allNodes(recurseGroups=True):
                     # ignore all nodes not member of defined class
-                    if node.Class() not in node_class:
+                    if node_class not in node.Class():
                         continue
                     # ignore all disabled nodes
                     if node["disable"].value():


### PR DESCRIPTION
The for loop was testing node.Class () in presenting string and so the string would need to be precise. In the case of the plugin update and the node class version change, nothing would be found until the preset changes. But if we flip the search and look for a predefined string within a node.Class () we might make it more versatile by adding a string without version number.