### PR TITLE
Fix - handle duplication of Task name

### DIFF
--- a/pype/plugins/harmony/publish/collect_farm_render.py
+++ b/pype/plugins/harmony/publish/collect_farm_render.py
@@ -124,10 +124,16 @@ class CollectFarmRender(pype.lib.abstract_collect_render.
             # TODO: handle pixel aspect and frame step
             # TODO: set Deadline stuff (pools, priority, etc. by presets)
             # because of using 'renderFarm' as a family, replace 'Farm' with
-            # capitalized task name
-            subset_name = node.split("/")[1].replace(
+            # capitalized task name - issue of avalon-core Creator app
+            subset_name = node.split("/")[1]
+            task_name = context.data["anatomyData"]["task"].capitalize()
+            replace_str = ""
+            if task_name.lower() not in subset_name.lower():
+                replace_str = task_name
+            subset_name = subset_name.replace(
                 'Farm',
-                context.data["anatomyData"]["task"].capitalize())
+                replace_str)
+
             render_instance = HarmonyRenderInstance(
                 version=version,
                 time=api.time(),


### PR DESCRIPTION
2.x version of pypeclub/pype#1225

Issue:
When rendered on farm files with duplicated task name were produced after change of template to explicitly contain Task name (`renderAnimationAnimationDefault`)

If Task name is explicitly set in template, it duplicated
it here. Task name might need be in template, but by default it should be in subset name.

This whole replace situation is because of avalon's Creator which modify subset name even if it shouldn't.
If Creator app is reworked (could have wide impact!), this should be cleaned up.