### PR TITLE
Fix executables from local settings

### DIFF
--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -489,7 +489,7 @@ def apply_local_settings_on_system_settings(system_settings, local_settings):
             # TODO This is temporary fix until launch arguments will be stored
             #   per platform and not per executable.
             # - local settings store only executable
-            new_executables = [[executable, ""]]
+            new_executables = [executable]
             new_executables.extend(platform_executables)
             variants[app_name]["executables"] = new_executables
 


### PR DESCRIPTION
## Issue
Local settings load executables still old way (with arguments) which cause crashes.

## Changes
- executables from local settings are loaded as expected