### PR TITLE
Igniter qt import

### DIFF
--- a/igniter/__init__.py
+++ b/igniter/__init__.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
 """Open install dialog."""
 
+import os
 import sys
 
-import os
 os.chdir(os.path.dirname(__file__))  # for override sys.path in Deadline
 
-from Qt import QtWidgets  # noqa
-from Qt.QtCore import Signal  # noqa
-
-from .install_dialog import InstallDialog
 from .bootstrap_repos import BootstrapRepos
 from .version import __version__ as version
 
@@ -25,11 +21,17 @@ def get_result(res: int):
 
 def open_dialog():
     """Show Igniter dialog."""
+    from Qt import QtWidgets
+    from .install_dialog import InstallDialog
+
     app = QtWidgets.QApplication(sys.argv)
+
     d = InstallDialog()
     d.finished.connect(get_result)
     d.open()
+
     app.exec()
+
     return RESULT
 
 

--- a/igniter/__init__.py
+++ b/igniter/__init__.py
@@ -36,7 +36,6 @@ def open_dialog():
 
 
 __all__ = [
-    "InstallDialog",
     "BootstrapRepos",
     "open_dialog",
     "version"


### PR DESCRIPTION
## Description
Import of igniter always trigger import of Qt in `__init__.py` file which may cause error even if Qt is not used.

## Changes
- moved Qt related imports into related function (`open_dialog`)

## TODOs
- find out why crashes
    - should be tested if crashes from code/build I think issue is that if it's launched from code venv is not added to sys.path