### PR TITLE
Forwards compatible config

### DIFF
--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -433,8 +433,13 @@ class CustomAttributes(BaseAction):
         tool_usages = self.presets.get("global", {}).get("tools") or {}
         tools_data = []
         for tool_name, usage in tool_usages.items():
-            if usage:
-                tools_data.append({tool_name: tool_name})
+            if not usage or not tool_name:
+                continue
+            # Forward compatibility with Pype 3
+            # - tools have group and variant joined with slash `/`
+            parts = tool_name.split("_")
+            new_name = "/".join([parts[0], tool_name])
+            tools_data.append({new_name: new_name})
 
         # Make sure there is at least one item
         if not tools_data:

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -438,7 +438,12 @@ class CustomAttributes(BaseAction):
             # Forward compatibility with Pype 3
             # - tools have group and variant joined with slash `/`
             parts = tool_name.split("_")
-            new_name = "/".join([parts[0], tool_name])
+            if len(parts) == 1:
+                new_name = "/".join([parts[0], parts[0]])
+            else:
+                tool_group = parts.pop(0)
+                remainder = "_".join(parts)
+                new_name = "/".join([tool_group, remainder])
             tools_data.append({new_name: new_name})
 
         # Make sure there is at least one item

--- a/pype/modules/ftrack/actions/action_create_cust_attrs.py
+++ b/pype/modules/ftrack/actions/action_create_cust_attrs.py
@@ -439,7 +439,8 @@ class CustomAttributes(BaseAction):
             # - tools have group and variant joined with slash `/`
             parts = tool_name.split("_")
             if len(parts) == 1:
-                new_name = "/".join([parts[0], parts[0]])
+                # This will cause incompatible tool name
+                new_name = parts[0]
             else:
                 tool_group = parts.pop(0)
                 remainder = "_".join(parts)


### PR DESCRIPTION
Forwards compatible changes for Pype 3.

## Changes
- tool names in custom attribute are stored with slash, with replacing first underscore
    - this is because tools are stored with slash in Pype 3 where separate tool's group name and tool's variant name (See in [PR](https://github.com/pypeclub/pype/pull/1190) )

## Note
Running **Create/Update Custom Attributes** will cause to loose data about previous tools and applications. We should probably prepare a way how to store their values per entity and reapply after change.

|:black_flag: |this depends on|
|---|---|
|pype-config|https://github.com/pypeclub/pype-config/pull/105|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/307|