### PR TITLE
Fix root return in Anatomy

### DIFF
--- a/openpype/lib/anatomy.py
+++ b/openpype/lib/anatomy.py
@@ -216,7 +216,7 @@ class Anatomy:
         """Returns value of root key from template."""
         root_templates = []
         for group in re.findall(self.root_key_regex, template):
-            root_templates.append(group)
+            root_templates.append("{" + group + "}")
 
         if not root_templates:
             return None


### PR DESCRIPTION
Pype 3 version of https://github.com/pypeclub/pype-setup/pull/92/files

## Issue
- `root_value_for_template` crashes as found key is without formatting 

## Changes
- fix `root_value_for_template` method in Anatomy

||Pype 2 PRs|
|---|---|
|pyp-setup|https://github.com/pypeclub/pype-setup/pull/92|