### PR TITLE
Minor settings changes

### DIFF
--- a/pype/settings/entities/dict_mutable_keys_entity.py
+++ b/pype/settings/entities/dict_mutable_keys_entity.py
@@ -44,6 +44,8 @@ class DictMutableKeysEntity(EndpointEntity):
     _miss_arg = object()
 
     def __getitem__(self, key):
+        if key not in self.children_by_key:
+            self.add_key(key)
         return self.children_by_key[key]
 
     def __setitem__(self, key, value):

--- a/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
+++ b/pype/settings/entities/schemas/projects_schema/schemas/schema_global_publish.json
@@ -119,7 +119,10 @@
                                                     "slate-frame": "Add slate frame"
                                                 },
                                                 {
-                                                    "no-hnadles": "Skip handle frames"
+                                                    "no-handles": "Skip handle frames"
+                                                },
+                                                {
+                                                    "sequence": "Output as image sequence"
                                                 }
                                             ]
                                         },


### PR DESCRIPTION
## Changes
- mutable dict will create new children if is accessed to a key which is not yet available with `__getitem__`
    - `entity["data"]["key"]` won't crash if entity is `dict-modifiable`, it's object type is dictionary entity and `"data"` was not in settings previously
- plugin `ExtractReview` has in Pype 2 tag `sequence` which is missing in Pype 3