### PR TITLE
Bulk mov strict task

### DIFF
--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -29,6 +29,8 @@ from .applications import (
 from .profiles_filtering import filter_profiles
 
 from .plugin_tools import (
+    TaskNotSetError,
+    get_subset_name,
     filter_pyblish_plugins,
     source_hash,
     get_unique_layer_name,
@@ -73,6 +75,8 @@ __all__ = [
 
     "filter_profiles",
 
+    "TaskNotSetError",
+    "get_subset_name",
     "filter_pyblish_plugins",
     "get_unique_layer_name",
     "get_background_layers",

--- a/pype/lib/plugin_tools.py
+++ b/pype/lib/plugin_tools.py
@@ -7,11 +7,98 @@ import re
 import json
 import pype.api
 import tempfile
-
+from . import filter_profiles
 from ..api import config
 
 
 log = logging.getLogger(__name__)
+
+# Subset name template used when plugin does not have defined any
+DEFAULT_SUBSET_TEMPLATE = "{family}{Variant}"
+
+
+class TaskNotSetError(KeyError):
+    """Exception raised when subset name requires task name but is not set."""
+    def __init__(self, msg=None):
+        if not msg:
+            msg = "Creator's subset name template requires task name."
+        super(TaskNotSetError, self).__init__(msg)
+
+
+def get_subset_name(
+    family,
+    variant,
+    task_name,
+    asset_id,
+    project_name=None,
+    host_name=None,
+    default_template=None
+):
+    if not family:
+        return ""
+
+    if not host_name:
+        host_name = os.environ["AVALON_APP"]
+
+    if project_name is None:
+        project_name = os.environ["AVALON_PROJECT"]
+
+    # Use only last part of class family value split by dot (`.`)
+    family = family.rsplit(".", 1)[-1]
+
+    # Get settings
+    profiles = (
+        config.get_presets(project_name)
+        .get("tools", {})
+        .get("creator_subset_name_profiles")
+    ) or []
+    filtering_criteria = {
+        "families": family,
+        "hosts": host_name,
+        "tasks": task_name
+    }
+
+    matching_profile = filter_profiles(profiles, filtering_criteria)
+    template = None
+    if matching_profile:
+        template = matching_profile["template"]
+
+    # Make sure template is set (matching may have empty string)
+    if not template:
+        template = default_template or DEFAULT_SUBSET_TEMPLATE
+
+    # Simple check of task name existence for template with {task} in
+    #   - missing task should be possible only in Standalone publisher
+    if not task_name and "{task" in template.lower():
+        raise TaskNotSetError()
+
+    fill_pairs = (
+        ("variant", variant),
+        ("family", family),
+        ("task", task_name)
+    )
+    fill_data = {}
+    for key, value in fill_pairs:
+        # Handle cases when value is `None` (standalone publisher)
+        if value is None:
+            continue
+        # Keep value as it is
+        fill_data[key] = value
+        # Both key and value are with upper case
+        fill_data[key.upper()] = value.upper()
+
+        # Capitalize only first char of value
+        # - conditions are because of possible index errors
+        capitalized = ""
+        if value:
+            # Upper first character
+            capitalized += value[0].upper()
+            # Append rest of string if there is any
+            if len(value) > 1:
+                capitalized += value[1:]
+        fill_data[key.capitalize()] = capitalized
+
+    return template.format(**fill_data)
 
 
 def filter_pyblish_plugins(plugins):

--- a/pype/plugin.py
+++ b/pype/plugin.py
@@ -4,7 +4,7 @@ import tempfile
 import pyblish.api
 import avalon.api
 from pype.api import config
-from pype.lib import filter_profiles
+from pype.lib import get_subset_name
 
 ValidatePipelineOrder = pyblish.api.ValidatorOrder + 0.05
 ValidateContentsOrder = pyblish.api.ValidatorOrder + 0.1
@@ -38,86 +38,19 @@ def imprint_attributes(plugin):
             print("setting {}: {} on {}".format(option, value, plugin_name))
 
 
-class TaskNotSetError(KeyError):
-    def __init__(self, msg=None):
-        if not msg:
-            msg = "Creator's subset name template requires task name."
-        super(TaskNotSetError, self).__init__(msg)
-
-
 class PypeCreatorMixin:
     """Helper to override avalon's default class methods.
 
     Mixin class must be used as first in inheritance order to override methods.
     """
-    default_tempate = "{family}{Variant}"
 
     @classmethod
     def get_subset_name(
         cls, variant, task_name, asset_id, project_name, host_name=None
     ):
-        if not cls.family:
-            return ""
-
-        if not host_name:
-            host_name = os.environ["AVALON_APP"]
-
-        # Use only last part of class family value split by dot (`.`)
-        family = cls.family.rsplit(".", 1)[-1]
-
-        # Get settings
-        profiles = (
-            config.get_presets(project_name)
-            .get("tools", {})
-            .get("creator_subset_name_profiles")
-        ) or []
-        filtering_criteria = {
-            "families": family,
-            "hosts": host_name,
-            "tasks": task_name
-        }
-
-        matching_profile = filter_profiles(profiles, filtering_criteria)
-        template = None
-        if matching_profile:
-            template = matching_profile["template"]
-
-        # Make sure template is set (matching may have empty string)
-        if not template:
-            template = cls.default_tempate
-
-        # Simple check of task name existence for template with {task} in
-        #   - missing task should be possible only in Standalone publisher
-        if not task_name and "{task" in template.lower():
-            raise TaskNotSetError()
-
-        fill_pairs = (
-            ("variant", variant),
-            ("family", family),
-            ("task", task_name)
+        return get_subset_name(
+            cls.family, variant, task_name, asset_id, project_name, host_name
         )
-        fill_data = {}
-        for key, value in fill_pairs:
-            # Handle cases when value is `None` (standalone publisher)
-            if value is None:
-                continue
-            # Keep value as it is
-            fill_data[key] = value
-            # Both key and value are with upper case
-            fill_data[key.upper()] = value.upper()
-
-            # Capitalize only first char of value
-            # - conditions are because of possible index errors
-            capitalized = ""
-            if value:
-                # Upper first character
-                capitalized += value[0].upper()
-                # Append rest of string if there is any
-                if len(value) > 1:
-                    capitalized += value[1:]
-            fill_data[key.capitalize()] = capitalized
-
-        return template.format(**fill_data)
 
 
 class Creator(PypeCreatorMixin, avalon.api.Creator):

--- a/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
+++ b/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
@@ -31,7 +31,10 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
                 "type": "asset",
                 "name": asset_name
             },
-            {"data.tasks": 1}
+            {
+                "_id": 1,
+                "data.tasks": 1
+            }
         )
         if not asset_doc:
             raise AssertionError((

--- a/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
+++ b/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
@@ -77,6 +77,10 @@ class CollectBulkMovInstances(pyblish.api.InstancePlugin):
             # can be shared across all new created objects
             new_instance.data[key] = copy.deepcopy(value)
 
+        # Add `render_mov_batch` for specific validators
+        if "families" not in new_instance.data:
+            new_instance.data["families"] = []
+        new_instance.data["families"].append("render_mov_batch")
 
         # delete original instance
         context.remove(instance)

--- a/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
+++ b/pype/plugins/standalonepublisher/publish/collect_bulk_mov_instances.py
@@ -3,31 +3,23 @@ import pyblish.api
 from pprint import pformat
 
 
-class CollectBatchInstances(pyblish.api.InstancePlugin):
+class CollectBulkMovInstances(pyblish.api.InstancePlugin):
     """Collect all available instances for batch publish."""
 
-    label = "Collect Batch Instances"
+    label = "Collect Bulk Mov Instances"
     order = pyblish.api.CollectorOrder + 0.489
     hosts = ["standalonepublisher"]
-    families = ["background_batch"]
+    families = ["render_mov_batch"]
 
     # presets
     default_subset_task = {
-        "background_batch": "background"
+        "render_mov_batch": "compositing"
     }
     subsets = {
-        "background_batch": {
-            "backgroundLayout": {
-                "task": "background",
-                "family": "backgroundLayout"
-            },
-            "backgroundComp": {
-                "task": "background",
-                "family": "backgroundComp"
-            },
-            "workfileBackground": {
-                "task": "background",
-                "family": "workfile"
+        "render_mov_batch": {
+            "renderCompositingDefault": {
+                "task": "compositing",
+                "family": "render"
             }
         }
     }

--- a/pype/plugins/standalonepublisher/publish/validate_task_existence.py
+++ b/pype/plugins/standalonepublisher/publish/validate_task_existence.py
@@ -1,0 +1,54 @@
+import collections
+import pyblish.api
+from avalon import io
+
+
+class ValidateTaskExistence(pyblish.api.ContextPlugin):
+    """Validating tasks on instances are filled and existing."""
+
+    label = "Validate Task Existence"
+    order = pyblish.api.ValidatorOrder
+
+    hosts = ["standalonepublisher"]
+    families = ["render_mov_batch"]
+
+    def process(self, context):
+        asset_names = set()
+        for instance in context:
+            asset_names.add(instance.data["asset"])
+
+        asset_docs = io.find(
+            {
+                "type": "asset",
+                "name": {"$in": list(asset_names)}
+            },
+            {"data.tasks": 1}
+        )
+        tasks_by_asset_names = {}
+        for asset_doc in asset_docs:
+            asset_name = asset_doc["name"]
+            asset_tasks = asset_doc.get("data", {}).get("tasks") or {}
+            tasks_by_asset_names[asset_name] = list(asset_tasks.keys())
+
+        missing_tasks = []
+        for instance in context:
+            asset_name = instance.data["asset"]
+            task_name = instance.data["task"]
+            task_names = tasks_by_asset_names.get(asset_name) or []
+            if task_name and task_name in task_names:
+                continue
+            missing_tasks.append((asset_name, task_name))
+
+        # Everything is OK
+        if not missing_tasks:
+            return
+
+        # Raise an exception
+        msg = "Couldn't find task name/s required for publishing.\n{}"
+        pair_msgs = []
+        for missing_pair in missing_tasks:
+            pair_msgs.append(
+                "Asset: \"{}\" Task: \"{}\"".format(*missing_pair)
+            )
+
+        raise AssertionError(msg.format("\n".join(pair_msgs)))

--- a/pype/plugins/standalonepublisher/publish/validate_task_existence.py
+++ b/pype/plugins/standalonepublisher/publish/validate_task_existence.py
@@ -22,7 +22,10 @@ class ValidateTaskExistence(pyblish.api.ContextPlugin):
                 "type": "asset",
                 "name": {"$in": list(asset_names)}
             },
-            {"data.tasks": 1}
+            {
+                "name": 1,
+                "data.tasks": 1
+            }
         )
         tasks_by_asset_names = {}
         for asset_doc in asset_docs:

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -8,7 +8,7 @@ from pype.api import (
     config,
     Creator
 )
-from pype.plugin import TaskNotSetError
+from pype.lib import TaskNotSetError
 from avalon.tools.creator.app import SubsetAllowedSymbols
 
 


### PR DESCRIPTION
## Changes
- `get_subset_name` logic moved from `PypeCreatorMixin` to pype.lib
    - gives ability to use it anywhere
- separated logic of creating new instances for for batch and bulk mov publishing
    - this is to not break PSD batch publishing while bulk mov must be fixed
    - bulk mov was simplified and has ability to se multiple task names that are checked to be set
- Bulk mov publishing is using the moved function `get_subset_name` to create subset name of renders
- added validation of task name existence on asset document