### PR TITLE
TV Paint: Validate mark in and out.

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_instances.py
@@ -34,8 +34,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
             instance_data["name"] = name
             instance_data["label"] = "{} [{}-{}]".format(
                 name,
-                context.data["sceneFrameStart"],
-                context.data["sceneFrameEnd"]
+                context.data["sceneMarkIn"] + 1,
+                context.data["sceneMarkOut"] + 1
             )
 
             active = instance_data.get("active", True)
@@ -78,8 +78,8 @@ class CollectInstances(pyblish.api.ContextPlugin):
             if instance is None:
                 continue
 
-            instance.data["frameStart"] = context.data["sceneFrameStart"]
-            instance.data["frameEnd"] = context.data["sceneFrameEnd"]
+            instance.data["frameStart"] = context.data["sceneMarkIn"] + 1
+            instance.data["frameEnd"] = context.data["sceneMarkOut"] + 1
 
             self.log.debug("Created instance: {}\n{}".format(
                 instance, json.dumps(instance.data, indent=4)

--- a/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_workfile_data.py
@@ -122,36 +122,26 @@ class CollectWorkfileData(pyblish.api.ContextPlugin):
         width = int(workfile_info_parts.pop(-1))
         workfile_path = " ".join(workfile_info_parts).replace("\"", "")
 
-        frame_start, frame_end = self.collect_clip_frames()
+        # Marks return as "{frame - 1} {state} ", example "0 set".
+        result = lib.execute_george("tv_markin")
+        mark_in_frame, mark_in_state, _ = result.split(" ")
+
+        result = lib.execute_george("tv_markout")
+        mark_out_frame, mark_out_state, _ = result.split(" ")
+
         scene_data = {
             "currentFile": workfile_path,
             "sceneWidth": width,
             "sceneHeight": height,
             "scenePixelAspect": pixel_apsect,
-            "sceneFrameStart": frame_start,
-            "sceneFrameEnd": frame_end,
             "sceneFps": frame_rate,
-            "sceneFieldOrder": field_order
+            "sceneFieldOrder": field_order,
+            "sceneMarkIn": int(mark_in_frame),
+            "sceneMarkInState": mark_in_state == "set",
+            "sceneMarkOut": int(mark_out_frame),
+            "sceneMarkOutState": mark_out_state == "set"
         }
         self.log.debug(
             "Scene data: {}".format(json.dumps(scene_data, indent=4))
         )
         context.data.update(scene_data)
-
-    def collect_clip_frames(self):
-        clip_info_str = lib.execute_george("tv_clipinfo")
-        self.log.debug("Clip info: {}".format(clip_info_str))
-        clip_info_items = clip_info_str.split(" ")
-        # Color index - not used
-        clip_info_items.pop(-1)
-        clip_info_items.pop(-1)
-
-        mark_out = int(clip_info_items.pop(-1))
-        frame_end = mark_out + 1
-        clip_info_items.pop(-1)
-
-        mark_in = int(clip_info_items.pop(-1))
-        frame_start = mark_in + 1
-        clip_info_items.pop(-1)
-
-        return frame_start, frame_end

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -41,18 +41,11 @@ class ValidateMarks(pyblish.api.ContextPlugin):
         }
 
     def process(self, context):
-        # Marks return as "{frame - 1} {state} ", example "0 set".
-        result = lib.execute_george("tv_markin")
-        mark_in_frame, mark_in_state, _ = result.split(" ")
-
-        result = lib.execute_george("tv_markout")
-        mark_out_frame, mark_out_state, _ = result.split(" ")
-
         current_data = {
-            "markIn": int(mark_in_frame) + 1,
-            "markInState": mark_in_state == "set",
-            "markOut": int(mark_out_frame) + 1,
-            "markOutState": mark_out_state == "set"
+            "markIn": context.data["sceneMarkIn"] + 1,
+            "markInState": context.data["sceneMarkInState"],
+            "markOut": context.data["sceneMarkOut"] + 1,
+            "markOutState": context.data["sceneMarkOutState"]
         }
         expected_data = self.get_expected_data(context)
         invalid = {}

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -13,6 +13,10 @@ class ValidateMarksRepair(pyblish.api.Action):
 
     def process(self, context, plugin):
         expected_data = ValidateMarks.get_expected_data(context)
+
+        expected_data["markIn"] -= 1
+        expected_data["markOut"] -= 1
+
         lib.execute_george("tv_markin {} set".format(expected_data["markIn"]))
         lib.execute_george(
             "tv_markout {} set".format(expected_data["markOut"])
@@ -30,9 +34,9 @@ class ValidateMarks(pyblish.api.ContextPlugin):
     @staticmethod
     def get_expected_data(context):
         return {
-            "markIn": context.data["assetEntity"]["data"]["frameStart"] - 1,
+            "markIn": int(context.data["frameStart"]),
             "markInState": True,
-            "markOut": context.data["assetEntity"]["data"]["frameEnd"] - 1,
+            "markOut": int(context.data["frameEnd"]),
             "markOutState": True
         }
 
@@ -45,9 +49,9 @@ class ValidateMarks(pyblish.api.ContextPlugin):
         mark_out_frame, mark_out_state, _ = result.split(" ")
 
         current_data = {
-            "markIn": int(mark_in_frame),
+            "markIn": int(mark_in_frame) + 1,
             "markInState": mark_in_state == "set",
-            "markOut": int(mark_out_frame),
+            "markOut": int(mark_out_frame) + 1,
             "markOutState": mark_out_state == "set"
         }
         expected_data = self.get_expected_data(context)

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -12,7 +12,7 @@ class ValidateMarksRepair(pyblish.api.Action):
     on = "failed"
 
     def process(self, context, plugin):
-        expected_data = ValidateMarks().get_expected_data(context)
+        expected_data = ValidateMarks.get_expected_data(context)
         lib.execute_george("tv_markin {} set".format(expected_data["markIn"]))
         lib.execute_george(
             "tv_markout {} set".format(expected_data["markOut"])
@@ -27,7 +27,8 @@ class ValidateMarks(pyblish.api.ContextPlugin):
     optional = True
     actions = [ValidateMarksRepair]
 
-    def get_expected_data(self, context):
+    @staticmethod
+    def get_expected_data(context):
         return {
             "markIn": context.data["assetEntity"]["data"]["frameStart"] - 1,
             "markInState": True,
@@ -55,7 +56,7 @@ class ValidateMarks(pyblish.api.ContextPlugin):
             if current_data[k] != expected_data[k]:
                 invalid[k] = {
                     "current": current_data[k],
-                    "expected_data": expected_data[k]
+                    "expected": expected_data[k]
                 }
 
         if invalid:

--- a/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_marks.py
@@ -1,0 +1,66 @@
+import json
+
+import pyblish.api
+from avalon.tvpaint import lib
+
+
+class ValidateMarksRepair(pyblish.api.Action):
+    """Repair the marks."""
+
+    label = "Repair"
+    icon = "wrench"
+    on = "failed"
+
+    def process(self, context, plugin):
+        expected_data = ValidateMarks().get_expected_data(context)
+        lib.execute_george("tv_markin {} set".format(expected_data["markIn"]))
+        lib.execute_george(
+            "tv_markout {} set".format(expected_data["markOut"])
+        )
+
+
+class ValidateMarks(pyblish.api.ContextPlugin):
+    """Validate mark in and out are enabled."""
+
+    label = "Validate Marks"
+    order = pyblish.api.ValidatorOrder
+    optional = True
+    actions = [ValidateMarksRepair]
+
+    def get_expected_data(self, context):
+        return {
+            "markIn": context.data["assetEntity"]["data"]["frameStart"] - 1,
+            "markInState": True,
+            "markOut": context.data["assetEntity"]["data"]["frameEnd"] - 1,
+            "markOutState": True
+        }
+
+    def process(self, context):
+        # Marks return as "{frame - 1} {state} ", example "0 set".
+        result = lib.execute_george("tv_markin")
+        mark_in_frame, mark_in_state, _ = result.split(" ")
+
+        result = lib.execute_george("tv_markout")
+        mark_out_frame, mark_out_state, _ = result.split(" ")
+
+        current_data = {
+            "markIn": int(mark_in_frame),
+            "markInState": mark_in_state == "set",
+            "markOut": int(mark_out_frame),
+            "markOutState": mark_out_state == "set"
+        }
+        expected_data = self.get_expected_data(context)
+        invalid = {}
+        for k in current_data.keys():
+            if current_data[k] != expected_data[k]:
+                invalid[k] = {
+                    "current": current_data[k],
+                    "expected_data": expected_data[k]
+                }
+
+        if invalid:
+            raise AssertionError(
+                "Marks does not match database:\n{}".format(
+                    json.dumps(invalid, sort_keys=True, indent=4)
+                )
+            )

--- a/openpype/hosts/tvpaint/plugins/publish/validate_project_settings.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_project_settings.py
@@ -13,8 +13,6 @@ class ValidateProjectSettings(pyblish.api.ContextPlugin):
 
     def process(self, context):
         scene_data = {
-            "frameStart": context.data.get("sceneFrameStart"),
-            "frameEnd": context.data.get("sceneFrameEnd"),
             "fps": context.data.get("sceneFps"),
             "resolutionWidth": context.data.get("sceneWidth"),
             "resolutionHeight": context.data.get("sceneHeight"),

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -1,6 +1,6 @@
 {
     "publish": {
-        "ValidateMissingLayers": {
+        "ValidateProjectSettings": {
             "enabled": true,
             "optional": true,
             "active": true

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -4,6 +4,11 @@
             "enabled": true,
             "optional": true,
             "active": true
+        },
+        "ValidateMarks": {
+            "enabled": true,
+            "optional": true,
+            "active": true
         }
     },
     "filters": {}

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -17,8 +17,9 @@
                     "name": "template_publish_plugin",
                     "template_data": [
                         {
-                            "key": "ValidateMissingLayers",
-                            "label": "ValidateMissingLayers"
+                            "key": "ValidateProjectSettings",
+                            "label": "ValidateProjectSettings",
+                            "docstring": "Validate if FPS and Resolution match shot data"
                         }
                     ]
                 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -22,6 +22,17 @@
                             "docstring": "Validate if FPS and Resolution match shot data"
                         }
                     ]
+                },
+                {
+                    "type": "schema_template",
+                    "name": "template_publish_plugin",
+                    "template_data": [
+                        {
+                            "key": "ValidateMarks",
+                            "label": "Validate MarkIn/Out",
+                            "docstring": "Validate MarkIn/Out match Frame start/end on shot data"
+                        }
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
Pype 3 version of https://github.com/pypeclub/pype/pull/1298

This validator checks whether the mark in and out are enabled, and set to the database settings.

If mark in/out are disabled, TVP will return the exposure frame range. In some cases the exposure frame range and the shots frame range can differ, so it more consistent to make sure the mark in/out are set and enabled.
When rendering the last frame gets extended to the fill the mark out range.

This has a repair action for enabling and setting the mark in/out to the database asset settings.

## Pype 3 changes
- added settings for `ValidateMarks`
- replaced `ValidateProjectSettings` with `ValidateMissingLayers` in settings (bad name in [PR](https://github.com/pypeclub/pype/pull/1320))

||Pype 2 PRs|
|---|---|
|pype|https://github.com/pypeclub/pype/pull/1298|