### PR TITLE
Avalon schema names

### DIFF
--- a/pype/plugins/global/publish/extract_hierarchy_avalon.py
+++ b/pype/plugins/global/publish/extract_hierarchy_avalon.py
@@ -148,7 +148,7 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
         # Unarchived asset should not use same data
         new_entity = {
             "_id": entity["_id"],
-            "schema": "avalon-core:asset-3.0",
+            "schema": "pype:asset-3.0",
             "name": entity["name"],
             "parent": self.project["_id"],
             "type": "asset",
@@ -162,7 +162,7 @@ class ExtractHierarchyToAvalon(pyblish.api.ContextPlugin):
 
     def create_avalon_asset(self, name, data):
         item = {
-            "schema": "avalon-core:asset-3.0",
+            "schema": "pype:asset-3.0",
             "name": name,
             "parent": self.project["_id"],
             "type": "asset",

--- a/pype/tools/assetcreator/app.py
+++ b/pype/tools/assetcreator/app.py
@@ -396,7 +396,7 @@ class Window(QtWidgets.QDialog):
         new_asset_info = {
             'parent': av_project['_id'],
             'name': name,
-            'schema': "avalon-core:asset-3.0",
+            'schema': "pype:asset-3.0",
             'type': 'asset',
             'data': new_asset_data
         }


### PR DESCRIPTION
## Changes
- `avalon-core:asset-3.0` replaced with `pype:asset-3.0` in code