### PR TITLE
Remaining active key for optional plugins

### DIFF
--- a/pype/settings/defaults/project_settings/deadline.json
+++ b/pype/settings/defaults/project_settings/deadline.json
@@ -3,6 +3,7 @@
         "MayaSubmitDeadline": {
             "enabled": true,
             "optional": false,
+            "active": true,
             "tile_assembler_plugin": "oiio",
             "use_published": true,
             "asset_dependencies": true,
@@ -12,6 +13,7 @@
         "NukeSubmitDeadline": {
             "enabled": true,
             "optional": false,
+            "active": true,
             "use_published": true,
             "priority": 50,
             "chunk_size": 10,
@@ -23,6 +25,7 @@
         "HarmonySubmitDeadline": {
             "enabled": true,
             "optional": false,
+            "active": true,
             "use_published": true,
             "priority": 50,
             "chunk_size": 10000,
@@ -34,6 +37,7 @@
         "AfterEffectsSubmitDeadline": {
             "enabled": true,
             "optional": false,
+            "active": true,
             "use_published": true,
             "priority": 50,
             "chunk_size": 10000,

--- a/pype/settings/defaults/project_settings/maya.json
+++ b/pype/settings/defaults/project_settings/maya.json
@@ -379,6 +379,7 @@
         "ExtractCameraAlembic": {
             "enabled": true,
             "optional": true,
+            "active": true,
             "bake_attributes": []
         },
         "MayaSubmitDeadline": {

--- a/pype/settings/entities/schemas/projects_schema/schema_project_deadline.json
+++ b/pype/settings/entities/schemas/projects_schema/schema_project_deadline.json
@@ -30,6 +30,11 @@
                             "label": "Optional"
                         },
                         {
+                            "type": "boolean",
+                            "key": "active",
+                            "label": "Active"
+                        },
+                        {
                             "type": "enum",
                             "key": "tile_assembler_plugin",
                             "label": "Tile Assembler Plugin",
@@ -82,6 +87,11 @@
                             "type": "boolean",
                             "key": "optional",
                             "label": "Optional"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "active",
+                            "label": "Active"
                         },
                         {
                             "type": "boolean",
@@ -139,6 +149,11 @@
                         },
                         {
                             "type": "boolean",
+                            "key": "active",
+                            "label": "Active"
+                        },
+                        {
+                            "type": "boolean",
                             "key": "use_published",
                             "label": "Use Published scene"
                         },
@@ -190,6 +205,11 @@
                             "type": "boolean",
                             "key": "optional",
                             "label": "Optional"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "active",
+                            "label": "Active"
                         },
                         {
                             "type": "boolean",

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -272,6 +272,11 @@
                     "label": "Optional"
                 },
                 {
+                    "type": "boolean",
+                    "key": "active",
+                    "label": "Active"
+                },
+                {
                     "type": "raw-json",
                     "key": "bake_attributes",
                     "label": "Bake Attributes",


### PR DESCRIPTION
Changes following PR https://github.com/pypeclub/pype/pull/1186

## Changes
- added `active` key to remaining optional plugins