### PR TITLE
Pype info window scrollable

### DIFF
--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -202,8 +202,6 @@ class CollapsibleWidget(QtWidgets.QWidget):
 
 
 class PypeInfoWidget(QtWidgets.QWidget):
-    not_applicable = "N/A"
-
     def __init__(self, parent=None):
         super(PypeInfoWidget, self).__init__(parent)
 
@@ -213,16 +211,19 @@ class PypeInfoWidget(QtWidgets.QWidget):
         self.setWindowIcon(icon)
         self.setWindowTitle("OpenPype info")
 
+        scroll_area = QtWidgets.QScrollArea(self)
+        info_widget = PypeInfoSubWidget(scroll_area)
+
+        scroll_area.setWidget(info_widget)
+        scroll_area.setWidgetResizable(True)
+
         main_layout = QtWidgets.QVBoxLayout(self)
-        main_layout.setAlignment(QtCore.Qt.AlignTop)
-        main_layout.addWidget(self._create_openpype_info_widget(), 0)
-        main_layout.addWidget(self._create_separator(), 0)
-        main_layout.addWidget(self._create_workstation_widget(), 0)
-        main_layout.addWidget(self._create_separator(), 0)
-        main_layout.addWidget(self._create_local_settings_widget(), 0)
-        main_layout.addWidget(self._create_separator(), 0)
-        main_layout.addWidget(self._create_environ_widget(), 1)
+        main_layout.addWidget(scroll_area, 1)
+
         main_layout.addWidget(self._create_btns_section(), 0)
+
+        self.scroll_area = scroll_area
+        self.info_widget = info_widget
 
     def _create_btns_section(self):
         btns_widget = QtWidgets.QWidget(self)
@@ -367,6 +368,7 @@ class PypeInfoSubWidget(QtWidgets.QWidget):
         env_widget = CollapsibleWidget("Environments", self)
 
         env_view = EnvironmentsView(env_widget)
+        env_view.setMinimumHeight(300)
 
         env_widget.set_content_widget(env_view)
 

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -348,6 +348,7 @@ class PypeInfoSubWidget(QtWidgets.QWidget):
             )
 
         wokstation_info_widget.set_content_widget(info_widget)
+        wokstation_info_widget.toggle_content()
 
         return wokstation_info_widget
 

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -275,6 +275,24 @@ class PypeInfoWidget(QtWidgets.QWidget):
             mime_data
         )
 
+
+class PypeInfoSubWidget(QtWidgets.QWidget):
+    not_applicable = "N/A"
+
+    def __init__(self, parent=None):
+        super(PypeInfoSubWidget, self).__init__(parent)
+
+        main_layout = QtWidgets.QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setAlignment(QtCore.Qt.AlignTop)
+        main_layout.addWidget(self._create_openpype_info_widget(), 0)
+        main_layout.addWidget(self._create_separator(), 0)
+        main_layout.addWidget(self._create_workstation_widget(), 0)
+        main_layout.addWidget(self._create_separator(), 0)
+        main_layout.addWidget(self._create_local_settings_widget(), 0)
+        main_layout.addWidget(self._create_separator(), 0)
+        main_layout.addWidget(self._create_environ_widget(), 1)
+
     def _create_separator(self):
         separator_widget = QtWidgets.QWidget(self)
         separator_widget.setStyleSheet("background: #222222;")

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -111,6 +111,13 @@ class EnvironmentsView(QtWidgets.QTreeView):
         else:
             return super(EnvironmentsView, self).keyPressEvent(event)
 
+    def wheelEvent(self, event):
+        if not self.hasFocus():
+            event.ignore()
+            return
+        return super(EnvironmentsView, self).wheelEvent(event)
+
+
 
 class ClickableWidget(QtWidgets.QWidget):
     clicked = QtCore.Signal()

--- a/openpype/tools/tray/pype_info_widget.py
+++ b/openpype/tools/tray/pype_info_widget.py
@@ -219,8 +219,9 @@ class PypeInfoWidget(QtWidgets.QWidget):
 
         main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.addWidget(scroll_area, 1)
-
         main_layout.addWidget(self._create_btns_section(), 0)
+
+        self.resize(740, 540)
 
         self.scroll_area = scroll_area
         self.info_widget = info_widget


### PR DESCRIPTION
## Changes
- pype info widget is wrapped into scrollable area so not matter how much environments are set all can be visible without moving the window out of desktop

## Potential changes
- set default size (maybe default size on open is too small)

## Screnshot
![image](https://user-images.githubusercontent.com/43494761/114683700-86b55380-9d10-11eb-94af-7924250d2154.png)
