### PR TITLE
Project plugin paths and envs

### DIFF
--- a/pype/__init__.py
+++ b/pype/__init__.py
@@ -99,20 +99,7 @@ def install():
     pyblish.register_discovery_filter(filter_pyblish_plugins)
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
 
-    # Register project specific plugins
     project_name = os.environ.get("AVALON_PROJECT")
-    if PROJECT_PLUGINS_PATH and project_name:
-        for path in PROJECT_PLUGINS_PATH.split(os.pathsep):
-            if not path:
-                continue
-            plugin_path = os.path.join(path, project_name, "plugins")
-            if os.path.exists(plugin_path):
-                pyblish.register_plugin_path(plugin_path)
-                avalon.register_plugin_path(avalon.Loader, plugin_path)
-                avalon.register_plugin_path(avalon.Creator, plugin_path)
-                avalon.register_plugin_path(
-                    avalon.InventoryAction, plugin_path
-                )
 
     # Register studio specific plugins
     if STUDIO_PLUGINS_PATH and project_name:

--- a/pype/__init__.py
+++ b/pype/__init__.py
@@ -13,8 +13,6 @@ pyblish = avalon = _original_discover = None
 log = logging.getLogger(__name__)
 
 
-PROJECT_PLUGINS_PATH = os.environ.get("PYPE_PROJECT_PLUGINS")
-STUDIO_PLUGINS_PATH = os.environ.get("PYPE_STUDIO_PLUGINS")
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 PLUGINS_DIR = os.path.join(PACKAGE_DIR, "plugins")
 
@@ -100,17 +98,6 @@ def install():
     avalon.register_plugin_path(avalon.Loader, LOAD_PATH)
 
     project_name = os.environ.get("AVALON_PROJECT")
-
-    # Register studio specific plugins
-    if STUDIO_PLUGINS_PATH and project_name:
-        for path in STUDIO_PLUGINS_PATH.split(os.pathsep):
-            if not path:
-                continue
-            if os.path.exists(path):
-                pyblish.register_plugin_path(path)
-                avalon.register_plugin_path(avalon.Loader, path)
-                avalon.register_plugin_path(avalon.Creator, path)
-                avalon.register_plugin_path(avalon.InventoryAction, path)
 
     if project_name:
         anatomy = Anatomy(project_name)

--- a/pype/hosts/celaction/api/cli.py
+++ b/pype/hosts/celaction/api/cli.py
@@ -91,14 +91,9 @@ def main():
     # Registers pype's Global pyblish plugins
     pype.install()
 
-    for path in PUBLISH_PATHS:
-        path = os.path.normpath(path)
-
-        if not os.path.exists(path):
-            continue
-
-        log.info(f"Registering path: {path}")
-        pyblish.api.register_plugin_path(path)
+    if os.path.exists(PUBLISH_PATH):
+        log.info(f"Registering path: {PUBLISH_PATH}")
+        pyblish.api.register_plugin_path(PUBLISH_PATH)
 
     pyblish.api.register_host(publish_host)
 

--- a/pype/hosts/celaction/api/cli.py
+++ b/pype/hosts/celaction/api/cli.py
@@ -102,14 +102,6 @@ def main():
 
     pyblish.api.register_host(publish_host)
 
-    # Register project specific plugins
-    project_name = os.environ["AVALON_PROJECT"]
-    project_plugins_paths = os.getenv("PYPE_PROJECT_PLUGINS", "")
-    for path in project_plugins_paths.split(os.pathsep):
-        plugin_path = os.path.join(path, project_name, "plugins")
-        if os.path.exists(plugin_path):
-            pyblish.api.register_plugin_path(plugin_path)
-
     return publish.show()
 
 

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -81,6 +81,7 @@ from .applications import (
     prepare_host_environments,
     prepare_context_environments,
     get_app_environments_for_context,
+    apply_project_environments_value,
 
     compile_list_of_regexes
 )
@@ -174,6 +175,7 @@ __all__ = [
     "prepare_host_environments",
     "prepare_context_environments",
     "get_app_environments_for_context",
+    "apply_project_environments_value",
 
     "compile_list_of_regexes",
 

--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -941,6 +941,20 @@ def prepare_host_environments(data):
 
 
 def apply_project_environments_value(project_name, env, project_settings=None):
+    """Apply project specific environments on passed environments.
+
+    Args:
+        project_name (str): Name of project for which environemnts should be
+            received.
+        env (dict): Environment values on which project specific environments
+            will be applied.
+        project_settings (dict): Project settings for passed project name.
+            Optional if project settings are already prepared.
+
+    Raises:
+        KeyError: If project settings do not contain keys for project specific
+            environments.
+    """
     import acre
 
     if project_settings is None:

--- a/pype/lib/applications.py
+++ b/pype/lib/applications.py
@@ -940,6 +940,19 @@ def prepare_host_environments(data):
     data["env"].update(final_env)
 
 
+def apply_project_environments_value(project_name, env, project_settings=None):
+    import acre
+
+    if project_settings is None:
+        project_settings = get_project_settings(project_name)
+
+    env_value = project_settings["global"]["project_environments"]
+    if not env_value:
+        return env
+    parsed = acre.parse(env_value)
+    return _merge_env(parsed, env)
+
+
 def prepare_context_environments(data):
     """Modify launch environemnts with context data for launched host.
 
@@ -963,6 +976,12 @@ def prepare_context_environments(data):
             " Launch context does not contain required data."
         )
         return
+
+    # Load project specific environments
+    project_name = project_doc["name"]
+    data["env"] = apply_project_environments_value(
+        project_name, data["env"]
+    )
 
     app = data["app"]
     workdir_data = get_workdir_data(

--- a/pype/settings/defaults/project_settings/global.json
+++ b/pype/settings/defaults/project_settings/global.json
@@ -1,4 +1,9 @@
 {
+    "project_plugins": {
+        "windows": [],
+        "darwin": [],
+        "linux": []
+    },
     "publish": {
         "IntegrateHeroVersion": {
             "enabled": true

--- a/pype/settings/defaults/project_settings/global.json
+++ b/pype/settings/defaults/project_settings/global.json
@@ -4,6 +4,7 @@
         "darwin": [],
         "linux": []
     },
+    "project_environments": {},
     "publish": {
         "IntegrateHeroVersion": {
             "enabled": true

--- a/pype/settings/defaults/system_settings/general.json
+++ b/pype/settings/defaults/system_settings/general.json
@@ -1,11 +1,6 @@
 {
     "studio_name": "Studio name",
     "studio_code": "stu",
-    "project_plugins": {
-        "windows": "convert from \"PYPE_PROJECT_PLUGINS\"",
-        "darwin": "",
-        "linux": ""
-    },
     "studio_soft": {
         "windows": "convert from \"STUDIO_SOFT\"",
         "darwin": "",

--- a/pype/settings/entities/schemas/projects_schema/schema_project_global.json
+++ b/pype/settings/entities/schemas/projects_schema/schema_project_global.json
@@ -22,6 +22,14 @@
         {
             "type": "schema",
             "name": "schema_project_syncserver"
+        },
+        {
+            "key": "project_plugins",
+            "type": "path",
+            "label": "Additional Project Plugin Paths",
+            "multiplatform": true,
+            "multipath": true,
+            "use_label_wrap": true
         }
     ]
 }

--- a/pype/settings/entities/schemas/projects_schema/schema_project_global.json
+++ b/pype/settings/entities/schemas/projects_schema/schema_project_global.json
@@ -30,6 +30,12 @@
             "multiplatform": true,
             "multipath": true,
             "use_label_wrap": true
+        },
+        {
+            "key": "project_environments",
+            "type": "raw-json",
+            "label": "Additional Project Environments (set on application launch)",
+            "use_label_wrap": true
         }
     ]
 }

--- a/pype/settings/entities/schemas/system_schema/schema_general.json
+++ b/pype/settings/entities/schemas/system_schema/schema_general.json
@@ -19,13 +19,6 @@
             "type": "splitter"
         },
         {
-            "key": "project_plugins",
-            "type": "path",
-            "label": "Additional Project Plugins Path",
-            "multiplatform": true,
-            "multipath": false
-        },
-        {
             "key": "studio_soft",
             "type": "path",
             "label": "Studio Software Location",

--- a/pype/tools/standalonepublish/publish.py
+++ b/pype/tools/standalonepublish/publish.py
@@ -19,14 +19,6 @@ def main(env):
             continue
         pyblish.api.register_plugin_path(path)
 
-    # Register project specific plugins
-    project_name = os.environ["AVALON_PROJECT"]
-    project_plugins_paths = env.get("PYPE_PROJECT_PLUGINS") or ""
-    for path in project_plugins_paths.split(os.pathsep):
-        plugin_path = os.path.join(path, project_name, "plugins")
-        if os.path.exists(plugin_path):
-            pyblish.api.register_plugin_path(plugin_path)
-
     return publish.show()
 
 

--- a/pype/tools/standalonepublish/widgets/widget_components.py
+++ b/pype/tools/standalonepublish/widgets/widget_components.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import tempfile
 import random
@@ -10,7 +9,10 @@ from . import DropDataFrame
 from .constants import HOST_NAME
 from avalon import io
 from pype.api import execute, Logger
-from pype.lib import get_pype_execute_args
+from pype.lib import (
+    get_pype_execute_args,
+    apply_project_environments_value
+)
 
 log = Logger().get_logger("standalonepublisher")
 
@@ -208,6 +210,9 @@ def cli_publish(data, publish_paths, gui=True):
     envcopy["PUBLISH_PATHS"] = os.pathsep.join(publish_paths)
     if data.get("family", "").lower() == "editorial":
         envcopy["PYBLISH_SUSPEND_LOGS"] = "1"
+
+    project_name = os.environ["AVALON_PROJECT"]
+    env_copy = apply_project_environments_value(project_name, envcopy)
 
     args = get_pype_execute_args("run", PUBLISH_SCRIPT_PATH)
     result = execute(args, env=envcopy)


### PR DESCRIPTION
## Changes
- removed usage of `PYPE_PROJECT_PLUGINS` and `PYPE_STUDIO_PLUGINS` environments variable
- removed settings item of `PYPE_PROJECT_PLUGINS` from system settings
- added `project_plugins` and `project_environments` keys to project settings under global
    - `project_plugins` can have multiple paths for each platform
    - `project_environments` are set before application launch and before publish in standalone publisher