### PR TITLE
Idle manager without settings

### DIFF
--- a/openpype/modules/idle_manager/idle_module.py
+++ b/openpype/modules/idle_manager/idle_module.py
@@ -40,8 +40,7 @@ class IdleManager(PypeModule, ITrayService):
     name = "idle_manager"
 
     def initialize(self, module_settings):
-        idle_man_settings = module_settings[self.name]
-        self.enabled = idle_man_settings["enabled"]
+        self.enabled = True
 
         self.time_callbacks = collections.defaultdict(list)
         self.idle_thread = None
@@ -50,7 +49,8 @@ class IdleManager(PypeModule, ITrayService):
         return
 
     def tray_start(self):
-        self.start_thread()
+        if self.time_callbacks:
+            self.start_thread()
 
     def tray_exit(self):
         self.stop_thread()

--- a/openpype/modules/timers_manager/timers_manager.py
+++ b/openpype/modules/timers_manager/timers_manager.py
@@ -45,11 +45,13 @@ class TimersManager(PypeModule, ITrayService, IIdleManager, IWebServerRoutes):
         timers_settings = modules_settings[self.name]
 
         self.enabled = timers_settings["enabled"]
+        auto_stop = timers_settings["auto_stop"]
         # When timer will stop if idle manager is running (minutes)
         full_time = int(timers_settings["full_time"] * 60)
         # How many minutes before the timer is stopped will popup the message
         message_time = int(timers_settings["message_time"] * 60)
 
+        self.auto_stop = auto_stop
         self.time_show_message = full_time - message_time
         self.time_stop_timer = full_time
 
@@ -160,6 +162,9 @@ class TimersManager(PypeModule, ITrayService, IIdleManager, IWebServerRoutes):
     def callbacks_by_idle_time(self):
         """Implementation of IIdleManager interface."""
         # Time when message is shown
+        if not self.auto_stop:
+            return {}
+
         callbacks = collections.defaultdict(list)
         callbacks[self.time_show_message].append(lambda: self.time_callback(0))
 

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -126,6 +126,7 @@
     },
     "timers_manager": {
         "enabled": true,
+        "auto_stop": true,
         "full_time": 15.0,
         "message_time": 0.5
     },

--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -165,8 +165,5 @@
     },
     "standalonepublish_tool": {
         "enabled": true
-    },
-    "idle_manager": {
-        "enabled": true
     }
 }

--- a/openpype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_modules.json
@@ -176,20 +176,6 @@
                     "label": "Enabled"
                 }
             ]
-        },
-        {
-            "type": "dict",
-            "key": "idle_manager",
-            "label": "Idle Manager",
-            "collapsible": true,
-            "checkbox_key": "enabled",
-            "children": [
-                {
-                    "type": "boolean",
-                    "key": "enabled",
-                    "label": "Enabled"
-                }
-            ]
         }
     ]
 }

--- a/openpype/settings/entities/schemas/system_schema/schema_modules.json
+++ b/openpype/settings/entities/schemas/system_schema/schema_modules.json
@@ -43,6 +43,11 @@
                     "label": "Enabled"
                 },
                 {
+                    "type": "boolean",
+                    "key": "auto_stop",
+                    "label": "Auto stop timer"
+                },
+                {
                     "type": "number",
                     "decimal": 2,
                     "key": "full_time",


### PR DESCRIPTION
## Changes
- idle manager module is always enabled but won't start it's thread if there are any registered timer callbacks
    - so don't have to be in settings UI
- timer manager has `auto_stop` attribute which defines if timer will be automatically stopped sowill register it's callbacks to idle manager