### PR TITLE
Ignore Ftrack url slash

### DIFF
--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -42,7 +42,7 @@ class FtrackModule(
         ftrack_settings = settings[self.name]
 
         self.enabled = ftrack_settings["enabled"]
-        self.ftrack_url = ftrack_settings["ftrack_server"]
+        self.ftrack_url = ftrack_settings["ftrack_server"].strip("/ ")
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         server_event_handlers_paths = [


### PR DESCRIPTION
## Issue
Ftrack url won't work is ends with slash `/` which is common mistake when copied from browser and not much issue.

## Changes
- strip slash and space from ftrack url