### PR TITLE
Ftrack custom attributes in bulks

### DIFF
--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1097,10 +1097,10 @@ class SyncEntitiesFactory:
                     "where entity_id in ({}) and configuration_id in ({})"
                 ).format(entity_ids_joined, attributes_joined)
             }]
-            if hasattr(self.session, "call"):
-                [result] = self.session.call(call_expr)
+            if hasattr(session, "call"):
+                [result] = session.call(call_expr)
             else:
-                [result] = self.session._call(call_expr)
+                [result] = session._call(call_expr)
 
             for item in result["data"]:
                 output.append(item)

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1079,12 +1079,8 @@ class SyncEntitiesFactory:
         ])
         attributes_len = len(conf_ids)
         chunk_size = int(5000 / attributes_len)
-        if chunk_size < 1:
-            chunk_size = 1
-        for idx in range(0, attributes_len, chunk_size):
+        for idx in range(0, len(entity_ids), chunk_size):
             _entity_ids = entity_ids[idx:idx + chunk_size]
-            if not _entity_ids:
-                continue
             entity_ids_joined = ", ".join([
                 "\"{}\"".format(entity_id)
                 for entity_id in _entity_ids

--- a/pype/modules/ftrack/lib/avalon_sync.py
+++ b/pype/modules/ftrack/lib/avalon_sync.py
@@ -1101,6 +1101,41 @@ class SyncEntitiesFactory:
                 self.entities_dict[child_id]["hier_attrs"].update(_hier_values)
                 hier_down_queue.put((_hier_values, child_id))
 
+    def _query_custom_attributes(self, session, conf_ids, entity_ids):
+        output = []
+        # Prepare values to query
+        attributes_joined = ", ".join([
+            "\"{}\"".format(conf_id) for conf_id in conf_ids
+        ])
+        attributes_len = len(conf_ids)
+        chunk_size = int(5000 / attributes_len)
+        if chunk_size < 1:
+            chunk_size = 1
+        for idx in range(0, attributes_len, chunk_size):
+            _entity_ids = entity_ids[idx:idx + chunk_size]
+            if not _entity_ids:
+                continue
+            entity_ids_joined = ", ".join([
+                "\"{}\"".format(entity_id)
+                for entity_id in _entity_ids
+            ])
+
+            call_expr = [{
+                "action": "query",
+                "expression": (
+                    "select value, entity_id from ContextCustomAttributeValue "
+                    "where entity_id in ({}) and configuration_id in ({})"
+                ).format(entity_ids_joined, attributes_joined)
+            }]
+            if hasattr(self.session, "call"):
+                [result] = self.session.call(call_expr)
+            else:
+                [result] = self.session._call(call_expr)
+
+            for item in result["data"]:
+                output.append(item)
+        return output
+
     def remove_from_archived(self, mongo_id):
         entity = self.avalon_archived_by_id.pop(mongo_id, None)
         if not entity:


### PR DESCRIPTION
## Issue
- on larger projects custom attributes value query may crash because of timeout (e.g. 10 custom attribute values for 20000 entities)

## Changes
- custom attribute values are not queied at once by in chunks

||Pype 3 PRs|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1313|