### PR TITLE
Bulk mov strict task

### DIFF
--- a/pype/hosts/standalonepublisher/plugins/publish/collect_batch_instances.py
+++ b/pype/hosts/standalonepublisher/plugins/publish/collect_batch_instances.py
@@ -9,12 +9,11 @@ class CollectBatchInstances(pyblish.api.InstancePlugin):
     label = "Collect Batch Instances"
     order = pyblish.api.CollectorOrder + 0.489
     hosts = ["standalonepublisher"]
-    families = ["background_batch", "render_mov_batch"]
+    families = ["background_batch"]
 
     # presets
     default_subset_task = {
-        "background_batch": "background",
-        "render_mov_batch": "compositing"
+        "background_batch": "background"
     }
     subsets = {
         "background_batch": {
@@ -29,12 +28,6 @@ class CollectBatchInstances(pyblish.api.InstancePlugin):
             "workfileBackground": {
                 "task": "background",
                 "family": "workfile"
-            }
-        },
-        "render_mov_batch": {
-            "renderCompositingDefault": {
-                "task": "compositing",
-                "family": "render"
             }
         }
     }

--- a/pype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
+++ b/pype/hosts/standalonepublisher/plugins/publish/collect_bulk_mov_instances.py
@@ -1,0 +1,98 @@
+import copy
+import json
+import pyblish.api
+
+from avalon import io
+from pype.lib import get_subset_name
+
+
+class CollectBulkMovInstances(pyblish.api.InstancePlugin):
+    """Collect all available instances for batch publish."""
+
+    label = "Collect Bulk Mov Instances"
+    order = pyblish.api.CollectorOrder + 0.489
+    hosts = ["standalonepublisher"]
+    families = ["render_mov_batch"]
+
+    new_instance_family = "render"
+    instance_task_names = [
+        "compositing",
+        "comp"
+    ]
+    default_task_name = "compositing"
+    subset_name_variant = "Default"
+
+    def process(self, instance):
+        context = instance.context
+        asset_name = instance.data["asset"]
+
+        asset_doc = io.find_one(
+            {
+                "type": "asset",
+                "name": asset_name
+            },
+            {
+                "_id": 1,
+                "data.tasks": 1
+            }
+        )
+        if not asset_doc:
+            raise AssertionError((
+                "Couldn't find Asset document with name \"{}\""
+            ).format(asset_name))
+
+        available_task_names = {}
+        asset_tasks = asset_doc.get("data", {}).get("tasks") or {}
+        for task_name in asset_tasks.keys():
+            available_task_names[task_name.lower()] = task_name
+
+        task_name = self.default_task_name
+        for _task_name in self.instance_task_names:
+            _task_name_low = _task_name.lower()
+            if _task_name_low in available_task_names:
+                task_name = available_task_names[_task_name_low]
+                break
+
+        subset_name = get_subset_name(
+            self.new_instance_family,
+            self.subset_name_variant,
+            task_name,
+            asset_doc["_id"],
+            io.Session["AVALON_PROJECT"]
+        )
+        instance_name = f"{asset_name}_{subset_name}"
+
+        # create new instance
+        new_instance = context.create_instance(instance_name)
+        new_instance_data = {
+            "name": instance_name,
+            "label": instance_name,
+            "family": self.new_instance_family,
+            "subset": subset_name,
+            "task": task_name
+        }
+        new_instance.data.update(new_instance_data)
+        # add original instance data except name key
+        for key, value in instance.data.items():
+            if key in new_instance_data:
+                continue
+            # Make sure value is copy since value may be object which
+            # can be shared across all new created objects
+            new_instance.data[key] = copy.deepcopy(value)
+
+        # Add `render_mov_batch` for specific validators
+        if "families" not in new_instance.data:
+            new_instance.data["families"] = []
+        new_instance.data["families"].append("render_mov_batch")
+
+        # delete original instance
+        context.remove(instance)
+
+        self.log.info(f"Created new instance: {instance_name}")
+
+        def convertor(value):
+            return str(value)
+
+        self.log.debug("Instance data: {}".format(
+            json.dumps(new_instance.data, indent=4, default=convertor)
+        ))

--- a/pype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
+++ b/pype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
@@ -1,4 +1,3 @@
-import collections
 import pyblish.api
 from avalon import io
 

--- a/pype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
+++ b/pype/hosts/standalonepublisher/plugins/publish/validate_task_existence.py
@@ -1,0 +1,57 @@
+import collections
+import pyblish.api
+from avalon import io
+
+
+class ValidateTaskExistence(pyblish.api.ContextPlugin):
+    """Validating tasks on instances are filled and existing."""
+
+    label = "Validate Task Existence"
+    order = pyblish.api.ValidatorOrder
+
+    hosts = ["standalonepublisher"]
+    families = ["render_mov_batch"]
+
+    def process(self, context):
+        asset_names = set()
+        for instance in context:
+            asset_names.add(instance.data["asset"])
+
+        asset_docs = io.find(
+            {
+                "type": "asset",
+                "name": {"$in": list(asset_names)}
+            },
+            {
+                "name": 1,
+                "data.tasks": 1
+            }
+        )
+        tasks_by_asset_names = {}
+        for asset_doc in asset_docs:
+            asset_name = asset_doc["name"]
+            asset_tasks = asset_doc.get("data", {}).get("tasks") or {}
+            tasks_by_asset_names[asset_name] = list(asset_tasks.keys())
+
+        missing_tasks = []
+        for instance in context:
+            asset_name = instance.data["asset"]
+            task_name = instance.data["task"]
+            task_names = tasks_by_asset_names.get(asset_name) or []
+            if task_name and task_name in task_names:
+                continue
+            missing_tasks.append((asset_name, task_name))
+
+        # Everything is OK
+        if not missing_tasks:
+            return
+
+        # Raise an exception
+        msg = "Couldn't find task name/s required for publishing.\n{}"
+        pair_msgs = []
+        for missing_pair in missing_tasks:
+            pair_msgs.append(
+                "Asset: \"{}\" Task: \"{}\"".format(*missing_pair)
+            )
+
+        raise AssertionError(msg.format("\n".join(pair_msgs)))

--- a/pype/lib/__init__.py
+++ b/pype/lib/__init__.py
@@ -89,6 +89,8 @@ from .applications import (
 from .profiles_filtering import filter_profiles
 
 from .plugin_tools import (
+    TaskNotSetError,
+    get_subset_name,
     filter_pyblish_plugins,
     source_hash,
     get_unique_layer_name,
@@ -181,6 +183,8 @@ __all__ = [
 
     "filter_profiles",
 
+    "TaskNotSetError",
+    "get_subset_name",
     "filter_pyblish_plugins",
     "source_hash",
     "get_unique_layer_name",

--- a/pype/plugin.py
+++ b/pype/plugin.py
@@ -2,8 +2,8 @@ import tempfile
 import os
 import pyblish.api
 import avalon.api
-from pype.api import get_project_settings
-from pype.lib import filter_profiles
+
+from pype.lib import get_subset_name
 
 ValidatePipelineOrder = pyblish.api.ValidatorOrder + 0.05
 ValidateContentsOrder = pyblish.api.ValidatorOrder + 0.1
@@ -11,83 +11,19 @@ ValidateSceneOrder = pyblish.api.ValidatorOrder + 0.2
 ValidateMeshOrder = pyblish.api.ValidatorOrder + 0.3
 
 
-class TaskNotSetError(KeyError):
-    def __init__(self, msg=None):
-        if not msg:
-            msg = "Creator's subset name template requires task name."
-        super(TaskNotSetError, self).__init__(msg)
-
-
 class PypeCreatorMixin:
     """Helper to override avalon's default class methods.
 
     Mixin class must be used as first in inheritance order to override methods.
     """
-    default_tempate = "{family}{Variant}"
 
     @classmethod
     def get_subset_name(
         cls, variant, task_name, asset_id, project_name, host_name=None
     ):
-        if not cls.family:
-            return ""
-
-        if not host_name:
-            host_name = os.environ["AVALON_APP"]
-
-        # Use only last part of class family value split by dot (`.`)
-        family = cls.family.rsplit(".", 1)[-1]
-
-        # Get settings
-        tools_settings = get_project_settings(project_name)["global"]["tools"]
-        profiles = tools_settings["creator"]["subset_name_profiles"]
-        filtering_criteria = {
-            "families": family,
-            "hosts": host_name,
-            "tasks": task_name
-        }
-
-        matching_profile = filter_profiles(profiles, filtering_criteria)
-        template = None
-        if matching_profile:
-            template = matching_profile["template"]
-
-        # Make sure template is set (matching may have empty string)
-        if not template:
-            template = cls.default_tempate
-
-        # Simple check of task name existence for template with {task} in
-        #   - missing task should be possible only in Standalone publisher
-        if not task_name and "{task" in template.lower():
-            raise TaskNotSetError()
-
-        fill_pairs = (
-            ("variant", variant),
-            ("family", family),
-            ("task", task_name)
+        return get_subset_name(
+            cls.family, variant, task_name, asset_id, project_name, host_name
         )
-        fill_data = {}
-        for key, value in fill_pairs:
-            # Handle cases when value is `None` (standalone publisher)
-            if value is None:
-                continue
-            # Keep value as it is
-            fill_data[key] = value
-            # Both key and value are with upper case
-            fill_data[key.upper()] = value.upper()
-
-            # Capitalize only first char of value
-            # - conditions are because of possible index errors
-            capitalized = ""
-            if value:
-                # Upper first character
-                capitalized += value[0].upper()
-                # Append rest of string if there is any
-                if len(value) > 1:
-                    capitalized += value[1:]
-            fill_data[key.capitalize()] = capitalized
-
-        return template.format(**fill_data)
 
 
 class Creator(PypeCreatorMixin, avalon.api.Creator):

--- a/pype/tools/standalonepublish/widgets/widget_family.py
+++ b/pype/tools/standalonepublish/widgets/widget_family.py
@@ -9,7 +9,7 @@ from pype.api import (
     get_project_settings,
     Creator
 )
-from pype.plugin import TaskNotSetError
+from pype.lib import TaskNotSetError
 from avalon.tools.creator.app import SubsetAllowedSymbols
 
 


### PR DESCRIPTION
Pype 3 version of PR https://github.com/pypeclub/pype/pull/1204

## Changes
- `get_subset_name` logic moved from `PypeCreatorMixin` to pype.lib
    - gives ability to use it anywhere
- separated logic of creating new instances for for batch and bulk mov publishing
    - this is to not break PSD batch publishing while bulk mov must be fixed
    - bulk mov was simplified and has ability to se multiple task names that are checked to be set
- Bulk mov publishing is using the moved function `get_subset_name` to create subset name of renders
- added validation of task name existence on asset document

## Question
- add settings for standalone published (not only these new but all relevant)