### PR TITLE
Fix - modified path of plugin loads for Harmony and TVPaint

### DIFF
--- a/pype/plugins/harmony/create/create_farm_render.py
+++ b/pype/plugins/harmony/create/create_farm_render.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Create Composite node for render on farm."""
 from avalon import harmony
-from pype.hosts.harmony.api import plugin
+from pype.hosts.harmony import plugin
 
 
 class CreateFarmRender(plugin.Creator):

--- a/pype/plugins/harmony/create/create_render.py
+++ b/pype/plugins/harmony/create/create_render.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Create render node."""
 from avalon import harmony
-from pype.hosts.harmony.api import plugin
+from pype.hosts.harmony import plugin
 
 
 class CreateRender(plugin.Creator):

--- a/pype/plugins/harmony/create/create_template.py
+++ b/pype/plugins/harmony/create/create_template.py
@@ -1,5 +1,5 @@
 from avalon import harmony
-from pype.hosts.harmony.api import plugin
+from pype.hosts.harmony import plugin
 
 
 class CreateTemplate(plugin.Creator):

--- a/pype/plugins/tvpaint/create/create_render_layer.py
+++ b/pype/plugins/tvpaint/create/create_render_layer.py
@@ -1,5 +1,5 @@
 from avalon.tvpaint import pipeline, lib
-from pype.hosts.tvpaint.api import plugin
+from pype.hosts.tvpaint import plugin
 
 
 class CreateRenderlayer(plugin.Creator):

--- a/pype/plugins/tvpaint/create/create_render_pass.py
+++ b/pype/plugins/tvpaint/create/create_render_pass.py
@@ -1,5 +1,5 @@
 from avalon.tvpaint import pipeline, lib
-from pype.hosts.tvpaint.api import plugin
+from pype.hosts.tvpaint import plugin
 
 
 class CreateRenderPass(plugin.Creator):

--- a/pype/plugins/tvpaint/create/create_review.py
+++ b/pype/plugins/tvpaint/create/create_review.py
@@ -1,5 +1,5 @@
 from avalon.tvpaint import pipeline
-from pype.hosts.tvpaint.api import plugin
+from pype.hosts.tvpaint import plugin
 
 
 class CreateReview(plugin.Creator):


### PR DESCRIPTION
It was pointing to 3.0 structure ('.hosts.api') previously

How to test it:
No creators showed up previously