### PR TITLE
Active key for optional plugins

### DIFF
--- a/pype/settings/defaults/project_settings/maya.json
+++ b/pype/settings/defaults/project_settings/maya.json
@@ -169,91 +169,113 @@
         },
         "ValidateColorSets": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshHasOverlappingUVs": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshArnoldAttributes": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshShaderConnections": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshSingleUVSet": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshHasUVs": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshLaminaFaces": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshNonManifold": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshNormalsUnlocked": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshUVSetMap1": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateMeshVerticesHaveEdges": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNoAnimation": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNoNamespace": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNoNullTransforms": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNoUnknownNodes": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNodeNoGhosting": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateShapeDefaultNames": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateShapeRenderStats": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateTransformZero": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateCameraAttributes": {
             "enabled": false,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateAssemblyName": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateAssRelativePaths": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ExtractPlayblast": {
             "capture_preset": {

--- a/pype/settings/defaults/project_settings/nuke.json
+++ b/pype/settings/defaults/project_settings/nuke.json
@@ -30,19 +30,23 @@
         },
         "ValidateOutputResolution": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateGizmo": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateScript": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ValidateNukeWriteBoundingBox": {
             "enabled": true,
-            "optional": true
+            "optional": true,
+            "active": true
         },
         "ExtractThumbnail": {
             "enabled": true,

--- a/pype/settings/entities/schemas/projects_schema/schemas/template_publish_plugin.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/template_publish_plugin.json
@@ -22,6 +22,11 @@
                 "label": "Optional"
             },
             {
+                "type": "boolean",
+                "key": "active",
+                "label": "Active"
+            },
+            {
                 "type": "label",
                 "label": "{docstring}"
             }


### PR DESCRIPTION
## Changes
- plugins with `optional` key also have `active` key to be able define if are turned on/off by default