### PR TITLE
New project schemas

### DIFF
--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -31,9 +31,9 @@ log = Logger.get_logger(__name__)
 
 # Current schemas for avalon types
 EntitySchemas = {
-    "project": "pype:project-2.1",
+    "project": "pype:project-3.0",
     "asset": "pype:asset-3.0",
-    "config": "pype:config-1.1"
+    "config": "pype:config-2.0"
 }
 
 # Group name of custom attributes

--- a/pype/settings/handlers.py
+++ b/pype/settings/handlers.py
@@ -610,6 +610,9 @@ class MongoSettingsHandler(SettingsHandler):
 
         Probably should fill missing keys and values.
         """
+        if not project_doc:
+            return {}
+
         attributes = {}
         project_doc_data = project_doc.get("data") or {}
         for key in self.attribute_keys:

--- a/schema/config-2.0.json
+++ b/schema/config-2.0.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "pype:config-2.0",
+    "description": "A project configuration.",
+
+    "type": "object",
+
+    "additionalProperties": false,
+    "required": [
+        "tasks",
+        "apps"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string"
+        },
+        "templates": {
+            "type": "object"
+        },
+        "roots": {
+            "type": "object"
+        },
+        "imageio": {
+            "type": "object"
+        },
+        "tasks": {
+            "type": "object",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": [
+                    "short_name"
+                ]
+            }
+        },
+        "apps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "group": {"type": "string"},
+                    "label": {"type": "string"}
+                },
+                "required": ["name"]
+            }
+        },
+        "families": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "label": {"type": "string"},
+                    "hideFilter": {"type": "boolean"}
+                },
+                "required": ["name"]
+            }
+        },
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "icon": {"type": "string"},
+                    "color": {"type": "string"},
+                    "order": {"type": ["integer", "number"]}
+                },
+                "required": ["name"]
+            }
+        },
+        "copy": {
+            "type": "object"
+        }
+    }
+}

--- a/schema/project-3.0.json
+++ b/schema/project-3.0.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "pype:project-3.0",
+    "description": "A unit of data",
+
+    "type": "object",
+
+    "additionalProperties": true,
+
+    "required": [
+        "schema",
+        "type",
+        "name",
+        "data",
+        "config"
+    ],
+
+    "properties": {
+        "schema": {
+            "description": "Schema identifier for payload",
+            "type": "string",
+            "enum": ["pype:project-3.0"],
+            "example": "pype:project-3.0"
+        },
+        "type": {
+            "description": "The type of document",
+            "type": "string",
+            "enum": ["project"],
+            "example": "project"
+        },
+        "parent": {
+            "description": "Unique identifier to parent document",
+            "example": "592c33475f8c1b064c4d1696"
+        },
+        "name": {
+            "description": "Name of directory",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.]*$",
+            "example": "hulk"
+        },
+        "data": {
+            "description": "Document metadata",
+            "type": "object",
+            "example": {
+                "fps": 24,
+                "width": 1920,
+                "height": 1080
+            }
+        },
+        "config": {
+            "type": "object",
+            "description": "Document metadata",
+            "$ref": "config-2.0.json"
+        }
+    },
+
+    "definitions": {}
+}


### PR DESCRIPTION
## Changes
- created new validation schemas for project and project's config
    - we've added 2 new keys to config and renamed `template` key to `templates` as new part of anatomy data
- settings handler won't crash if project document does not exist yet