### PR TITLE
Pype's workfiles tool in nuke

### DIFF
--- a/pype/hosts/nuke/api/__init__.py
+++ b/pype/hosts/nuke/api/__init__.py
@@ -3,7 +3,7 @@ import sys
 import nuke
 
 from avalon import api as avalon
-from avalon.tools import workfiles
+from pype.tools import workfiles
 from pyblish import api as pyblish
 from pype.api import Logger
 import pype.hosts.nuke

--- a/pype/hosts/nuke/api/menu.py
+++ b/pype/hosts/nuke/api/menu.py
@@ -1,4 +1,3 @@
-import os
 import nuke
 from avalon.api import Session
 

--- a/pype/hosts/nuke/api/menu.py
+++ b/pype/hosts/nuke/api/menu.py
@@ -9,10 +9,6 @@ from pype.tools import workfiles
 log = Logger().get_logger(__name__)
 
 
-def _show_workfiles(*args, **kwargs):
-    workfiles.show(os.environ["AVALON_WORKDIR"])
-
-
 def install():
     menubar = nuke.menu("Nuke")
     menu = menubar.findItem(Session["AVALON_LABEL"])
@@ -28,7 +24,7 @@ def install():
     menu.removeItem(rm_item[1].name())
     menu.addCommand(
         name,
-        _show_workfiles,
+        workfiles.show,
         index=(rm_item[0])
     )
 

--- a/pype/hosts/nuke/api/menu.py
+++ b/pype/hosts/nuke/api/menu.py
@@ -1,15 +1,37 @@
+import os
 import nuke
 from avalon.api import Session
 
 from .lib import WorkfileSettings
 from pype.api import Logger, BuildWorkfile, get_current_project_settings
+from pype.tools import workfiles
 
 log = Logger().get_logger(__name__)
+
+
+def _show_workfiles(*args, **kwargs):
+    workfiles.show(os.environ["AVALON_WORKDIR"])
 
 
 def install():
     menubar = nuke.menu("Nuke")
     menu = menubar.findItem(Session["AVALON_LABEL"])
+
+    # replace reset resolution from avalon core to pype's
+    name = "Work Files..."
+    rm_item = [
+        (i, item) for i, item in enumerate(menu.items()) if name in item.name()
+    ][0]
+
+    log.debug("Changing Item: {}".format(rm_item))
+
+    menu.removeItem(rm_item[1].name())
+    menu.addCommand(
+        name,
+        _show_workfiles,
+        index=(rm_item[0])
+    )
+
     # replace reset resolution from avalon core to pype's
     name = "Reset Resolution"
     new_name = "Set Resolution"


### PR DESCRIPTION
## Changes
- reimplemented [PR](https://github.com/pypeclub/pype/pull/877) so it's possible to use pype's workfile tool in nuke
- changes were probably lost with commit `434f1615e4e379a3a7e7cff006468199eb3a2b46`

Resolves https://github.com/pypeclub/pype/issues/1216