### PR TITLE
Blender: Load Scene Settings from Ftrack and New Validator for Object Mode

### DIFF
--- a/openpype/hosts/blender/api/__init__.py
+++ b/openpype/hosts/blender/api/__init__.py
@@ -51,18 +51,38 @@ def set_start_end_frames():
         "name": asset_name
     })
 
-    # Default frame start/end
-    frameStart = 0
-    frameEnd = 100
+    scene = bpy.context.scene
 
-    # Check if frameStart/frameEnd are set
-    if asset_doc["data"]["frameStart"]:
-        frameStart = asset_doc["data"]["frameStart"]
-    if asset_doc["data"]["frameEnd"]:
-        frameEnd = asset_doc["data"]["frameEnd"]
+    # Default scene settings
+    frameStart = scene.frame_start
+    frameEnd = scene.frame_end
+    fps = scene.render.fps
+    resolution_x = scene.render.resolution_x
+    resolution_y = scene.render.resolution_y
 
-    bpy.context.scene.frame_start = frameStart
-    bpy.context.scene.frame_end = frameEnd
+    # Check if settings are set
+    data = asset_doc.get("data")
+
+    if not data:
+        return
+
+    if data.get("frameStart"):
+        frameStart = data.get("frameStart")
+    if data.get("frameEnd"):
+        frameEnd = data.get("frameEnd")
+    if data.get("fps"):
+        fps = data.get("fps")
+    if data.get("resolutionWidth"):
+        resolution_x = data.get("resolutionWidth")
+    if data.get("resolutionHeight"):
+        resolution_y = data.get("resolutionHeight")
+
+    scene.frame_start = frameStart
+    scene.frame_end = frameEnd
+    scene.render.fps = fps
+    scene.render.resolution_x = resolution_x
+    scene.render.resolution_y = resolution_y
+
 
 def on_new(arg1, arg2):
     set_start_end_frames()

--- a/openpype/hosts/blender/plugins/publish/validate_object_mode.py
+++ b/openpype/hosts/blender/plugins/publish/validate_object_mode.py
@@ -1,0 +1,36 @@
+from typing import List
+
+import bpy
+
+import pyblish.api
+import openpype.hosts.blender.api.action
+
+
+class ValidateObjectIsInObjectMode(pyblish.api.InstancePlugin):
+    """Validate that the current object is in Object Mode."""
+
+    order = pyblish.api.ValidatorOrder - 0.01
+    hosts = ["blender"]
+    families = ["model", "rig"]
+    category = "geometry"
+    label = "Object is in Object Mode"
+    actions = [openpype.hosts.blender.api.action.SelectInvalidAction]
+    optional = True
+
+    @classmethod
+    def get_invalid(cls, instance) -> List:
+        invalid = []
+        for obj in [obj for obj in instance]:
+            try:
+                if obj.type == 'MESH' or obj.type == 'ARMATURE':
+                    # Check if the object is in object mode.
+                    if not obj.mode == 'OBJECT':
+                        invalid.append(obj)
+            except:
+                continue
+        return invalid
+
+    def process(self, instance):
+        invalid = self.get_invalid(instance)
+        if invalid:
+            raise RuntimeError(f"Object found in instance is not in Object Mode: {invalid}")

--- a/openpype/hosts/blender/plugins/publish/validate_object_mode.py
+++ b/openpype/hosts/blender/plugins/publish/validate_object_mode.py
@@ -1,7 +1,5 @@
 from typing import List
 
-import bpy
-
 import pyblish.api
 import openpype.hosts.blender.api.action
 
@@ -26,11 +24,12 @@ class ValidateObjectIsInObjectMode(pyblish.api.InstancePlugin):
                     # Check if the object is in object mode.
                     if not obj.mode == 'OBJECT':
                         invalid.append(obj)
-            except:
+            except Exception:
                 continue
         return invalid
 
     def process(self, instance):
         invalid = self.get_invalid(instance)
         if invalid:
-            raise RuntimeError(f"Object found in instance is not in Object Mode: {invalid}")
+            raise RuntimeError(
+                f"Object found in instance is not in Object Mode: {invalid}")


### PR DESCRIPTION
This PR include two small improvements for Blender. 

- When opening or creating a new file, Blender will load the scene settings (start/end frame, fps and resolution) from Ftrack
- A new validator to check that all the objects that are being published are in Object Mode