### PR TITLE
App variant keys

### DIFF
--- a/pype/settings/defaults/system_settings/applications.json
+++ b/pype/settings/defaults/system_settings/applications.json
@@ -253,7 +253,7 @@
             }
         },
         "variants": {
-            "nuke_12.2": {
+            "nuke_12_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.2",
@@ -274,11 +274,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nuke_12.2": []
+                        "nuke_12_2": []
                     }
                 }
             },
-            "nuke_12.0": {
+            "nuke_12_0": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.0",
@@ -299,11 +299,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nuke_12.0": []
+                        "nuke_12_0": []
                     }
                 }
             },
-            "nuke_11.3": {
+            "nuke_11_3": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.3",
@@ -324,11 +324,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nuke_11.3": []
+                        "nuke_11_3": []
                     }
                 }
             },
-            "nuke_11.2": {
+            "nuke_11_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.2",
@@ -347,7 +347,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nuke_11.2": []
+                        "nuke_11_2": []
                     }
                 }
             }
@@ -377,7 +377,7 @@
             }
         },
         "variants": {
-            "nukex_12.2": {
+            "nukex_12_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.2",
@@ -404,11 +404,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukex_12.2": []
+                        "nukex_12_2": []
                     }
                 }
             },
-            "nukex_12.0": {
+            "nukex_12_0": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.0",
@@ -435,11 +435,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukex_12.0": []
+                        "nukex_12_0": []
                     }
                 }
             },
-            "nukex_11.3": {
+            "nukex_11_3": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.3",
@@ -466,11 +466,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukex_11.3": []
+                        "nukex_11_3": []
                     }
                 }
             },
-            "nukex_11.2": {
+            "nukex_11_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.2",
@@ -495,7 +495,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukex_11.2": []
+                        "nukex_11_2": []
                     }
                 }
             }
@@ -527,7 +527,7 @@
             }
         },
         "variants": {
-            "nukestudio_12.2": {
+            "nukestudio_12_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.2",
@@ -554,11 +554,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukestudio_12.2": []
+                        "nukestudio_12_2": []
                     }
                 }
             },
-            "nukestudio_12.0": {
+            "nukestudio_12_0": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.0",
@@ -585,11 +585,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukestudio_12.0": []
+                        "nukestudio_12_0": []
                     }
                 }
             },
-            "nukestudio_11.3": {
+            "nukestudio_11_3": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.3",
@@ -616,11 +616,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukestudio_11.3": []
+                        "nukestudio_11_3": []
                     }
                 }
             },
-            "nukestudio_11.2": {
+            "nukestudio_11_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.2",
@@ -643,7 +643,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "nukestudio_11.2": []
+                        "nukestudio_11_2": []
                     }
                 }
             }
@@ -675,7 +675,7 @@
             }
         },
         "variants": {
-            "hiero_12.2": {
+            "hiero_12_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.2",
@@ -702,11 +702,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "hiero_12.2": []
+                        "hiero_12_2": []
                     }
                 }
             },
-            "hiero_12.0": {
+            "hiero_12_0": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "12.0",
@@ -733,11 +733,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "hiero_12.0": []
+                        "hiero_12_0": []
                     }
                 }
             },
-            "hiero_11.3": {
+            "hiero_11_3": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.3",
@@ -764,11 +764,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "hiero_11.3": []
+                        "hiero_11_3": []
                     }
                 }
             },
-            "hiero_11.2": {
+            "hiero_11_2": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11.2",
@@ -793,7 +793,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "hiero_11.2": []
+                        "hiero_11_2": []
                     }
                 }
             }
@@ -1057,36 +1057,7 @@
             }
         },
         "variants": {
-            "blender_2.90": {
-                "enabled": true,
-                "label": "",
-                "variant_label": "2.90",
-                "icon": "",
-                "executables": {
-                    "windows": [
-                        "C:\\Program Files\\Blender Foundation\\Blender 2.90\\blender.exe"
-                    ],
-                    "darwin": [],
-                    "linux": []
-                },
-                "arguments": {
-                    "windows": [
-                        "--python-use-system-env"
-                    ],
-                    "darwin": [
-                        "--python-use-system-env"
-                    ],
-                    "linux": [
-                        "--python-use-system-env"
-                    ]
-                },
-                "environment": {
-                    "__environment_keys__": {
-                        "blender_2.90": []
-                    }
-                }
-            },
-            "blender_2.83": {
+            "blender_2_83": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "2.83",
@@ -1111,7 +1082,36 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "blender_2.83": []
+                        "blender_2_83": []
+                    }
+                }
+            },
+            "blender_2_90": {
+                "enabled": true,
+                "label": "",
+                "variant_label": "2.90",
+                "icon": "",
+                "executables": {
+                    "windows": [
+                        "C:\\Program Files\\Blender Foundation\\Blender 2.90\\blender.exe"
+                    ],
+                    "darwin": [],
+                    "linux": []
+                },
+                "arguments": {
+                    "windows": [
+                        "--python-use-system-env"
+                    ],
+                    "darwin": [
+                        "--python-use-system-env"
+                    ],
+                    "linux": [
+                        "--python-use-system-env"
+                    ]
+                },
+                "environment": {
+                    "__environment_keys__": {
+                        "blender_2_90": []
                     }
                 }
             }
@@ -1193,7 +1193,7 @@
             }
         },
         "variants": {
-            "tvpaint_Animation 11 (64bits)": {
+            "tvpaint_animation_11_64bit": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11 (64bits)",
@@ -1212,11 +1212,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "tvpaint_Animation 11 (64bits)": []
+                        "tvpaint_animation_11_64bit": []
                     }
                 }
             },
-            "tvpaint_Animation 11 (32bits)": {
+            "tvpaint_animation_11_32bit": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "11 (32bits)",
@@ -1235,7 +1235,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "tvpaint_Animation 11 (32bits)": []
+                        "tvpaint_animation_11_32bit": []
                     }
                 }
             }
@@ -1445,7 +1445,7 @@
             }
         },
         "variants": {
-            "unreal_4.24": {
+            "unreal_4_24": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "4.24",
@@ -1462,7 +1462,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "unreal_4.24": []
+                        "unreal_4_24": []
                     }
                 }
             }
@@ -1476,7 +1476,7 @@
             }
         },
         "variants": {
-            "python_Python 3.7": {
+            "python_python_3_7": {
                 "enabled": true,
                 "label": "Python",
                 "variant_label": "3.7",
@@ -1493,11 +1493,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "python_Python 3.7": []
+                        "python_python_3_7": []
                     }
                 }
             },
-            "python_Python 2.7": {
+            "python_python_2_7": {
                 "enabled": true,
                 "label": "Python",
                 "variant_label": "2.7",
@@ -1514,11 +1514,11 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "python_Python 2.7": []
+                        "python_python_2_7": []
                     }
                 }
             },
-            "terminal_Terminal": {
+            "terminal_terminal": {
                 "enabled": true,
                 "label": "Terminal",
                 "variant_label": "",
@@ -1535,7 +1535,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "terminal_Terminal": []
+                        "terminal_terminal": []
                     }
                 }
             }
@@ -1552,7 +1552,7 @@
             }
         },
         "variants": {
-            "djvview_1.1": {
+            "djvview_1_1": {
                 "enabled": true,
                 "label": "",
                 "variant_label": "1.1",
@@ -1569,7 +1569,7 @@
                 },
                 "environment": {
                     "__environment_keys__": {
-                        "djvview_1.1": []
+                        "djvview_1_1": []
                     }
                 }
             }

--- a/pype/settings/defaults/system_settings/tools.json
+++ b/pype/settings/defaults/system_settings/tools.json
@@ -36,18 +36,18 @@
             }
         },
         "variants": {
-            "mtoa_3.2": {
+            "mtoa_3_2": {
                 "MTOA_VERSION": "3.2",
                 "__environment_keys__": {
-                    "mtoa_3.2": [
+                    "mtoa_3_2": [
                         "MTOA_VERSION"
                     ]
                 }
             },
-            "mtoa_3.1": {
+            "mtoa_3_1": {
                 "MTOA_VERSION": "3.1",
                 "__environment_keys__": {
-                    "mtoa_3.1": [
+                    "mtoa_3_1": [
                         "MTOA_VERSION"
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_aftereffects.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "2020",
-                            "host_name": "aftereffects"
+                            "app_variant_label": "2020",
+                            "app_variant": "2020",
+                            "app_name": "aftereffects"
                         },
                         {
-                            "host_version": "2021",
-                            "host_name": "aftereffects"
+                            "app_variant_label": "2021",
+                            "app_variant": "2021",
+                            "app_name": "aftereffects"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_blender.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "2.90",
-                            "host_name": "blender"
+                            "app_variant_label": "2.83",
+                            "app_variant": "2_83",
+                            "app_name": "blender"
                         },
                         {
-                            "host_version": "2.83",
-                            "host_name": "blender"
+                            "app_variant_label": "2.90",
+                            "app_variant": "2_90",
+                            "app_name": "blender"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_celaction.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_celaction.json
@@ -29,14 +29,16 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "Local",
-                            "host_name": "celation",
+                            "app_variant_label": "Local",
+                            "app_variant": "Local",
+                            "app_name": "celation",
                             "multiplatform": false,
                             "multipath_executables": false
                         },
                         {
-                            "host_version": "Publish",
-                            "host_name": "celation",
+                            "app_variant_label": "Publish",
+                            "app_variant": "Publish",
+                            "app_name": "celation",
                             "multiplatform": false,
                             "multipath_executables": false
                         }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_djv.json
@@ -28,8 +28,9 @@
                     "type": "schema_template",
                     "name": "template_host_variant",
                     "template_data": {
-                        "host_version": "1.1",
-                        "host_name": "djvview"
+                        "app_variant_label": "1.1",
+                        "app_variant": "1_1",
+                        "app_name": "djvview"
                     }
                 }
             ]

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_fusion.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_fusion.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "16",
-                            "host_name": "fusion"
+                            "app_variant_label": "16",
+                            "app_variant": "16",
+                            "app_name": "fusion"
                         },
                         {
-                            "host_version": "9",
-                            "host_name": "fusion"
+                            "app_variant_label": "9",
+                            "app_variant": "9",
+                            "app_name": "fusion"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_harmony.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_harmony.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "20",
-                            "host_name": "harmony"
+                            "app_variant_label": "20",
+                            "app_variant": "20",
+                            "app_name": "harmony"
                         },
                         {
-                            "host_version": "17",
-                            "host_name": "harmony"
+                            "app_variant_label": "17",
+                            "app_variant": "17",
+                            "app_name": "harmony"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_houdini.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "18",
-                            "host_name": "houdini"
+                            "app_variant_label": "18",
+                            "app_variant": "18",
+                            "app_name": "houdini"
                         },
                         {
-                            "host_version": "17",
-                            "host_name": "houdini"
+                            "app_variant_label": "17",
+                            "app_variant": "17",
+                            "app_name": "houdini"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_maya.json
@@ -29,16 +29,19 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "2020",
-                            "host_name": "maya"
+                            "app_variant_label": "2020",
+                            "app_variant": "2020",
+                            "app_name": "maya"
                         },
                         {
-                            "host_version": "2019",
-                            "host_name": "maya"
+                            "app_variant_label": "2019",
+                            "app_variant": "2019",
+                            "app_name": "maya"
                         },
                         {
-                            "host_version": "2018",
-                            "host_name": "maya"
+                            "app_variant_label": "2018",
+                            "app_variant": "2018",
+                            "app_name": "maya"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_mayabatch.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_mayabatch.json
@@ -29,16 +29,19 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "2020",
-                            "host_name": "mayabatch"
+                            "app_variant_label": "2020",
+                            "app_variant": "2020",
+                            "app_name": "mayabatch"
                         },
                         {
-                            "host_version": "2019",
-                            "host_name": "mayabatch"
+                            "app_variant_label": "2019",
+                            "app_variant": "2019",
+                            "app_name": "mayabatch"
                         },
                         {
-                            "host_version": "2018",
-                            "host_name": "mayabatch"
+                            "app_variant_label": "2018",
+                            "app_variant": "2018",
+                            "app_name": "mayabatch"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_photoshop.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_photoshop.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "2020",
-                            "host_name": "photoshop"
+                            "app_variant_label": "2020",
+                            "app_variant": "2020",
+                            "app_name": "photoshop"
                         },
                         {
-                            "host_version": "2021",
-                            "host_name": "photoshop"
+                            "app_variant_label": "2021",
+                            "app_variant": "2021",
+                            "app_name": "photoshop"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_resolve.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_resolve.json
@@ -29,8 +29,9 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "16",
-                            "host_name": "resolve"
+                            "app_variant_label": "16",
+                            "app_variant": "16",
+                            "app_name": "resolve"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_shell.json
@@ -25,16 +25,19 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "Python 3.7",
-                            "host_name": "python"
+                            "app_variant": "python_3_7",
+                            "app_variant_label": "Python 3.7",
+                            "app_name": "python"
                         },
                         {
-                            "host_version": "Python 2.7",
-                            "host_name": "python"
+                            "app_variant": "python_2_7",
+                            "app_variant_label": "Python 2.7",
+                            "app_name": "python"
                         },
                         {
-                            "host_version": "Terminal",
-                            "host_name": "terminal"
+                            "app_variant": "terminal",
+                            "app_variant_label": "Terminal",
+                            "app_name": "terminal"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_tvpaint.json
@@ -29,12 +29,14 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "Animation 11 (64bits)",
-                            "host_name": "tvpaint"
+                            "app_variant_label": "Animation 11 (64bits)",
+                            "app_variant": "animation_11_64bit",
+                            "app_name": "tvpaint"
                         },
                         {
-                            "host_version": "Animation 11 (32bits)",
-                            "host_name": "tvpaint"
+                            "app_variant_label": "Animation 11 (32bits)",
+                            "app_variant": "animation_11_32bit",
+                            "app_name": "tvpaint"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/schema_unreal.json
@@ -29,8 +29,9 @@
                     "name": "template_host_variant",
                     "template_data": [
                         {
-                            "host_version": "4.24",
-                            "host_name": "unreal"
+                            "app_variant": "4_24",
+                            "app_variant_label": "4.24",
+                            "app_name": "unreal"
                         }
                     ]
                 }

--- a/pype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/template_host_variant.json
@@ -7,8 +7,8 @@
     },
     {
         "type": "dict",
-        "key": "{host_name}_{host_version}",
-        "label": "{host_version}",
+        "key": "{app_name}_{app_variant}",
+        "label": "{app_variant_label}",
         "collapsible": true,
         "checkbox_key": "enabled",
         "children": [
@@ -78,7 +78,7 @@
                 "key": "environment",
                 "label": "Environment",
                 "type": "raw-json",
-                "env_group_key": "{host_name}_{host_version}"
+                "env_group_key": "{app_name}_{app_variant}"
             }
         ]
     }

--- a/pype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
+++ b/pype/settings/entities/schemas/system_schema/host_settings/template_nuke.json
@@ -30,24 +30,24 @@
                         "name": "template_host_variant",
                         "template_data": [
                             {
-                                "host_version": "12.2",
-                                "host_name": "{nuke_type}",
-                                "multipath_executables": true
+                                "app_variant": "12_2",
+                                "app_variant_label": "12.2",
+                                "app_name": "{nuke_type}"
                             },
                             {
-                                "host_version": "12.0",
-                                "host_name": "{nuke_type}",
-                                "multipath_executables": true
+                                "app_variant": "12_0",
+                                "app_variant_label": "12.0",
+                                "app_name": "{nuke_type}"
                             },
                             {
-                                "host_version": "11.3",
-                                "host_name": "{nuke_type}",
-                                "multipath_executables": true
+                                "app_variant": "11_3",
+                                "app_variant_label": "11.3",
+                                "app_name": "{nuke_type}"
                             },
                             {
-                                "host_version": "11.2",
-                                "host_name": "{nuke_type}",
-                                "multipath_executables": true
+                                "app_variant": "11_2",
+                                "app_variant_label": "11.2",
+                                "app_name": "{nuke_type}"
                             }
                         ]
                     }


### PR DESCRIPTION
## Changes
- app variant template does not expect `host_version` and `host_name` but `app_name`, `app_variant` and `app_variant_label`
- this way it is possible to define different variant label than variant key
- removed dots from app variants and default tools