### PR TITLE
OpenPype settings registry

### DIFF
--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -14,7 +14,10 @@ from zipfile import ZipFile, BadZipFile
 from appdirs import user_data_dir
 from speedcopy import copyfile
 
-from .user_settings import OpenPypeSettingsRegistry
+from .user_settings import (
+    OpenPypeSecureRegistry,
+    OpenPypeSettingsRegistry
+)
 from .tools import get_openpype_path_from_db
 
 
@@ -239,6 +242,7 @@ class BootstrapRepos:
         self._app = "openpype"
         self._log = log.getLogger(str(__class__))
         self.data_dir = Path(user_data_dir(self._app, self._vendor))
+        self.secure_registry = OpenPypeSecureRegistry("Settings")
         self.registry = OpenPypeSettingsRegistry()
         self.zip_filter = [".pyc", "__pycache__"]
         self.openpype_filter = [

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -242,7 +242,7 @@ class BootstrapRepos:
         self._app = "openpype"
         self._log = log.getLogger(str(__class__))
         self.data_dir = Path(user_data_dir(self._app, self._vendor))
-        self.secure_registry = OpenPypeSecureRegistry("Settings")
+        self.secure_registry = OpenPypeSecureRegistry("mongodb")
         self.registry = OpenPypeSettingsRegistry()
         self.zip_filter = [".pyc", "__pycache__"]
         self.openpype_filter = [

--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -13,7 +13,7 @@ from .tools import (
     validate_mongo_connection,
     get_openpype_path_from_db
 )
-from .user_settings import OpenPypeSettingsRegistry
+from .user_settings import OpenPypeSecureRegistry
 from .version import __version__
 
 
@@ -42,13 +42,13 @@ class InstallDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None):
         super(InstallDialog, self).__init__(parent)
-        self.registry = OpenPypeSettingsRegistry()
+        self.secure_registry = OpenPypeSecureRegistry("Settings")
 
         self.mongo_url = ""
         try:
             self.mongo_url = (
                 os.getenv("OPENPYPE_MONGO", "")
-                or self.registry.get_secure_item("openPypeMongo")
+                or self.secure_registry.get_item("openPypeMongo")
             )
         except ValueError:
             pass

--- a/igniter/install_dialog.py
+++ b/igniter/install_dialog.py
@@ -42,7 +42,7 @@ class InstallDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None):
         super(InstallDialog, self).__init__(parent)
-        self.secure_registry = OpenPypeSecureRegistry("Settings")
+        self.secure_registry = OpenPypeSecureRegistry("mongodb")
 
         self.mongo_url = ""
         try:

--- a/igniter/install_thread.py
+++ b/igniter/install_thread.py
@@ -71,7 +71,7 @@ class InstallThread(QThread):
                 if not os.getenv("OPENPYPE_MONGO"):
                     # try to get it from settings registry
                     try:
-                        self._mongo = bs.registry.get_secure_item(
+                        self._mongo = bs.secure_registry.get_item(
                             "openPypeMongo")
                     except ValueError:
                         self.message.emit(
@@ -82,7 +82,7 @@ class InstallThread(QThread):
                     self._mongo = os.getenv("OPENPYPE_MONGO")
             else:
                 self.message.emit("Saving mongo connection string ...", False)
-                bs.registry.set_secure_item("openPypeMongo", self._mongo)
+                bs.secure_registry.set_item("openPypeMongo", self._mongo)
 
             os.environ["OPENPYPE_MONGO"] = self._mongo
 
@@ -169,7 +169,7 @@ class InstallThread(QThread):
                         f"!!! invalid mongo url {self._mongo}", True)
                     self.finished.emit(InstallResult(-1))
                     return
-                bs.registry.set_secure_item("openPypeMongo", self._mongo)
+                bs.secure_registry.set_item("openPypeMongo", self._mongo)
                 os.environ["OPENPYPE_MONGO"] = self._mongo
 
             self.message.emit(f"processing {self._path}", True)

--- a/igniter/user_settings.py
+++ b/igniter/user_settings.py
@@ -459,9 +459,10 @@ class OpenPypeSettingsRegistry(JSONSettingRegistry):
 
     """
 
-    def __init__(self):
+    def __init__(self, name=None):
         self.vendor = "pypeclub"
         self.product = "openpype"
+        if name is None:
+            name = "openpype_settings"
         path = appdirs.user_data_dir(self.product, self.vendor)
-        super(OpenPypeSettingsRegistry, self).__init__(
-            "openpype_settings", path)
+        super(OpenPypeSettingsRegistry, self).__init__(name, path)

--- a/igniter/user_settings.py
+++ b/igniter/user_settings.py
@@ -25,8 +25,8 @@ except ImportError:
 
 import platform
 
-import appdirs
 import six
+import appdirs
 
 _PLACEHOLDER = object()
 
@@ -139,13 +139,6 @@ class ASettingRegistry():
         # type: (str) -> ASettingRegistry
         super(ASettingRegistry, self).__init__()
 
-        if six.PY3:
-            import keyring
-            # hack for cx_freeze and Windows keyring backend
-            if platform.system() == "Windows":
-                from keyring.backends import Windows
-                keyring.set_keyring(Windows.WinVaultKeyring())
-
         self._name = name
         self._items = {}
 
@@ -219,78 +212,6 @@ class ASettingRegistry():
     def __delitem__(self, name):
         del self._items[name]
         self._delete_item(name)
-
-    def set_secure_item(self, name, value):
-        # type: (str, str) -> None
-        """Set sensitive item into system's keyring.
-
-        This uses `Keyring module`_ to save sensitive stuff into system's
-        keyring.
-
-        Args:
-            name (str): Name of the item.
-            value (str): Value of the item.
-
-        .. _Keyring module:
-            https://github.com/jaraco/keyring
-
-        """
-        if six.PY2:
-            raise NotImplementedError(
-                "Keyring not available on Python 2 hosts")
-        import keyring
-        keyring.set_password(self._name, name, value)
-
-    @lru_cache(maxsize=32)
-    def get_secure_item(self, name):
-        # type: (str) -> str
-        """Get value of sensitive item from system's keyring.
-
-        See also `Keyring module`_
-
-        Args:
-            name (str): Name of the item.
-
-        Returns:
-            value (str): Value of the item.
-
-        Raises:
-            ValueError: If item doesn't exist.
-
-        .. _Keyring module:
-            https://github.com/jaraco/keyring
-
-        """
-        if six.PY2:
-            raise NotImplementedError(
-                "Keyring not available on Python 2 hosts")
-        import keyring
-        value = keyring.get_password(self._name, name)
-        if not value:
-            raise ValueError(
-                "Item {}:{} does not exist in keyring.".format(
-                    self._name, name))
-        return value
-
-    def delete_secure_item(self, name):
-        # type: (str) -> None
-        """Delete value stored in system's keyring.
-
-        See also `Keyring module`_
-
-        Args:
-            name (str): Name of the item to be deleted.
-
-        .. _Keyring module:
-            https://github.com/jaraco/keyring
-
-        """
-        if six.PY2:
-            raise NotImplementedError(
-                "Keyring not available on Python 2 hosts")
-        import keyring
-        self.get_secure_item.cache_clear()
-        keyring.delete_password(self._name, name)
 
 
 class IniSettingRegistry(ASettingRegistry):
@@ -555,7 +476,7 @@ class OpenPypeSettingsRegistry(JSONSettingRegistry):
     def __init__(self, name=None):
         self.vendor = "pypeclub"
         self.product = "openpype"
-        if name is None:
+        if not name:
             name = "openpype_settings"
         path = appdirs.user_data_dir(self.product, self.vendor)
         super(OpenPypeSettingsRegistry, self).__init__(name, path)

--- a/igniter/user_settings.py
+++ b/igniter/user_settings.py
@@ -32,6 +32,17 @@ _PLACEHOLDER = object()
 
 
 class OpenPypeSecureRegistry:
+    """Store information using keyring.
+
+    Registry should be used for private data that should be available only for
+    user.
+
+    All passed registry names will have added prefix `OpenPype/` to easier
+    identify which data were created by OpenPype.
+
+    Args:
+        name(str): Name of registry used as identifier for data.
+    """
     def __init__(self, name):
         try:
             import keyring

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -104,7 +104,7 @@ from .plugin_tools import (
 from .local_settings import (
     IniSettingRegistry,
     JSONSettingRegistry,
-    PypeSettingsRegistry,
+    OpenPypeSettingsRegistry,
     get_local_site_id,
     change_openpype_mongo_url
 )
@@ -217,7 +217,7 @@ __all__ = [
 
     "IniSettingRegistry",
     "JSONSettingRegistry",
-    "PypeSettingsRegistry",
+    "OpenPypeSettingsRegistry",
     "get_local_site_id",
     "change_openpype_mongo_url",
 

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -104,6 +104,7 @@ from .plugin_tools import (
 from .local_settings import (
     IniSettingRegistry,
     JSONSettingRegistry,
+    OpenPypeSecureRegistry,
     OpenPypeSettingsRegistry,
     get_local_site_id,
     change_openpype_mongo_url
@@ -217,6 +218,7 @@ __all__ = [
 
     "IniSettingRegistry",
     "JSONSettingRegistry",
+    "OpenPypeSecureRegistry",
     "OpenPypeSettingsRegistry",
     "get_local_site_id",
     "change_openpype_mongo_url",

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -452,7 +452,7 @@ class JSONSettingRegistry(ASettingRegistry):
             json.dump(data, cfg, indent=4)
 
 
-class PypeSettingsRegistry(JSONSettingRegistry):
+class OpenPypeSettingsRegistry(JSONSettingRegistry):
     """Class handling Pype general settings registry.
 
     Attributes:
@@ -463,9 +463,9 @@ class PypeSettingsRegistry(JSONSettingRegistry):
 
     def __init__(self):
         self.vendor = "pypeclub"
-        self.product = "pype"
+        self.product = "openpype"
         path = appdirs.user_data_dir(self.product, self.vendor)
-        super(PypeSettingsRegistry, self).__init__("pype_settings", path)
+        super(OpenPypeSettingsRegistry, self).__init__("openpype_settings", path)
 
 
 def _create_local_site_id(registry=None):
@@ -473,7 +473,7 @@ def _create_local_site_id(registry=None):
     from uuid import uuid4
 
     if registry is None:
-        registry = PypeSettingsRegistry()
+        registry = OpenPypeSettingsRegistry()
 
     new_id = str(uuid4())
 
@@ -489,7 +489,7 @@ def get_local_site_id():
 
     Identifier is created if does not exists yet.
     """
-    registry = PypeSettingsRegistry()
+    registry = OpenPypeSettingsRegistry()
     try:
         return registry.get_item("localId")
     except ValueError:
@@ -504,5 +504,5 @@ def change_openpype_mongo_url(new_mongo_url):
     """
 
     validate_mongo_connection(new_mongo_url)
-    registry = PypeSettingsRegistry()
-    registry.set_secure_item("pypeMongo", new_mongo_url)
+    registry = OpenPypeSettingsRegistry()
+    registry.set_secure_item("openPypeMongo", new_mongo_url)

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -461,11 +461,13 @@ class OpenPypeSettingsRegistry(JSONSettingRegistry):
 
     """
 
-    def __init__(self):
+    def __init__(self, name=None):
         self.vendor = "pypeclub"
         self.product = "openpype"
+        if name is None:
+            name = "openpype_settings"
         path = appdirs.user_data_dir(self.product, self.vendor)
-        super(OpenPypeSettingsRegistry, self).__init__("openpype_settings", path)
+        super(OpenPypeSettingsRegistry, self).__init__(name, path)
 
 
 def _create_local_site_id(registry=None):

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -532,5 +532,5 @@ def change_openpype_mongo_url(new_mongo_url):
     """
 
     validate_mongo_connection(new_mongo_url)
-    registry = OpenPypeSecureRegistry("Settings")
+    registry = OpenPypeSecureRegistry("mongodb")
     registry.set_item("openPypeMongo", new_mongo_url)

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -106,7 +106,7 @@ class OpenPypeSecureRegistry:
         import keyring
 
         value = keyring.get_password(self._name, name)
-        if value:
+        if value is not None:
             return value
 
         if default is not _PLACEHOLDER:
@@ -532,5 +532,9 @@ def change_openpype_mongo_url(new_mongo_url):
     """
 
     validate_mongo_connection(new_mongo_url)
+    key = "openPypeMongo"
     registry = OpenPypeSecureRegistry("mongodb")
-    registry.set_item("openPypeMongo", new_mongo_url)
+    existing_value = registry.get_item(key, None)
+    if existing_value is not None:
+        registry.delete_item(key)
+    registry.set_item(key, new_mongo_url)

--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -35,6 +35,17 @@ _PLACEHOLDER = object()
 
 
 class OpenPypeSecureRegistry:
+    """Store information using keyring.
+
+    Registry should be used for private data that should be available only for
+    user.
+
+    All passed registry names will have added prefix `OpenPype/` to easier
+    identify which data were created by OpenPype.
+
+    Args:
+        name(str): Name of registry used as identifier for data.
+    """
     def __init__(self, name):
         try:
             import keyring

--- a/start.py
+++ b/start.py
@@ -296,7 +296,7 @@ def _determine_mongodb() -> str:
     if not openpype_mongo:
         # try system keyring
         try:
-            openpype_mongo = bootstrap.registry.get_secure_item(
+            openpype_mongo = bootstrap.secure_registry.get_item(
                 "openPypeMongo")
         except ValueError:
             print("*** No DB connection string specified.")
@@ -305,7 +305,7 @@ def _determine_mongodb() -> str:
             igniter.open_dialog()
 
             try:
-                openpype_mongo = bootstrap.registry.get_secure_item(
+                openpype_mongo = bootstrap.secure_registry.get_item(
                     "openPypeMongo")
             except ValueError:
                 raise RuntimeError("missing mongodb url")

--- a/tests/igniter/test_bootstrap_repos.py
+++ b/tests/igniter/test_bootstrap_repos.py
@@ -11,7 +11,7 @@ import pytest
 
 from igniter.bootstrap_repos import BootstrapRepos
 from igniter.bootstrap_repos import PypeVersion
-from pype.lib import PypeSettingsRegistry
+from pype.lib import OpenPypeSettingsRegistry
 
 
 @pytest.fixture
@@ -348,7 +348,7 @@ def test_find_pype(fix_bootstrap, tmp_path_factory, monkeypatch, printer):
         return d_path.as_posix()
 
     monkeypatch.setattr(appdirs, "user_data_dir", mock_user_data_dir)
-    fix_bootstrap.registry = PypeSettingsRegistry()
+    fix_bootstrap.registry = OpenPypeSettingsRegistry()
     fix_bootstrap.registry.set_item("pypePath", d_path.as_posix())
 
     result = fix_bootstrap.find_pype(include_zips=True)

--- a/tests/pype/lib/test_user_settings.py
+++ b/tests/pype/lib/test_user_settings.py
@@ -1,8 +1,18 @@
 import pytest
-from pype.lib import IniSettingRegistry
-from pype.lib import JSONSettingRegistry
+from pype.lib import (
+    IniSettingRegistry,
+    JSONSettingRegistry,
+    OpenPypeSecureRegistry
+)
 from uuid import uuid4
 import configparser
+
+
+@pytest.fixture
+def secure_registry(tmpdir):
+    name = "pypetest_{}".format(str(uuid4()))
+    r = OpenPypeSecureRegistry(name, tmpdir)
+    yield r
 
 
 @pytest.fixture
@@ -19,21 +29,21 @@ def ini_registry(tmpdir):
     yield r
 
 
-def test_keyring(json_registry):
-    json_registry.set_secure_item("item1", "foo")
-    json_registry.set_secure_item("item2", "bar")
-    result1 = json_registry.get_secure_item("item1")
-    result2 = json_registry.get_secure_item("item2")
+def test_keyring(secure_registry):
+    secure_registry.set_item("item1", "foo")
+    secure_registry.set_item("item2", "bar")
+    result1 = secure_registry.get_item("item1")
+    result2 = secure_registry.get_item("item2")
 
     assert result1 == "foo"
     assert result2 == "bar"
 
-    json_registry.delete_secure_item("item1")
-    json_registry.delete_secure_item("item2")
+    secure_registry.delete_item("item1")
+    secure_registry.delete_item("item2")
 
     with pytest.raises(ValueError):
-        json_registry.get_secure_item("item1")
-        json_registry.get_secure_item("item2")
+        secure_registry.get_item("item1")
+        secure_registry.get_item("item2")
 
 
 def test_ini_registry(ini_registry):


### PR DESCRIPTION
## Issue
Class `PypeSettingsRegistry` in `pype.lib` was not renamed to `OpenPypeSettingsRegistry` and is using bad keys.

## Changes
- fixed `"pype"` -> `"openpype"` in `pype.lib.local_settings`
- extracted secure items logic from `ASettingRegistry` to `OpenPypeSecureRegistry`
    - this is because to be able access to secure items it was required to create `IniSettingRegistry` or `JSONSettingRegistry` object
    - it is possible to specify name where data will be stored but to all names is added prefix `"OpenPype/"` to easily see what was created by pype
- it is also possible to specify name of registry for `OpenPypeSettingsRegistry`
- secure item of `openPypeMongo` is stored under `"OpenPype/mongodb"` key in keyring

## Nice to have in future PR
- code of registry is same in both igniter and pype.lib it would be better if in pype is possible to use igniter without any issues
    - define `change_mongo_url` function in igniter so pype can "not know" about it's logic