### PR TITLE
add openpype_root to pythonpath

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -8,7 +8,7 @@ on:
     branches: [develop]
     types: [review_requested, ready_for_review]
     paths-ignore:
-    - 'docs/**',
+    - 'docs/**'
     - 'website/**'
     - 'vendor/**'
 

--- a/start.py
+++ b/start.py
@@ -326,6 +326,7 @@ def _initialize_environment(openpype_version: OpenPypeVersion) -> None:
     # TODO move additional paths to `boot` part when OPENPYPE_ROOT will point
     # to same hierarchy from code and from frozen OpenPype
     additional_paths = [
+        os.environ["OPENPYPE_ROOT"],
         # add OpenPype tools
         os.path.join(os.environ["OPENPYPE_ROOT"], "openpype", "tools"),
         # add common OpenPype vendor


### PR DESCRIPTION
When running from build, we were removing the build folder from sys.path but not adding the picked up repository version to pythonpath in turn. 

that resulted in openpyne not being importable from hosts