### PR TITLE
Fix TVPaints usage of pywin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,12 @@ include_files = [
 ]
 
 if sys.platform == "win32":
-    install_requires.append("win32ctypes")
+    install_requires.extend([
+        # `pywin32` packages
+        "win32ctypes",
+        "win32comext",
+        "pythoncom"
+    ])
 
 build_options = dict(
     packages=install_requires,


### PR DESCRIPTION
## Issue
Python's pywin32 module behavior is not the same from code as from build. In build it is not possible to import submodules of `win32com`, reason is that most of them are actually not imported from `win32com` but from `win32comext`, which is handled with python code inside which is not possible in build. Also there are few missing packages of `pywin32` module in setup.py.

## Changes
- specify more packages of pywin32 module

|:black_flag: |this depends on|
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/305|