### PR TITLE
Settings exceptions

### DIFF
--- a/pype/settings/entities/__init__.py
+++ b/pype/settings/entities/__init__.py
@@ -96,6 +96,7 @@ from .input_entities import (
 )
 
 from .enum_entity import (
+    BaseEnumEntity,
     EnumEntity,
     AppsEnumEntity,
     ToolsEnumEntity
@@ -141,6 +142,7 @@ __all__ = (
     "PathInput",
     "RawJsonEntity",
 
+    "BaseEnumEntity",
     "EnumEntity",
     "AppsEnumEntity",
     "ToolsEnumEntity",

--- a/pype/settings/entities/dict_immutable_keys_entity.py
+++ b/pype/settings/entities/dict_immutable_keys_entity.py
@@ -15,7 +15,10 @@ from . import (
     BoolEntity,
     GUIEntity
 )
-from .exceptions import SchemaDuplicatedKeys
+from .exceptions import (
+    SchemaDuplicatedKeys,
+    EntitySchemaError
+)
 
 
 class DictImmutableKeysEntity(ItemEntity):
@@ -83,20 +86,21 @@ class DictImmutableKeysEntity(ItemEntity):
             elif child_entity.key not in children_keys:
                 children_keys.add(child_entity.key)
             else:
-                raise SchemaDuplicatedKeys(self.path, child_entity.key)
+                raise SchemaDuplicatedKeys(self, child_entity.key)
 
         if self.checkbox_key:
             checkbox_child = self.non_gui_children.get(self.checkbox_key)
             if not checkbox_child:
-                raise ValueError(
-                    "{}: Checkbox children \"{}\" was not found.".format(
-                        self.path, self.checkbox_key
-                    )
+                reason = "Checkbox children \"{}\" was not found.".format(
+                    self.checkbox_key
                 )
+                raise EntitySchemaError(self, reason)
+
             if not isinstance(checkbox_child, BoolEntity):
-                raise TypeError((
-                    "{}: Checkbox children \"{}\" is not `boolean` type."
-                ).format(self.path, self.checkbox_key))
+                reason = "Checkbox children \"{}\" is not `boolean` type.".format(
+                    self.checkbox_key
+                )
+                raise EntitySchemaError(self, reason)
 
         super(DictImmutableKeysEntity, self).schema_validations()
         # Trigger schema validation on children entities

--- a/pype/settings/entities/dict_immutable_keys_entity.py
+++ b/pype/settings/entities/dict_immutable_keys_entity.py
@@ -97,9 +97,9 @@ class DictImmutableKeysEntity(ItemEntity):
                 raise EntitySchemaError(self, reason)
 
             if not isinstance(checkbox_child, BoolEntity):
-                reason = "Checkbox children \"{}\" is not `boolean` type.".format(
-                    self.checkbox_key
-                )
+                reason = (
+                    "Checkbox children \"{}\" is not `boolean` type."
+                ).format(self.checkbox_key)
                 raise EntitySchemaError(self, reason)
 
         super(DictImmutableKeysEntity, self).schema_validations()

--- a/pype/settings/entities/dict_mutable_keys_entity.py
+++ b/pype/settings/entities/dict_mutable_keys_entity.py
@@ -8,7 +8,8 @@ from . import EndpointEntity
 from .exceptions import (
     DefaultsNotDefined,
     StudioDefaultsNotDefined,
-    RequiredKeyModified
+    RequiredKeyModified,
+    EntitySchemaError
 )
 from pype.settings.constants import (
     METADATA_KEYS,
@@ -213,10 +214,11 @@ class DictMutableKeysEntity(EndpointEntity):
 
         # TODO Ability to store labels should be defined with different key
         if self.collapsible_key and not self.file_item:
-            raise ValueError((
-                "{}: Modifiable dictionary with collapsible keys is not under"
+            reason = (
+                "Modifiable dictionary with collapsible keys is not under"
                 " file item so can't store metadata."
-            ).format(self.path))
+            )
+            raise EntitySchemaError(self, reason)
 
         for child_obj in self.children_by_key.values():
             child_obj.schema_validations()

--- a/pype/settings/entities/enum_entity.py
+++ b/pype/settings/entities/enum_entity.py
@@ -72,8 +72,8 @@ class EnumEntity(InputEntity):
         for item in check_values:
             if item not in self.valid_keys:
                 raise ValueError(
-                    "Invalid value \"{}\". Expected: {}".format(
-                        item, self.valid_keys
+                    "{} Invalid value \"{}\". Expected: {}".format(
+                        self.path, item, self.valid_keys
                     )
                 )
         self._current_value = new_value

--- a/pype/settings/entities/enum_entity.py
+++ b/pype/settings/entities/enum_entity.py
@@ -50,6 +50,8 @@ class EnumEntity(InputEntity):
         if self.multiselection:
             if isinstance(value, (set, tuple)):
                 return list(value)
+        elif isinstance(value, (int, float)):
+            return str(value)
         return NOT_SET
 
     def set(self, value):

--- a/pype/settings/entities/enum_entity.py
+++ b/pype/settings/entities/enum_entity.py
@@ -1,5 +1,8 @@
 from .input_entities import InputEntity
-from .lib import NOT_SET
+from .lib import (
+    NOT_SET,
+    STRING_TYPE
+)
 
 
 class EnumEntity(InputEntity):
@@ -21,13 +24,12 @@ class EnumEntity(InputEntity):
             self.valid_value_types = (list, )
             self.value_on_not_set = []
         else:
-            valid_value_types = set()
             for key in valid_keys:
                 if self.value_on_not_set is NOT_SET:
                     self.value_on_not_set = key
-                valid_value_types.add(type(key))
+                    break
 
-            self.valid_value_types = tuple(valid_value_types)
+            self.valid_value_types = (STRING_TYPE, )
 
         # GUI attribute
         self.placeholder = self.schema_data.get("placeholder")
@@ -40,6 +42,12 @@ class EnumEntity(InputEntity):
                 raise ValueError(
                     "{}: Key \"{}\" is more than once in enum items.".format(
                         self.path, key
+                    )
+                )
+            if not isinstance(key, STRING_TYPE):
+                raise ValueError(
+                    "{}: Key \"{}\" has invalid type {}, expected {}.".format(
+                        self.path, key, type(key), STRING_TYPE
                     )
                 )
             enum_keys.add(key)

--- a/pype/settings/entities/exceptions.py
+++ b/pype/settings/entities/exceptions.py
@@ -38,6 +38,23 @@ class SchemaError(Exception):
     pass
 
 
+class EntitySchemaError(SchemaError):
+    def __init__(self, entity, reason):
+        self.entity = entity
+        self.reason = reason
+        msg = "{} {} - {}".format(entity.__class__, entity.path, reason)
+        super(EntitySchemaError, self).__init__(msg)
+
+
+class SchemeGroupHierarchyBug(EntitySchemaError):
+    def __init__(self, entity):
+        reason = (
+            "Items with attribute \"is_group\" can't have another item with"
+            " \"is_group\" attribute as child."
+        )
+        super(SchemeGroupHierarchyBug, self).__init__(entity, reason)
+
+
 class SchemaMissingFileInfo(SchemaError):
     def __init__(self, invalid):
         full_path_keys = []
@@ -51,22 +68,13 @@ class SchemaMissingFileInfo(SchemaError):
         super(SchemaMissingFileInfo, self).__init__(msg)
 
 
-class SchemeGroupHierarchyBug(SchemaError):
-    def __init__(self, entity_path):
-        msg = (
-            "Items with attribute \"is_group\" can't have another item with"
-            " \"is_group\" attribute as child. Error happened in entity: {}"
-        ).format(entity_path)
-        super(SchemeGroupHierarchyBug, self).__init__(msg)
-
-
 class SchemaDuplicatedKeys(SchemaError):
-    def __init__(self, entity_path, key):
+    def __init__(self, entity, key):
         msg = (
             "Schema item contain duplicated key \"{}\" in"
-            " one hierarchy level. {}"
-        ).format(key, entity_path)
-        super(SchemaDuplicatedKeys, self).__init__(msg)
+            " one hierarchy level."
+        ).format(key)
+        super(SchemaDuplicatedKeys, self).__init__(entity, msg)
 
 
 class SchemaDuplicatedEnvGroupKeys(SchemaError):

--- a/pype/settings/entities/input_entities.py
+++ b/pype/settings/entities/input_entities.py
@@ -369,6 +369,12 @@ class TextEntity(InputEntity):
         self.multiline = self.schema_data.get("multiline", False)
         self.placeholder_text = self.schema_data.get("placeholder")
 
+    def _convert_to_valid_type(self, value):
+        # Allow numbers converted to string
+        if isinstance(value, (int, float)):
+            return str(value)
+        return NOT_SET
+
 
 class PathInput(InputEntity):
     schema_types = ["path-input"]

--- a/pype/settings/entities/input_entities.py
+++ b/pype/settings/entities/input_entities.py
@@ -9,7 +9,8 @@ from .lib import (
 )
 from .exceptions import (
     DefaultsNotDefined,
-    StudioDefaultsNotDefined
+    StudioDefaultsNotDefined,
+    EntitySchemaError
 )
 
 from pype.settings.constants import (
@@ -39,11 +40,10 @@ class EndpointEntity(ItemEntity):
         """Validation of entity schema and schema hierarchy."""
         # Default value when even defaults are not filled must be set
         if self.value_on_not_set is NOT_SET:
-            raise ValueError(
-                "Attribute `value_on_not_set` is not filled. {}".format(
-                    self.__class__.__name__
-                )
+            reason = "Attribute `value_on_not_set` is not filled. {}".format(
+                self.__class__.__name__
             )
+            raise EntitySchemaError(self, reason)
 
         super(EndpointEntity, self).schema_validations()
 
@@ -105,9 +105,7 @@ class InputEntity(EndpointEntity):
     def schema_validations(self):
         # Input entity must have file parent.
         if not self.file_item:
-            raise ValueError(
-                "{}: Missing parent file entity.".format(self.path)
-            )
+            raise EntitySchemaError(self, "Missing parent file entity.")
 
         super(InputEntity, self).schema_validations()
 

--- a/pype/settings/entities/item_entities.py
+++ b/pype/settings/entities/item_entities.py
@@ -5,7 +5,8 @@ from .lib import (
 )
 from .exceptions import (
     DefaultsNotDefined,
-    StudioDefaultsNotDefined
+    StudioDefaultsNotDefined,
+    EntitySchemaError
 )
 from .base_entity import ItemEntity
 
@@ -204,8 +205,8 @@ class ListStrictEntity(ItemEntity):
     def schema_validations(self):
         # List entity must have file parent.
         if not self.file_item and not self.is_file:
-            raise ValueError(
-                "{}: Missing file entity in hierarchy.".format(self.path)
+            raise EntitySchemaError(
+                self, "Missing file entity in hierarchy."
             )
 
         super(ListStrictEntity, self).schema_validations()

--- a/pype/settings/entities/list_entity.py
+++ b/pype/settings/entities/list_entity.py
@@ -9,7 +9,8 @@ from .lib import (
 )
 from .exceptions import (
     DefaultsNotDefined,
-    StudioDefaultsNotDefined
+    StudioDefaultsNotDefined,
+    EntitySchemaError
 )
 
 
@@ -153,16 +154,18 @@ class ListEntity(EndpointEntity):
         super(ListEntity, self).schema_validations()
 
         if self.is_dynamic_item and self.use_label_wrap:
-            raise ValueError(
+            reason = (
                 "`ListWidget` can't have set `use_label_wrap` to True and"
                 " be used as widget at the same time."
             )
+            raise EntitySchemaError(self, reason)
 
         if self.use_label_wrap and not self.label:
-            raise ValueError(
+            reason = (
                 "`ListWidget` can't have set `use_label_wrap` to True and"
                 " not have set \"label\" key at the same time."
             )
+            raise EntitySchemaError(self, reason)
 
         for child_obj in self.children:
             child_obj.schema_validations()

--- a/pype/settings/entities/root_entities.py
+++ b/pype/settings/entities/root_entities.py
@@ -13,6 +13,7 @@ from .lib import (
     get_studio_settings_schema,
     get_project_settings_schema
 )
+from .exceptions import EntitySchemaError
 from pype.settings.constants import (
     SYSTEM_SETTINGS_KEY,
     PROJECT_SETTINGS_KEY,
@@ -145,10 +146,11 @@ class RootEntity(BaseItemEntity):
     def schema_validations(self):
         for child_entity in self.children:
             if child_entity.is_group:
-                raise ValueError((
+                reason = (
                     "Root entity \"{}\" has child with `is_group`"
                     " attribute set to True but root can't save overrides."
-                ).format(self.__class__.__name__))
+                ).format(self.__class__.__name__)
+                raise EntitySchemaError(self, reason)
             child_entity.schema_validations()
 
     def get_entity_from_path(self, path):

--- a/pype/settings/entities/root_entities.py
+++ b/pype/settings/entities/root_entities.py
@@ -175,7 +175,8 @@ class RootEntity(BaseItemEntity):
                 entities.BaseItemEntity,
                 entities.ItemEntity,
                 entities.EndpointEntity,
-                entities.InputEntity
+                entities.InputEntity,
+                entities.BaseEnumEntity
             )
 
             self._loaded_types = {}

--- a/pype/tools/settings/settings/widgets/categories.py
+++ b/pype/tools/settings/settings/widgets/categories.py
@@ -15,7 +15,7 @@ from pype.settings.entities import (
 
     NumberEntity,
     BoolEntity,
-    EnumEntity,
+    BaseEnumEntity,
     TextEntity,
     PathInput,
     RawJsonEntity,
@@ -112,7 +112,7 @@ class SettingsCategoryWidget(QtWidgets.QWidget):
         elif isinstance(entity, RawJsonEntity):
             return RawJsonWidget(*args)
 
-        elif isinstance(entity, EnumEntity):
+        elif isinstance(entity, BaseEnumEntity):
             return EnumeratorWidget(*args)
 
         elif isinstance(entity, PathEntity):


### PR DESCRIPTION
## Changes
- settings entities are not using `ValueError` but `EntitySchemaError` that always shows path of entity and class with reason
- added type of enum item types which must be always string (and it's validation)
- abstracted enum entity to be able differentiate schema validations for `enum`, `enum-apps` and `enum-tools`
- entity `text` can convert value from numbers to string