### PR TITLE
Forward compatible ftrack group

### DIFF
--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -86,7 +86,7 @@ def get_pype_attr(session, split_hierarchical=True):
     cust_attrs_query = (
         "select id, entity_type, object_type_id, is_hierarchical, default"
         " from CustomAttributeConfiguration"
-        " where group.name in (\"avalon\", \"pype\")"
+        " where group.name in (\"avalon\", \"pype\", \"openpype\")"
     )
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:

--- a/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
+++ b/pype/plugins/ftrack/publish/integrate_hierarchy_ftrack.py
@@ -17,7 +17,7 @@ def get_pype_attr(session, split_hierarchical=True):
     cust_attrs_query = (
         "select id, entity_type, object_type_id, is_hierarchical, default"
         " from CustomAttributeConfiguration"
-        " where group.name in (\"avalon\", \"pype\")"
+        " where group.name in (\"avalon\", \"pype\", \"openpype\")"
     )
     all_avalon_attr = session.query(cust_attrs_query).all()
     for cust_attr in all_avalon_attr:


### PR DESCRIPTION
## Changes
- ftrack attribute configuration query can expect `openpype` custom attribute