### PR TITLE
OpenPype root redefinition

### DIFF
--- a/openpype/hooks/pre_python2_vendor.py
+++ b/openpype/hooks/pre_python2_vendor.py
@@ -11,7 +11,7 @@ class PrePython2Vendor(PreLaunchHook):
     def execute(self):
         # Prepare vendor dir path
         self.log.info("adding global python 2 vendor")
-        pype_root = os.getenv("OPENPYPE_ROOT")
+        pype_root = os.getenv("OPENPYPE_REPOS_ROOT")
         python_2_vendor = os.path.join(
             pype_root,
             "openpype",

--- a/openpype/lib/__init__.py
+++ b/openpype/lib/__init__.py
@@ -9,7 +9,7 @@ import site
 # add Python version specific vendor folder
 site.addsitedir(
     os.path.join(
-        os.getenv("OPENPYPE_ROOT", ""),
+        os.getenv("OPENPYPE_REPOS_ROOT", ""),
         "vendor", "python", "python_{}".format(sys.version[0])))
 
 from .terminal import Terminal

--- a/openpype/lib/import_utils.py
+++ b/openpype/lib/import_utils.py
@@ -8,7 +8,7 @@ log = Logger().get_logger(__name__)
 
 def discover_host_vendor_module(module_name):
     host = os.environ["AVALON_APP"]
-    pype_root = os.environ["OPENPYPE_ROOT"]
+    pype_root = os.environ["OPENPYPE_REPOS_ROOT"]
     main_module = module_name.split(".")[0]
     module_path = os.path.join(
         pype_root, "hosts", host, "vendor", main_module)

--- a/openpype/lib/pype_info.py
+++ b/openpype/lib/pype_info.py
@@ -28,7 +28,7 @@ def get_pype_info():
         "version": get_pype_version(),
         "version_type": version_type,
         "executable": executable_args[-1],
-        "pype_root": os.environ["OPENPYPE_ROOT"],
+        "pype_root": os.environ["OPENPYPE_REPOS_ROOT"],
         "mongo_url": os.environ["OPENPYPE_MONGO"]
     }
 

--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -6,9 +6,9 @@
         "host_name": "maya",
         "environment": {
             "PYTHONPATH": [
-                "{OPENPYPE_ROOT}/openpype/hosts/maya/startup",
-                "{OPENPYPE_ROOT}/repos/avalon-core/setup/maya",
-                "{OPENPYPE_ROOT}/repos/maya-look-assigner",
+                "{OPENPYPE_REPOS_ROOT}/openpype/hosts/maya/startup",
+                "{OPENPYPE_REPOS_ROOT}/repos/avalon-core/setup/maya",
+                "{OPENPYPE_REPOS_ROOT}/repos/maya-look-assigner",
                 "{PYTHONPATH}"
             ],
             "MAYA_DISABLE_CLIC_IPM": "Yes",
@@ -85,8 +85,8 @@
         "host_name": "nuke",
         "environment": {
             "NUKE_PATH": [
-                "{OPENPYPE_ROOT}/repos/avalon-core/setup/nuke/nuke_path",
-                "{OPENPYPE_ROOT}/openpype/hosts/nuke/startup",
+                "{OPENPYPE_REPOS_ROOT}/repos/avalon-core/setup/nuke/nuke_path",
+                "{OPENPYPE_REPOS_ROOT}/openpype/hosts/nuke/startup",
                 "{OPENPYPE_STUDIO_PLUGINS}/nuke"
             ],
             "PATH": {
@@ -175,8 +175,8 @@
         "host_name": "nuke",
         "environment": {
             "NUKE_PATH": [
-                "{OPENPYPE_ROOT}/repos/avalon-core/setup/nuke/nuke_path",
-                "{OPENPYPE_ROOT}/openpype/hosts/nuke/startup",
+                "{OPENPYPE_REPOS_ROOT}/repos/avalon-core/setup/nuke/nuke_path",
+                "{OPENPYPE_REPOS_ROOT}/openpype/hosts/nuke/startup",
                 "{OPENPYPE_STUDIO_PLUGINS}/nuke"
             ],
             "PATH": {
@@ -290,7 +290,7 @@
         "host_name": "hiero",
         "environment": {
             "HIERO_PLUGIN_PATH": [
-                "{OPENPYPE_ROOT}/openpype/hosts/hiero/startup"
+                "{OPENPYPE_REPOS_ROOT}/openpype/hosts/hiero/startup"
             ],
             "PATH": {
                 "windows": "C:/Program Files (x86)/QuickTime/QTSystem/;{PATH}"
@@ -403,7 +403,7 @@
         "host_name": "hiero",
         "environment": {
             "HIERO_PLUGIN_PATH": [
-                "{OPENPYPE_ROOT}/openpype/hosts/hiero/startup"
+                "{OPENPYPE_REPOS_ROOT}/openpype/hosts/hiero/startup"
             ],
             "PATH": {
                 "windows": "C:/Program Files (x86)/QuickTime/QTSystem/;{PATH}"
@@ -614,7 +614,7 @@
                 "{PYTHON36_RESOLVE}/Scripts",
                 "{PATH}"
             ],
-            "PRE_PYTHON_SCRIPT": "{OPENPYPE_ROOT}/openpype/resolve/preload_console.py",
+            "PRE_PYTHON_SCRIPT": "{OPENPYPE_REPOS_ROOT}/openpype/resolve/preload_console.py",
             "OPENPYPE_LOG_NO_COLORS": "True",
             "RESOLVE_DEV": "True"
         },
@@ -645,14 +645,14 @@
         "host_name": "houdini",
         "environment": {
             "HOUDINI_PATH": {
-                "darwin": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup:&",
-                "linux": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup:&",
-                "windows": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup;&"
+                "darwin": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup:&",
+                "linux": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup:&",
+                "windows": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup;&"
             },
             "HOUDINI_MENU_PATH": {
-                "darwin": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup:&",
-                "linux": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup:&",
-                "windows": "{OPENPYPE_ROOT}/openpype/hosts/houdini/startup;&"
+                "darwin": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup:&",
+                "linux": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup:&",
+                "windows": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/houdini/startup;&"
             }
         },
         "variants": {
@@ -710,9 +710,9 @@
         "icon": "{}/app_icons/blender.png",
         "host_name": "blender",
         "environment": {
-            "BLENDER_USER_SCRIPTS": "{OPENPYPE_ROOT}/repos/avalon-core/setup/blender",
+            "BLENDER_USER_SCRIPTS": "{OPENPYPE_REPOS_ROOT}/repos/avalon-core/setup/blender",
             "PYTHONPATH": [
-                "{OPENPYPE_ROOT}/repos/avalon-core/setup/blender",
+                "{OPENPYPE_REPOS_ROOT}/repos/avalon-core/setup/blender",
                 "{PYTHONPATH}"
             ],
             "QT_PREFERRED_BINDING": "PySide2"
@@ -773,7 +773,7 @@
         "host_name": "harmony",
         "environment": {
             "AVALON_HARMONY_WORKFILES_ON_LAUNCH": "1",
-            "LIB_OPENHARMONY_PATH": "{OPENPYPE_ROOT}/pype/vendor/OpenHarmony"
+            "LIB_OPENHARMONY_PATH": "{OPENPYPE_REPOS_ROOT}/pype/vendor/OpenHarmony"
         },
         "variants": {
             "20": {
@@ -957,7 +957,7 @@
         "icon": "app_icons/celaction.png",
         "host_name": "celaction",
         "environment": {
-            "CELACTION_TEMPLATE": "{OPENPYPE_ROOT}/openpype/hosts/celaction/celaction_template_scene.scn"
+            "CELACTION_TEMPLATE": "{OPENPYPE_REPOS_ROOT}/openpype/hosts/celaction/celaction_template_scene.scn"
         },
         "variants": {
             "local": {
@@ -983,7 +983,7 @@
         "icon": "{}/app_icons/ue4.png'",
         "host_name": "unreal",
         "environment": {
-            "AVALON_UNREAL_PLUGIN": "{OPENPYPE_ROOT}/repos/avalon-unreal-integration",
+            "AVALON_UNREAL_PLUGIN": "{OPENPYPE_REPOS_ROOT}/repos/avalon-unreal-integration",
             "OPENPYPE_LOG_NO_COLORS": "True",
             "QT_PREFERRED_BINDING": "PySide"
         },

--- a/openpype/settings/defaults/system_settings/general.json
+++ b/openpype/settings/defaults/system_settings/general.json
@@ -3,9 +3,9 @@
     "studio_code": "stu",
     "environment": {
         "FFMPEG_PATH": {
-            "windows": "{OPENPYPE_ROOT}/vendor/bin/ffmpeg_exec/windows/bin",
-            "darwin": "{OPENPYPE_ROOT}/vendor/bin/ffmpeg_exec/darwin/bin",
-            "linux": ":{OPENPYPE_ROOT}/vendor/bin/ffmpeg_exec/linux"
+            "windows": "{OPENPYPE_REPOS_ROOT}/vendor/bin/ffmpeg_exec/windows/bin",
+            "darwin": "{OPENPYPE_REPOS_ROOT}/vendor/bin/ffmpeg_exec/darwin/bin",
+            "linux": ":{OPENPYPE_REPOS_ROOT}/vendor/bin/ffmpeg_exec/linux"
         },
         "OPENPYPE_OCIO_CONFIG": "{STUDIO_SOFT}/OpenColorIO-Configs",
         "__environment_keys__": {

--- a/start.py
+++ b/start.py
@@ -475,16 +475,10 @@ def _bootstrap_from_code(use_version):
     # run through repos and add them to `sys.path` and `PYTHONPATH`
     # set root
     if getattr(sys, 'frozen', False):
-        openpype_root = os.path.normpath(
-            os.path.dirname(sys.executable))
-        local_version = bootstrap.get_version(Path(openpype_root))
+        local_version = bootstrap.get_version(Path(OPENPYPE_ROOT))
         print(f"  - running version: {local_version}")
         assert local_version
     else:
-        openpype_root = os.path.normpath(
-            os.path.dirname(
-                os.path.dirname(
-                    os.path.realpath(igniter.__file__))))
         # get current version of OpenPype
         local_version = bootstrap.get_local_live_version()
 
@@ -498,14 +492,17 @@ def _bootstrap_from_code(use_version):
             bootstrap.add_paths_from_directory(version_path)
             os.environ["OPENPYPE_VERSION"] = use_version
     else:
-        version_path = openpype_root
-    os.environ["OPENPYPE_ROOT"] = openpype_root
-    repos = os.listdir(os.path.join(openpype_root, "repos"))
-    repos = [os.path.join(openpype_root, "repos", repo) for repo in repos]
+        version_path = OPENPYPE_ROOT
+
+    repos = os.listdir(os.path.join(OPENPYPE_ROOT, "repos"))
+    repos = [os.path.join(OPENPYPE_ROOT, "repos", repo) for repo in repos]
     # add self to python paths
-    repos.insert(0, openpype_root)
+    repos.insert(0, OPENPYPE_ROOT)
     for repo in repos:
         sys.path.insert(0, repo)
+
+    # Set OPENPYPE_REPOS_ROOT to code root
+    os.environ["OPENPYPE_REPOS_ROOT"] = OPENPYPE_ROOT
 
     # add venv 'site-packages' to PYTHONPATH
     python_path = os.getenv("PYTHONPATH", "")
@@ -517,15 +514,15 @@ def _bootstrap_from_code(use_version):
     # in case when we are running without any version installed.
     if not getattr(sys, 'frozen', False):
         split_paths.append(site.getsitepackages()[-1])
-        # TODO move additional paths to `boot` part when OPENPYPE_ROOT will point
-        # to same hierarchy from code and from frozen OpenPype
+        # TODO move additional paths to `boot` part when OPENPYPE_ROOT will
+        # point to same hierarchy from code and from frozen OpenPype
         additional_paths = [
             # add OpenPype tools
-            os.path.join(os.environ["OPENPYPE_ROOT"], "openpype", "tools"),
+            os.path.join(OPENPYPE_ROOT, "openpype", "tools"),
             # add common OpenPype vendor
             # (common for multiple Python interpreter versions)
             os.path.join(
-                os.environ["OPENPYPE_ROOT"],
+                OPENPYPE_ROOT,
                 "openpype",
                 "vendor",
                 "python",

--- a/start.py
+++ b/start.py
@@ -590,7 +590,7 @@ def boot():
     # ------------------------------------------------------------------------
     # Find OpenPype versions
     # ------------------------------------------------------------------------
-    # WARNING: Environment OPENPYPE_ROOT may change if frozen OpenPype
+    # WARNING: Environment OPENPYPE_REPOS_ROOT may change if frozen OpenPype
     # is executed
     if getattr(sys, 'frozen', False):
         # find versions of OpenPype to be used with frozen code

--- a/start.py
+++ b/start.py
@@ -100,10 +100,20 @@ import subprocess
 import site
 from pathlib import Path
 
-# add dependencies folder to sys.pat for frozen code
-if getattr(sys, 'frozen', False):
+# OPENPYPE_ROOT is variable pointing to build (or code) directory
+# WARNING `OPENPYPE_ROOT` must be defined before igniter import
+# - igniter changes cwd which cause that filepath of this script won't lead
+#   to right directory
+if not getattr(sys, 'frozen', False):
+    # Code root defined by `start.py` directory
+    OPENPYPE_ROOT = os.path.dirname(os.path.abspath(__file__))
+else:
+    OPENPYPE_ROOT = os.path.dirname(sys.executable)
+
+    # add dependencies folder to sys.pat for frozen code
     frozen_libs = os.path.normpath(
-        os.path.join(os.path.dirname(sys.executable), "dependencies"))
+        os.path.join(OPENPYPE_ROOT, "dependencies")
+    )
     sys.path.append(frozen_libs)
     # add stuff from `<frozen>/dependencies` to PYTHONPATH.
     pythonpath = os.getenv("PYTHONPATH", "")

--- a/start.py
+++ b/start.py
@@ -326,23 +326,25 @@ def _determine_mongodb() -> str:
 def _initialize_environment(openpype_version: OpenPypeVersion) -> None:
     version_path = openpype_version.path
     os.environ["OPENPYPE_VERSION"] = openpype_version.version
-    # set OPENPYPE_ROOT to point to currently used OpenPype version.
-    os.environ["OPENPYPE_ROOT"] = os.path.normpath(version_path.as_posix())
+    # set OPENPYPE_REPOS_ROOT to point to currently used OpenPype version.
+    os.environ["OPENPYPE_REPOS_ROOT"] = os.path.normpath(
+        version_path.as_posix()
+    )
     # inject version to Python environment (sys.path, ...)
     print(">>> Injecting OpenPype version to running environment  ...")
     bootstrap.add_paths_from_directory(version_path)
 
-    # Additional sys paths related to OPENPYPE_ROOT directory
-    # TODO move additional paths to `boot` part when OPENPYPE_ROOT will point
-    # to same hierarchy from code and from frozen OpenPype
+    # Additional sys paths related to OPENPYPE_REPOS_ROOT directory
+    # TODO move additional paths to `boot` part when OPENPYPE_REPOS_ROOT will
+    # point to same hierarchy from code and from frozen OpenPype
     additional_paths = [
-        os.environ["OPENPYPE_ROOT"],
+        os.environ["OPENPYPE_REPOS_ROOT"],
         # add OpenPype tools
-        os.path.join(os.environ["OPENPYPE_ROOT"], "openpype", "tools"),
+        os.path.join(os.environ["OPENPYPE_REPOS_ROOT"], "openpype", "tools"),
         # add common OpenPype vendor
         # (common for multiple Python interpreter versions)
         os.path.join(
-            os.environ["OPENPYPE_ROOT"],
+            os.environ["OPENPYPE_REPOS_ROOT"],
             "openpype",
             "vendor",
             "python",
@@ -363,7 +365,7 @@ def _find_frozen_openpype(use_version: str = None,
     """Find OpenPype to run from frozen code.
 
     This will process and modify environment variables:
-    ``PYTHONPATH``, ``OPENPYPE_VERSION``, ``OPENPYPE_ROOT``
+    ``PYTHONPATH``, ``OPENPYPE_VERSION``, ``OPENPYPE_REPOS_ROOT``
 
     Args:
         use_version (str, optional): Try to use specified version.

--- a/start.py
+++ b/start.py
@@ -544,6 +544,11 @@ def boot():
     """Bootstrap OpenPype."""
 
     # ------------------------------------------------------------------------
+    # Set environment to OpenPype root path
+    # ------------------------------------------------------------------------
+    os.environ["OPENPYPE_ROOT"] = OPENPYPE_ROOT
+
+    # ------------------------------------------------------------------------
     # Play animation
     # ------------------------------------------------------------------------
 
@@ -573,16 +578,6 @@ def boot():
     os.environ["OPENPYPE_MONGO"] = openpype_mongo
     os.environ["OPENPYPE_DATABASE_NAME"] = "openpype"  # name of Pype database
 
-    # ------------------------------------------------------------------------
-    # Set environments - load OpenPype path from database (if set)
-    # ------------------------------------------------------------------------
-    # set OPENPYPE_ROOT to running location until proper version can be
-    # determined.
-    if getattr(sys, 'frozen', False):
-        os.environ["OPENPYPE_ROOT"] = os.path.dirname(sys.executable)
-    else:
-        os.environ["OPENPYPE_ROOT"] = os.path.dirname(__file__)
-
     # Get openpype path from database and set it to environment so openpype can
     # find its versions there and bootstrap them.
     openpype_path = get_openpype_path_from_db(openpype_mongo)
@@ -611,12 +606,6 @@ def boot():
     # set this to point either to `python` from venv in case of live code
     # or to `openpype` or `openpype_console` in case of frozen code
     os.environ["OPENPYPE_EXECUTABLE"] = sys.executable
-
-    if getattr(sys, 'frozen', False):
-        os.environ["OPENPYPE_REPOS_ROOT"] = os.environ["OPENPYPE_ROOT"]
-    else:
-        os.environ["OPENPYPE_REPOS_ROOT"] = os.path.join(
-            os.environ["OPENPYPE_ROOT"], "repos")
 
     # delete OpenPype module and it's submodules from cache so it is used from
     # specific version

--- a/start.py
+++ b/start.py
@@ -676,7 +676,9 @@ def get_info() -> list:
         inf.append(("OpenPype variant", "staging"))
     else:
         inf.append(("OpenPype variant", "production"))
-    inf.append(("Running OpenPype from", os.environ.get('OPENPYPE_ROOT')))
+    inf.append(
+        ("Running OpenPype from", os.environ.get('OPENPYPE_REPOS_ROOT'))
+    )
     inf.append(("Using mongodb", components["host"]))
 
     if os.environ.get("FTRACK_SERVER"):


### PR DESCRIPTION
## Description
We currently have `OPENPYPE_ROOT` and `OPENPYPE_REPOS_ROOT` both lead to same direcotry path of used openpype version on launch but we don't have defined path to executable directory or code directory. It was discussed that `OPENPYPE_ROOT` should be used for this purpose and lead to executable directory or code directory all the time and `OPENPYPE_REPOS_ROOT` to root of used version ([Discussed here](https://github.com/pypeclub/pype/pull/1240/files))

## Changes
- `OPENPYPE_ROOT` is not used to store path to directory of used openpype version but to directory of executable or code source
- `OPENPYPE_REPOS_ROOT` replaced usage of `OPENPYPE_ROOT` in settings and code