### PR TITLE
TVPaint asset name validation

### DIFF
--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -57,9 +57,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
 
         # Collect context from workfile metadata
         self.log.info("Collecting workfile context")
+
         workfile_context = pipeline.get_current_workfile_context()
+        # Store workfile context to pyblish context
+        context.data["workfile_context"] = workfile_context
         if workfile_context:
-            asset_name = workfile_context["asset"]
             # Change current context with context from workfile
             key_map = (
                 ("AVALON_ASSET", "asset"),
@@ -70,8 +72,12 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
                 os.environ[env_key] = workfile_context[key]
             self.log.info("Context changed to: {}".format(workfile_context))
 
+            asset_name = workfile_context["asset"]
+            task_name = workfile_context["task"]
+
         else:
             asset_name = current_context["asset"]
+            task_name = current_context["task"]
             # Handle older workfiles or workfiles without metadata
             self.log.warning((
                 "Workfile does not contain information about context."
@@ -80,8 +86,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
 
         # Store context asset name
         context.data["asset"] = asset_name
-        # Store workfile context
-        context.data["workfile_context"] = workfile_context
+        self.log.info(
+            "Context is set to Asset: \"{}\" and Task: \"{}\"".format(
+                asset_name, task_name
+            )
+        )
 
         # Collect instances
         self.log.info("Collecting instance data from workfile")

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -73,10 +73,10 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         else:
             asset_name = current_context["asset"]
             # Handle older workfiles or workfiles without metadata
-            self.log.warning(
+            self.log.warning((
                 "Workfile does not contain information about context."
                 " Using current Session context."
-            )
+            ))
 
         # Store context asset name
         context.data["asset"] = asset_name

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -75,7 +75,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             )
             workfile_context = current_context.copy()
 
-        context.data["asset"] = avalon.api.Session["AVALON_ASSET"]
+        context.data["asset"] = workfile_context["AVALON_ASSET"]
         context.data["workfile_context"] = workfile_context
         self.log.info("Context changed to: {}".format(workfile_context))
 

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -68,6 +68,8 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             for env_key, key in key_map:
                 avalon.api.Session[env_key] = workfile_context[key]
                 os.environ[env_key] = workfile_context[key]
+            self.log.info("Context changed to: {}".format(workfile_context))
+
         else:
             asset_name = current_context["asset"]
             # Handle older workfiles or workfiles without metadata
@@ -75,13 +77,11 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
                 "Workfile does not contain information about context."
                 " Using current Session context."
             )
-            workfile_context = current_context.copy()
 
         # Store context asset name
         context.data["asset"] = asset_name
         # Store workfile context
         context.data["workfile_context"] = workfile_context
-        self.log.info("Context changed to: {}".format(workfile_context))
 
         # Collect instances
         self.log.info("Collecting instance data from workfile")

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -59,6 +59,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         self.log.info("Collecting workfile context")
         workfile_context = pipeline.get_current_workfile_context()
         if workfile_context:
+            asset_name = workfile_context["asset"]
             # Change current context with context from workfile
             key_map = (
                 ("AVALON_ASSET", "asset"),
@@ -68,6 +69,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
                 avalon.api.Session[env_key] = workfile_context[key]
                 os.environ[env_key] = workfile_context[key]
         else:
+            asset_name = current_context["asset"]
             # Handle older workfiles or workfiles without metadata
             self.log.warning(
                 "Workfile does not contain information about context."
@@ -75,7 +77,9 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             )
             workfile_context = current_context.copy()
 
-        context.data["asset"] = workfile_context["AVALON_ASSET"]
+        # Store context asset name
+        context.data["asset"] = asset_name
+        # Store workfile context
         context.data["workfile_context"] = workfile_context
         self.log.info("Context changed to: {}".format(workfile_context))
 

--- a/pype/plugins/tvpaint/publish/collect_workfile_data.py
+++ b/pype/plugins/tvpaint/publish/collect_workfile_data.py
@@ -75,6 +75,7 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
             )
             workfile_context = current_context.copy()
 
+        context.data["asset"] = avalon.api.Session["AVALON_ASSET"]
         context.data["workfile_context"] = workfile_context
         self.log.info("Context changed to: {}".format(workfile_context))
 

--- a/pype/plugins/tvpaint/publish/validate_asset_name.py
+++ b/pype/plugins/tvpaint/publish/validate_asset_name.py
@@ -1,5 +1,5 @@
 import pyblish.api
-from avalon.tvpaint import pipeline, lib
+from avalon.tvpaint import pipeline
 
 
 class FixAssetNames(pyblish.api.Action):

--- a/pype/plugins/tvpaint/publish/validate_asset_name.py
+++ b/pype/plugins/tvpaint/publish/validate_asset_name.py
@@ -1,0 +1,55 @@
+import pyblish.api
+from avalon.tvpaint import pipeline, lib
+
+
+class FixAssetNames(pyblish.api.Action):
+    """Repair the asset names.
+
+    Change instanace metadata in the workfile.
+    """
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        context_asset_name = context.data["asset"]
+        old_instance_items = pipeline.list_instances()
+        new_instance_items = []
+        for instance_item in old_instance_items:
+            instance_asset_name = instance_item.get("asset")
+            if (
+                instance_asset_name
+                and instance_asset_name != context_asset_name
+            ):
+                instance_item["asset"] = context_asset_name
+            new_instance_items.append(instance_item)
+        pipeline._write_instances(new_instance_items)
+
+
+class ValidateMissingLayers(pyblish.api.ContextPlugin):
+    """Validate assset name present on instance.
+
+    Asset name on instance should be the same as context's.
+    """
+
+    label = "Validate Asset Names"
+    order = pyblish.api.ValidatorOrder
+    hosts = ["tvpaint"]
+    actions = [FixAssetNames]
+
+    def process(self, context):
+        context_asset_name = context.data["asset"]
+        for instance in context:
+            asset_name = instance.data.get("asset")
+            if asset_name and asset_name == context_asset_name:
+                continue
+
+            instance_label = (
+                instance.data.get("label") or instance.data["name"]
+            )
+            raise AssertionError((
+                "Different asset name on instance then context's."
+                " Instance \"{}\" has asset name: \"{}\""
+                " Context asset name is: \"{}\""
+            ).format(instance_label, asset_name, context_asset_name))

--- a/pype/plugins/tvpaint/publish/validate_workfile_project_name.py
+++ b/pype/plugins/tvpaint/publish/validate_workfile_project_name.py
@@ -13,7 +13,15 @@ class ValidateWorkfileProjectName(pyblish.api.ContextPlugin):
     order = pyblish.api.ValidatorOrder
 
     def process(self, context):
-        workfile_context = context.data["workfile_context"]
+        workfile_context = context.data.get("workfile_context")
+        # If workfile context is missing than project is matching to
+        #   `AVALON_PROJECT` value for 100%
+        if not workfile_context:
+            self.log.info(
+                "Workfile context (\"workfile_context\") is not filled."
+            )
+            return
+
         workfile_project_name = workfile_context["project"]
         env_project_name = os.environ["AVALON_PROJECT"]
         if workfile_project_name == env_project_name:


### PR DESCRIPTION
## Changes
- implemented asset name validation on each instance for publishing
    - asset name for publishing is used from collected instance from metadata which are handled only "On Create"
- workfile context is not used from "current context" (in `api.Session`) if workfile does not contain metadata

||Pype 3 PRs|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1319|