### PR TITLE
Hide expand button if content does not contain any widget

### DIFF
--- a/pype/tools/settings/settings/widgets/item_widgets.py
+++ b/pype/tools/settings/settings/widgets/item_widgets.py
@@ -59,6 +59,9 @@ class DictImmutableKeysWidget(BaseWidget):
                 )
             )
 
+        if self.entity.use_label_wrap and self.content_layout.count() == 0:
+            self.body_widget.hide_toolbox(True)
+
         self.entity_widget.add_widget_to_layout(self, label)
 
     def _prepare_entity_layouts(self, children, widget):


### PR DESCRIPTION
## Changes
- hide expanding(collapse) button if content layout does not have any widget

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/43494761/113119502-cbb99000-9210-11eb-8f82-999a87eb3228.png)


### After
![image](https://user-images.githubusercontent.com/43494761/113119451-bf353780-9210-11eb-9952-1481098de5de.png)
