### PR TITLE
Validate project settings

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_instances.py
+++ b/pype/plugins/tvpaint/publish/collect_instances.py
@@ -18,7 +18,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
         ))
 
         for instance_data in workfile_instances:
-            instance_data["fps"] = context.data["fps"]
+            instance_data["fps"] = context.data["sceneFps"]
 
             # Store workfile instance data to instance data
             instance_data["originData"] = copy.deepcopy(instance_data)
@@ -32,6 +32,11 @@ class CollectInstances(pyblish.api.ContextPlugin):
             subset_name = instance_data["subset"]
             name = instance_data.get("name", subset_name)
             instance_data["name"] = name
+            instance_data["label"] = "{} [{}-{}]".format(
+                name,
+                context.data["sceneFrameStart"],
+                context.data["sceneFrameEnd"]
+            )
 
             active = instance_data.get("active", True)
             instance_data["active"] = active
@@ -81,8 +86,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
 
             instance.data["publish"] = any_visible
 
-            instance.data["frameStart"] = context.data["frameStart"]
-            instance.data["frameEnd"] = context.data["frameEnd"]
+            instance.data["frameStart"] = context.data["sceneFrameStart"]
+            instance.data["frameEnd"] = context.data["sceneFrameEnd"]
 
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -127,11 +127,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             "currentFile": workfile_path,
             "sceneWidth": width,
             "sceneHeight": height,
-            "pixelAspect": pixel_apsect,
-            "frameStart": frame_start,
-            "frameEnd": frame_end,
-            "fps": frame_rate,
-            "fieldOrder": field_order
+            "scenePixelAspect": pixel_apsect,
+            "sceneFrameStart": frame_start,
+            "sceneFrameEnd": frame_end,
+            "sceneFps": frame_rate,
+            "sceneFieldOrder": field_order
         }
         self.log.debug(
             "Scene data: {}".format(json.dumps(scene_data, indent=4))

--- a/pype/plugins/tvpaint/publish/validate_project_settings.py
+++ b/pype/plugins/tvpaint/publish/validate_project_settings.py
@@ -1,0 +1,36 @@
+import json
+
+import pyblish.api
+
+
+class ValidateProjectSettings(pyblish.api.ContextPlugin):
+    """Validate project settings against database.
+    """
+
+    label = "Validate Project Settings"
+    order = pyblish.api.ValidatorOrder
+    optional = True
+
+    def process(self, context):
+        scene_data = {
+            "frameStart": context.data.get("sceneFrameStart"),
+            "frameEnd": context.data.get("sceneFrameEnd"),
+            "fps": context.data.get("sceneFps"),
+            "resolutionWidth": context.data.get("sceneWidth"),
+            "resolutionHeight": context.data.get("sceneHeight"),
+            "pixelAspect": context.data.get("scenePixelAspect")
+        }
+        invalid = {}
+        for k in scene_data.keys():
+            expected_value = context.data["assetEntity"]["data"][k]
+            if scene_data[k] != expected_value:
+                invalid[k] = {
+                    "current": scene_data[k], "expected": expected_value
+                }
+
+        if invalid:
+            raise AssertionError(
+                "Project settings does not match database:\n{}".format(
+                    json.dumps(invalid, sort_keys=True, indent=4)
+                )
+            )


### PR DESCRIPTION
The validator checks the asset data to the project settings on these member;

- resolution
- framerate
- pixel aspect
- frame range

The validator does not have any repair because when publishing, changing this data can result in loss of work, so it needs user care to resolve.

Had to prefix the data member, with `scene`, collected from TVP because they were otherwise being overwritten by https://github.com/pypeclub/pype/blob/2.x/main/pype/plugins/global/publish/collect_avalon_entities.py

||Pype 3 PRs|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1320|