### PR TITLE
Shell prelaunch hook fix

### DIFF
--- a/openpype/hooks/pre_with_windows_shell.py
+++ b/openpype/hooks/pre_with_windows_shell.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from openpype.lib import PreLaunchHook
 
 
@@ -15,10 +16,22 @@ class LaunchWithWindowsShell(PreLaunchHook):
     platforms = ["windows"]
 
     def execute(self):
-        # Get comspec which is cmd.exe in most cases.
-        comspec = os.environ.get("COMSPEC", "cmd.exe")
-        # Add comspec to arguments list and add "/k"
-        new_args = [comspec, "/c"]
-        new_args.extend(self.launch_context.launch_args)
+        new_args = [
+            # Get comspec which is cmd.exe in most cases.
+            os.environ.get("COMSPEC", "cmd.exe"),
+            # NOTE change to "/k" if want to keep console opened
+            "/c",
+            # Convert arguments to command line arguments (as string)
+            "\"{}\"".format(
+                subprocess.list2cmdline(self.launch_context.launch_args)
+            )
+        ]
+        # Convert list to string
+        # WARNING this only works if is used as string
+        args_string = " ".join(new_args)
+        self.log.info((
+            "Modified launch arguments to be launched with shell \"{}\"."
+        ).format(args_string))
+
         # Replace launch args with new one
-        self.launch_context.launch_args = new_args
+        self.launch_context.launch_args = args_string

--- a/openpype/hooks/pre_with_windows_shell.py
+++ b/openpype/hooks/pre_with_windows_shell.py
@@ -35,3 +35,7 @@ class LaunchWithWindowsShell(PreLaunchHook):
 
         # Replace launch args with new one
         self.launch_context.launch_args = args_string
+        # Change `creationflags` to CREATE_NEW_CONSOLE
+        self.launch_context.kwargs["creationflags"] = (
+            subprocess.CREATE_NEW_CONSOLE
+        )

--- a/openpype/hooks/pre_with_windows_shell.py
+++ b/openpype/hooks/pre_with_windows_shell.py
@@ -11,7 +11,8 @@ class LaunchWithWindowsShell(PreLaunchHook):
     instead.
     """
 
-    order = 10
+    # Should be as last hook becuase must change launch arguments to string
+    order = 1000
     app_groups = ["resolve", "nuke", "nukex", "hiero", "nukestudio"]
     platforms = ["windows"]
 

--- a/openpype/hooks/pre_with_windows_shell.py
+++ b/openpype/hooks/pre_with_windows_shell.py
@@ -13,7 +13,7 @@ class LaunchWithWindowsShell(PreLaunchHook):
 
     # Should be as last hook becuase must change launch arguments to string
     order = 1000
-    app_groups = ["resolve", "nuke", "nukex", "hiero", "nukestudio"]
+    app_groups = ["nuke", "nukex", "hiero", "nukestudio"]
     platforms = ["windows"]
 
     def execute(self):

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -858,7 +858,10 @@ class ApplicationLaunchContext:
         Return:
             list: Unpacked arguments.
         """
-        while True:
+        if isinstance(args, str):
+            return args
+        all_cleared = False
+        while not all_cleared:
             all_cleared = True
             new_args = []
             for arg in args:
@@ -870,8 +873,6 @@ class ApplicationLaunchContext:
                     new_args.append(arg)
             args = new_args
 
-            if all_cleared:
-                break
         return args
 
 

--- a/openpype/lib/applications.py
+++ b/openpype/lib/applications.py
@@ -804,10 +804,15 @@ class ApplicationLaunchContext:
         self.log.debug("All prelaunch hook executed. Starting new process.")
 
         # Prepare subprocess args
-        args = self.clear_launch_args(self.launch_args)
-        self.log.debug(
-            "Launching \"{}\" with args ({}): {}".format(
-                self.app_name, len(args), args
+        args_len_str = ""
+        if isinstance(self.launch_args, str):
+            args = self.launch_args
+        else:
+            args = self.clear_launch_args(self.launch_args)
+            args_len_str = " ({})".format(len(args))
+        self.log.info(
+            "Launching \"{}\" with args{}: {}".format(
+                self.app_name, args_len_str, args
             )
         )
         # Run process


### PR DESCRIPTION
## Issue
Some arguments are not correctly converted when prelaunch hook `LaunchWithWindowsShell` is used. They are mixed with command line arguments so are not parsed correctly. This is mainly issue when quotation mark `"` is part of any argument or path has spaces.

## Changes
- launch arguments collected before the prelaunch hook are converted to string using `subprocess.list2cmdline`
    - the prelaunch hook must be executed as last hook modifying launch arguments
- creation flags of subprocess are changed to `CREATE_NEW_CONSOLE`
- whole arguments are passed to `subprocess.Popen` as string not as list
    - this is required otherwise python's `subprocess` module will try to deparse and parse arguments again
- launch context can expected launch arguments as string

## Note
Not sure why `resolve` is one of applications that use the prelaunch hook, I can't test it as I don't have Resolve. But I think Resolve doesn't need the hook at first place.