### PR TITLE
Feature/rename master to hero version

### DIFF
--- a/pype/lib/avalon_context.py
+++ b/pype/lib/avalon_context.py
@@ -40,7 +40,7 @@ def is_latest(representation):
     """
 
     version = avalon.io.find_one({"_id": representation['parent']})
-    if version["type"] == "master_version":
+    if version["type"] == "hero_version":
         return True
 
     # Get highest version under the parent

--- a/pype/modules/sync_server/tray/app.py
+++ b/pype/modules/sync_server/tray/app.py
@@ -784,7 +784,7 @@ class SyncRepresentationModel(QtCore.QAbstractTableModel):
             if context.get("version"):
                 version = "v{:0>3d}".format(context.get("version"))
             else:
-                version = "master"
+                version = "hero"
 
             item = self.SyncRepresentation(
                 repre.get("_id"),

--- a/pype/settings/defaults/project_anatomy/templates.json
+++ b/pype/settings/defaults/project_anatomy/templates.json
@@ -21,9 +21,9 @@
         "path": "{@folder}/{@file}",
         "thumbnail": "{thumbnail_root}/{project[name]}/{_id}_{thumbnail_type}.{ext}"
     },
-    "master": {
-        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/master",
-        "file": "{project[code]}_{asset}_{subset}_master<_{output}><.{frame}>.{ext}",
+    "hero": {
+        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/hero",
+        "file": "{project[code]}_{asset}_{subset}_hero<_{output}><.{frame}>.{ext}",
         "path": "{@folder}/{@file}"
     },
     "delivery": {},

--- a/pype/settings/defaults/project_settings/global.json
+++ b/pype/settings/defaults/project_settings/global.json
@@ -1,6 +1,6 @@
 {
     "publish": {
-        "IntegrateMasterVersion": {
+        "IntegrateHeroVersion": {
             "enabled": true
         },
         "ExtractJpegEXR": {

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_templates.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_anatomy_templates.json
@@ -113,8 +113,8 @@
         },
         {
             "type": "dict",
-            "key": "master",
-            "label": "Master",
+            "key": "hero",
+            "label": "Hero",
             "children": [
                 {
                     "type": "text",

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -8,8 +8,8 @@
             "type": "dict",
             "collapsible": true,
             "checkbox_key": "enabled",
-            "key": "IntegrateMasterVersion",
-            "label": "IntegrateMasterVersion",
+            "key": "IntegrateHeroVersion",
+            "label": "IntegrateHeroVersion",
             "is_group": true,
             "children": [
                 {

--- a/schema/hero_version-1.0.json
+++ b/schema/hero_version-1.0.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
 
-    "title": "pype:master_version-1.0",
-    "description": "Master version of asset",
+    "title": "pype:hero_version-1.0",
+    "description": "Hero version of asset",
 
     "type": "object",
 
@@ -27,14 +27,14 @@
         "schema": {
             "description": "The schema associated with this document",
             "type": "string",
-            "enum": ["avalon-core:master_version-1.0", "pype:master_version-1.0"],
-            "example": "pype:master_version-1.0"
+            "enum": ["avalon-core:hero_version-1.0", "pype:hero_version-1.0"],
+            "example": "pype:hero_version-1.0"
         },
         "type": {
             "description": "The type of document",
             "type": "string",
-            "enum": ["master_version"],
-            "example": "master_version"
+            "enum": ["hero_version"],
+            "example": "hero_version"
         },
         "parent": {
             "description": "Unique identifier to parent document",

--- a/test_localsystem.txt
+++ b/test_localsystem.txt
@@ -1,0 +1,1 @@
+I have run

--- a/test_localsystem.txt
+++ b/test_localsystem.txt
@@ -1,1 +1,0 @@
-I have run


### PR DESCRIPTION
This PR renames `Master` version feature to use more widely acceptable `Hero` version.

Important note is that this will need a corresponding **Patch**, to convert old master publishes in the DB to Hero

|:black_flag: | depends on|
|---|---|
|avalon-core|pypeclub/avalon-core#306