### PR TITLE
Maya: Make tx option configurable with presets

### DIFF
--- a/pype/plugins/maya/create/create_look.py
+++ b/pype/plugins/maya/create/create_look.py
@@ -12,6 +12,7 @@ class CreateLook(plugin.Creator):
     family = "look"
     icon = "paint-brush"
     defaults = ['Main']
+    make_tx = True
 
     def __init__(self, *args, **kwargs):
         super(CreateLook, self).__init__(*args, **kwargs)
@@ -19,7 +20,7 @@ class CreateLook(plugin.Creator):
         self.data["renderlayer"] = lib.get_current_renderlayer()
 
         # Whether to automatically convert the textures to .tx upon publish.
-        self.data["maketx"] = True
+        self.data["maketx"] = self.make_tx
 
         # Enable users to force a copy.
         self.data["forceCopy"] = False


### PR DESCRIPTION
## Feature
`make tx` option in look creator was not set to be configurable with creator plugin presets.