### PR TITLE
Extract review with resolution

### DIFF
--- a/pype/plugins/publish/extract_review.py
+++ b/pype/plugins/publish/extract_review.py
@@ -757,8 +757,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
         self.log.debug("input_height: `{}`".format(input_height))
 
         # NOTE Setting only one of `width` or `heigth` is not allowed
-        output_width = output_def.get("width")
-        output_height = output_def.get("height")
+        # - settings value can't have None but has value of 0
+        output_width = output_def.get("width") or None
+        output_height = output_def.get("height") or None
         # Use instance resolution if output definition has not set it.
         if output_width is None or output_height is None:
             output_width = temp_data["resolution_width"]

--- a/pype/settings/defaults/project_settings/global.json
+++ b/pype/settings/defaults/project_settings/global.json
@@ -41,7 +41,9 @@
                                     "review",
                                     "ftrack"
                                 ]
-                            }
+                            },
+                            "width": 0,
+                            "height": 0
                         }
                     }
                 }

--- a/pype/settings/entities/input_entities.py
+++ b/pype/settings/entities/input_entities.py
@@ -329,12 +329,15 @@ class NumberEntity(InputEntity):
         self.maximum = self.schema_data.get("maximum", 99999)
         self.decimal = self.schema_data.get("decimal", 0)
 
+        value_on_not_set = self.schema_data.get("default", 0)
         if self.decimal:
             valid_value_types = (float, )
+            value_on_not_set = float(value_on_not_set)
         else:
             valid_value_types = (int, )
+            value_on_not_set = int(value_on_not_set)
         self.valid_value_types = valid_value_types
-        self.value_on_not_set = 0
+        self.value_on_not_set = value_on_not_set
 
     def _convert_to_valid_type(self, value):
         if isinstance(value, str):

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -177,6 +177,29 @@
                                                     "object_type": "text"
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "type": "separator"
+                                        },
+                                        {
+                                            "type": "label",
+                                            "label": "Width and Height must be both set to higher value than 0 else source resolution is used."
+                                        },
+                                        {
+                                            "key": "width",
+                                            "label": "Output width",
+                                            "type": "number",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "maximum": 100000
+                                        },
+                                        {
+                                            "key": "height",
+                                            "label": "Output height",
+                                            "type": "number",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "maximum": 100000
                                         }
                                     ]
                                 }


### PR DESCRIPTION
## Description
- plugin `ExtractReview` does not have possibility to define output resolution for output definition in settings

## Changes
- output definiton has `width` and `height` keys to be able specify resolution
    - values are ignored if one of them is set to `0`
- `number` entity may have defined `default` value
