### PR TITLE
Repository: Switch from ssh to https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,13 +1,13 @@
 [submodule "repos/avalon-core"]
 	path = repos/avalon-core
-	url = git@github.com:pypeclub/avalon-core.git
+	url = https://github.com/pypeclub/avalon-core.git
 	branch = develop
 [submodule "repos/avalon-unreal-integration"]
 	path = repos/avalon-unreal-integration
-	url = git@github.com:pypeclub/avalon-unreal-integration.git
+	url = https://github.com/pypeclub/avalon-unreal-integration.git
 [submodule "openpype/modules/ftrack/python2_vendor/ftrack-python-api"]
 	path = openpype/modules/ftrack/python2_vendor/ftrack-python-api
 	url = https://bitbucket.org/ftrack/ftrack-python-api.git
 [submodule "openpype/modules/ftrack/python2_vendor/arrow"]
 	path = openpype/modules/ftrack/python2_vendor/arrow
-	url = git@github.com:arrow-py/arrow.git
+	url = https://github.com/arrow-py/arrow.git


### PR DESCRIPTION
## Problem

Submodules are defined with ssh access schema requiring user to have GitHub account. This PR changes this to less restricting https schema.