### PR TITLE
Pype 3: modules path unification in zips/dirs

### DIFF
--- a/igniter/tools.py
+++ b/igniter/tools.py
@@ -6,6 +6,7 @@ Functions ``compose_url()`` and ``decompose_url()`` are the same as in
 version is decided.
 
 """
+import sys
 from typing import Dict, Union
 from urllib.parse import urlparse, parse_qs
 from pathlib import Path
@@ -244,6 +245,10 @@ def get_pype_path_from_db(url: str) -> Union[str, None]:
 
     try:
         client = MongoClient(**mongo_args)
+    except ServerSelectionTimeoutError as e:
+        print("!!! Can't connect to mongodb database server.")
+        print("!!! {}".format(e))
+        return None
     except Exception:
         return None
 

--- a/start.py
+++ b/start.py
@@ -100,6 +100,8 @@ import subprocess
 import site
 from pathlib import Path
 
+from pymongo.errors import ServerSelectionTimeoutError
+
 # add dependencies folder to sys.pat for frozen code
 if getattr(sys, 'frozen', False):
     frozen_libs = os.path.normpath(
@@ -569,7 +571,13 @@ def boot():
 
     # Get Pype path from database and set it to environment so Pype can
     # find its versions there and bootstrap them.
-    pype_path = get_pype_path_from_db(pype_mongo)
+    try:
+        pype_path = get_pype_path_from_db(pype_mongo)
+    except ServerSelectionTimeoutError as e:
+        print("!!! Can't connect to mongodb database server.")
+        print("!!! {}".format(e))
+        sys.exit(1)
+
     if not os.getenv("PYPE_PATH") and pype_path:
         os.environ["PYPE_PATH"] = pype_path
 

--- a/start.py
+++ b/start.py
@@ -100,7 +100,6 @@ import subprocess
 import site
 from pathlib import Path
 
-from pymongo.errors import ServerSelectionTimeoutError
 
 # add dependencies folder to sys.pat for frozen code
 if getattr(sys, 'frozen', False):
@@ -327,12 +326,11 @@ def _initialize_environment(pype_version: PypeVersion) -> None:
     # to same hierarchy from code and from frozen pype
     additional_paths = [
         # add pype tools
-        os.path.join(os.environ["PYPE_ROOT"], "pype", "pype", "tools"),
+        os.path.join(os.environ["PYPE_ROOT"], "pype", "tools"),
         # add common pype vendor
         # (common for multiple Python interpreter versions)
         os.path.join(
             os.environ["PYPE_ROOT"],
-            "pype",
             "pype",
             "vendor",
             "python",
@@ -571,12 +569,10 @@ def boot():
 
     # Get Pype path from database and set it to environment so Pype can
     # find its versions there and bootstrap them.
-    try:
-        pype_path = get_pype_path_from_db(pype_mongo)
-    except ServerSelectionTimeoutError as e:
-        print("!!! Can't connect to mongodb database server.")
-        print("!!! {}".format(e))
-        sys.exit(1)
+
+    pype_path = get_pype_path_from_db(pype_mongo)
+    if not pype_path:
+        print("*** Cannot get Pype path from database.")
 
     if not os.getenv("PYPE_PATH") and pype_path:
         os.environ["PYPE_PATH"] = pype_path

--- a/tests/igniter/test_bootstrap_repos.py
+++ b/tests/igniter/test_bootstrap_repos.py
@@ -150,9 +150,9 @@ def test_install_live_repos(fix_bootstrap, printer):
     pype_version = fix_bootstrap.create_version_from_live_code()
     sep = os.path.sep
     expected_paths = [
-        f"{pype_version.path}{sep}avalon-core",
-        f"{pype_version.path}{sep}avalon-unreal-integration",
-        f"{pype_version.path}{sep}pype"
+        f"{pype_version.path}{sep}repos{sep}avalon-core",
+        f"{pype_version.path}{sep}repos{sep}avalon-unreal-integration",
+        f"{pype_version.path}"
     ]
     printer("testing zip creation")
     assert os.path.exists(pype_version.path), "zip archive was not created"
@@ -165,10 +165,9 @@ def test_install_live_repos(fix_bootstrap, printer):
     import pype  # noqa: F401
 
     # test if pype is imported from specific location in zip
-    print(pype.__file__)
     assert "pype" in sys.modules.keys(), "Pype not imported"
     assert sys.modules["pype"].__file__ == \
-        f"{pype_version.path}{sep}pype{sep}pype{sep}__init__.py"
+        f"{pype_version.path}{sep}pype{sep}__init__.py"
 
 
 def test_find_pype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
@@ -252,7 +251,7 @@ def test_find_pype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
     def _create_valid_zip(path: Path, version: str):
         with ZipFile(path, "w") as zf:
             zf.writestr(
-                "pype/pype/version.py", f"__version__ = '{version}'\n\n")
+                "pype/version.py", f"__version__ = '{version}'\n\n")
 
     def _create_invalid_dir(path: Path):
         path.mkdir(parents=True, exist_ok=True)
@@ -260,7 +259,7 @@ def test_find_pype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
             fp.write("invalid")
 
     def _create_valid_dir(path: Path, version: str):
-        pype_path = path / "pype" / "pype"
+        pype_path = path / "pype"
         version_path = pype_path / "version.py"
         pype_path.mkdir(parents=True, exist_ok=True)
         with open(version_path, "w") as fp:

--- a/tests/igniter/test_bootstrap_repos.py
+++ b/tests/igniter/test_bootstrap_repos.py
@@ -145,18 +145,18 @@ def test_search_string_for_pype_version(printer):
         assert PypeVersion.version_in_str(ver_string[0])[0] == ver_string[1]
 
 
+@pytest.mark.slow
 def test_install_live_repos(fix_bootstrap, printer):
-    rf = fix_bootstrap.create_version_from_live_code()
+    pype_version = fix_bootstrap.create_version_from_live_code()
     sep = os.path.sep
     expected_paths = [
-        f"{rf}{sep}avalon-core",
-        f"{rf}{sep}avalon-unreal-integration",
-        f"{rf}{sep}maya-look-assigner",
-        f"{rf}{sep}pype"
+        f"{pype_version.path}{sep}avalon-core",
+        f"{pype_version.path}{sep}avalon-unreal-integration",
+        f"{pype_version.path}{sep}pype"
     ]
     printer("testing zip creation")
-    assert os.path.exists(rf), "zip archive was not created"
-    fix_bootstrap.add_paths_from_archive(rf)
+    assert os.path.exists(pype_version.path), "zip archive was not created"
+    fix_bootstrap.add_paths_from_archive(pype_version.path)
     for ep in expected_paths:
         assert ep in sys.path, f"{ep} not set correctly"
 
@@ -168,7 +168,7 @@ def test_install_live_repos(fix_bootstrap, printer):
     print(pype.__file__)
     assert "pype" in sys.modules.keys(), "Pype not imported"
     assert sys.modules["pype"].__file__ == \
-        f"{rf}{sep}pype{sep}pype{sep}__init__.py"
+        f"{pype_version.path}{sep}pype{sep}pype{sep}__init__.py"
 
 
 def test_find_pype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):

--- a/tests/igniter/test_tools.py
+++ b/tests/igniter/test_tools.py
@@ -10,7 +10,3 @@ def test_validate_path_string(tmp_path):
     status2, _ = validate_path_string("booo" + str(uuid4()))
     assert status2 is False
 
-    # todo: change when Pype token is implemented
-    status3, reason = validate_path_string(str(uuid4()))
-    assert status3 is False
-    assert reason == "Not implemented yet"

--- a/tools/run_mongo.ps1
+++ b/tools/run_mongo.ps1
@@ -37,37 +37,37 @@ function Exit-WithCode($exitcode) {
 
 
 function Find-Mongo {
-  Write-Host ">>> " -NoNewLine -ForegroundColor Green
-  Write-Host "Detecting MongoDB ... " -NoNewline
-  if (-not (Get-Command "mongod" -ErrorAction SilentlyContinue)) {
-    if(Test-Path 'C:\Program Files\MongoDB\Server\*\bin\mongod.exe' -PathType Leaf) {
-      # we have mongo server installed on standard Windows location
-      # so we can inject it to the PATH. We'll use latest version available.
-      $mongoVersions = Get-ChildItem -Directory 'C:\Program Files\MongoDB\Server' | Sort-Object -Property {$_.Name -as [int]}
-      if(Test-Path "$($mongoVersions[-1])\bin\mongod.exe" -PathType Leaf) {
-        $env:PATH="$($env:PATH);$($mongoVersions[-1])\bin\"
-        Write-Host "OK" -ForegroundColor Green
-        Write-Host "  - auto-added from [ " -NoNewline
-        Write-Host "$($mongoVersions[-1])\bin\" -NoNewLine -ForegroundColor Cyan
-        Write-Host " ]"
-      } else {
-          Write-Host "FAILED " -NoNewLine -ForegroundColor Red
-          Write-Host "MongoDB not detected" -ForegroundColor Yellow
-          Write-Host "Tried to find it on standard location " -NoNewline -ForegroundColor Gray
-          Write-Host " [ " -NoNewline -ForegroundColor Cyan
-          Write-Host "$($mongoVersions[-1])\bin\" -NoNewline -ForegroundColor White
-          Write-Host " ] " -NonNewLine -ForegroundColor Cyan
-          Write-Host "but failed." -ForegroundColor Gray
-          Exit-WithCode 1
-      }
+    $defaultPath = "C:\Program Files\MongoDB\Server"
+    Write-Host ">>> " -NoNewLine -ForegroundColor Green
+    Write-Host "Detecting MongoDB ... " -NoNewline
+    if (-not (Get-Command "mongod" -ErrorAction SilentlyContinue)) {
+        if(Test-Path "$($defaultPath)\*\bin\mongod.exe" -PathType Leaf) {
+        # we have mongo server installed on standard Windows location
+        # so we can inject it to the PATH. We'll use latest version available.
+        $mongoVersions = Get-ChildItem -Directory 'C:\Program Files\MongoDB\Server' | Sort-Object -Property {$_.Name -as [int]}
+        if(Test-Path "$($defaultPath)\$($mongoVersions[-1])\bin\mongod.exe" -PathType Leaf) {
+            $env:PATH="$($env:PATH);$($defaultPath)\$($mongoVersions[-1])\bin\"
+            Write-Host "OK" -ForegroundColor Green
+            Write-Host "  - auto-added from [ " -NoNewline
+            Write-Host "$($defaultPath)\$($mongoVersions[-1])\bin\" -NoNewLine -ForegroundColor Cyan
+            Write-Host " ]"
+        } else {
+            Write-Host "FAILED " -NoNewLine -ForegroundColor Red
+            Write-Host "MongoDB not detected" -ForegroundColor Yellow
+            Write-Host "Tried to find it on standard location " -NoNewline -ForegroundColor Gray
+            Write-Host " [ " -NoNewline -ForegroundColor Cyan
+            Write-Host "$($defaultPath)\$($mongoVersions[-1])\bin\" -NoNewline -ForegroundColor White
+            Write-Host " ] " -NonNewLine -ForegroundColor Cyan
+            Write-Host "but failed." -ForegroundColor Gray
+            Exit-WithCode 1
+        }
     } else {
-      Write-Host "FAILED " -NoNewLine -ForegroundColor Red
-      Write-Host "MongoDB not detected in PATH" -ForegroundColor Yellow
-      Exit-WithCode 1
+        Write-Host "FAILED " -NoNewLine -ForegroundColor Red
+        Write-Host "MongoDB not detected in PATH" -ForegroundColor Yellow
+        Exit-WithCode 1
     }
-
   } else {
-    Write-Host "OK" -ForegroundColor Green
+        Write-Host "OK" -ForegroundColor Green
   }
   <#
   .SYNOPSIS
@@ -90,4 +90,7 @@ $dbpath = (Get-Item $pype_root).parent.FullName + "\mongo_db_data"
 
 Find-Mongo
 $mongo = Get-Command "mongod" | Select-Object -ExpandProperty Definition
-Start-Process -FilePath $mongo "--dbpath $($dbpath) --port $($port)"
+$process = Start-Process -FilePath $mongo "--dbpath $($dbpath) --port $($port)" -PassThru -NoNewWindow -Wait
+$process.WaitForExit()
+Start-Process PowerShell -NoNewWindow -Wait
+

--- a/tools/run_mongo.ps1
+++ b/tools/run_mongo.ps1
@@ -45,19 +45,20 @@ function Find-Mongo {
         # we have mongo server installed on standard Windows location
         # so we can inject it to the PATH. We'll use latest version available.
         $mongoVersions = Get-ChildItem -Directory 'C:\Program Files\MongoDB\Server' | Sort-Object -Property {$_.Name -as [int]}
-        if(Test-Path "$($defaultPath)\$($mongoVersions[-1])\bin\mongod.exe" -PathType Leaf) {
-            $env:PATH="$($env:PATH);$($defaultPath)\$($mongoVersions[-1])\bin\"
+        if(Test-Path "$($mongoVersions[-1])\bin\mongod.exe" -PathType Leaf) {
+            $env:PATH = "$($env:PATH);$($mongoVersions[-1])\bin\"
             Write-Host "OK" -ForegroundColor Green
             Write-Host "  - auto-added from [ " -NoNewline
-            Write-Host "$($defaultPath)\$($mongoVersions[-1])\bin\" -NoNewLine -ForegroundColor Cyan
+            Write-Host "$($mongoVersions[-1])\bin\mongod.exe" -NoNewLine -ForegroundColor Cyan
             Write-Host " ]"
+            return "$($mongoVersions[-1])\bin\mongod.exe"
         } else {
             Write-Host "FAILED " -NoNewLine -ForegroundColor Red
             Write-Host "MongoDB not detected" -ForegroundColor Yellow
             Write-Host "Tried to find it on standard location " -NoNewline -ForegroundColor Gray
             Write-Host " [ " -NoNewline -ForegroundColor Cyan
-            Write-Host "$($defaultPath)\$($mongoVersions[-1])\bin\" -NoNewline -ForegroundColor White
-            Write-Host " ] " -NonNewLine -ForegroundColor Cyan
+            Write-Host "$($mongoVersions[-1])\bin\mongod.exe" -NoNewline -ForegroundColor White
+            Write-Host " ] " -NoNewLine -ForegroundColor Cyan
             Write-Host "but failed." -ForegroundColor Gray
             Exit-WithCode 1
         }
@@ -68,6 +69,7 @@ function Find-Mongo {
     }
   } else {
         Write-Host "OK" -ForegroundColor Green
+        return Get-Command "mongod" -ErrorAction SilentlyContinue
   }
   <#
   .SYNOPSIS
@@ -88,9 +90,7 @@ $port = 2707
 # path to database
 $dbpath = (Get-Item $pype_root).parent.FullName + "\mongo_db_data"
 
-Find-Mongo
-$mongo = Get-Command "mongod" | Select-Object -ExpandProperty Definition
-$process = Start-Process -FilePath $mongo "--dbpath $($dbpath) --port $($port)" -PassThru -NoNewWindow -Wait
-$process.WaitForExit()
-Start-Process PowerShell -NoNewWindow -Wait
+$mongoPath = Find-Mongo
+Start-Process -FilePath $mongopath "--dbpath $($dbpath) --port $($port)" -PassThru
+
 


### PR DESCRIPTION
## Feature

This PR is unifying paths to repositories (submodules) to be the same as in live source code - *avalon-core* and others are now again in repos and module depth is same as in live code so relative paths to Pype parts are identical.