### PR TITLE
Ftrack URL cleanup

### DIFF
--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -42,7 +42,16 @@ class FtrackModule(
         ftrack_settings = settings[self.name]
 
         self.enabled = ftrack_settings["enabled"]
-        self.ftrack_url = ftrack_settings["ftrack_server"].strip("/ ")
+        # Add http schema
+        ftrack_url = ftrack_settings["ftrack_server"].strip("/ ")
+        if "http" not in ftrack_url:
+            ftrack_url = "https://" + ftrack_url
+
+        # Check if "ftrack.app" is part os url
+        if "ftrackapp.com" not in ftrack_url:
+            ftrack_url = ftrack_url + ".ftrackapp.com"
+
+        self.ftrack_url = ftrack_url
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         server_event_handlers_paths = [

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -44,12 +44,13 @@ class FtrackModule(
         self.enabled = ftrack_settings["enabled"]
         # Add http schema
         ftrack_url = ftrack_settings["ftrack_server"].strip("/ ")
-        if "http" not in ftrack_url:
-            ftrack_url = "https://" + ftrack_url
+        if ftrack_url:
+            if "http" not in ftrack_url:
+                ftrack_url = "https://" + ftrack_url
 
-        # Check if "ftrack.app" is part os url
-        if "ftrackapp.com" not in ftrack_url:
-            ftrack_url = ftrack_url + ".ftrackapp.com"
+            # Check if "ftrack.app" is part os url
+            if "ftrackapp.com" not in ftrack_url:
+                ftrack_url = ftrack_url + ".ftrackapp.com"
 
         self.ftrack_url = ftrack_url
 

--- a/openpype/modules/ftrack/lib/credentials.py
+++ b/openpype/modules/ftrack/lib/credentials.py
@@ -15,7 +15,10 @@ API_KEY_KEY = "api_key"
 
 def get_ftrack_hostname(ftrack_server=None):
     if not ftrack_server:
-        ftrack_server = os.environ["FTRACK_SERVER"]
+        ftrack_server = os.environ.get("FTRACK_SERVER")
+
+    if not ftrack_server:
+        return None
 
     if "//" not in ftrack_server:
         ftrack_server = "//" + ftrack_server
@@ -29,17 +32,24 @@ def _get_ftrack_secure_key(hostname, key):
 
 
 def get_credentials(ftrack_server=None):
+    output = {
+        USERNAME_KEY: None,
+        API_KEY_KEY: None
+    }
     hostname = get_ftrack_hostname(ftrack_server)
+    if not hostname:
+        return output
+
     username_name = _get_ftrack_secure_key(hostname, USERNAME_KEY)
     api_key_name = _get_ftrack_secure_key(hostname, API_KEY_KEY)
 
     username_registry = OpenPypeSecureRegistry(username_name)
     api_key_registry = OpenPypeSecureRegistry(api_key_name)
 
-    return {
-        USERNAME_KEY: username_registry.get_item(USERNAME_KEY, None),
-        API_KEY_KEY: api_key_registry.get_item(API_KEY_KEY, None)
-    }
+    output[USERNAME_KEY] = username_registry.get_item(USERNAME_KEY, None)
+    output[API_KEY_KEY] = api_key_registry.get_item(API_KEY_KEY, None)
+
+    return output
 
 
 def save_credentials(username, api_key, ftrack_server=None):
@@ -77,9 +87,9 @@ def clear_credentials(ftrack_server=None):
 
 def check_credentials(username, api_key, ftrack_server=None):
     if not ftrack_server:
-        ftrack_server = os.environ["FTRACK_SERVER"]
+        ftrack_server = os.environ.get("FTRACK_SERVER")
 
-    if not username or not api_key:
+    if not ftrack_server or not username or not api_key:
         return False
 
     try:

--- a/openpype/modules/ftrack/tray/ftrack_tray.py
+++ b/openpype/modules/ftrack/tray/ftrack_tray.py
@@ -289,12 +289,6 @@ class FtrackTrayWrapper:
 
         parent_menu.addMenu(tray_menu)
 
-    def tray_start(self):
-        self.validate()
-
-    def tray_exit(self):
-        self.stop_action_server()
-
     # Definition of visibility of each menu actions
     def set_menu_visibility(self):
         self.tray_server_menu.menuAction().setVisible(self.bool_logged)

--- a/openpype/modules/ftrack/tray/login_dialog.py
+++ b/openpype/modules/ftrack/tray/login_dialog.py
@@ -134,11 +134,11 @@ class CredentialsDialog(QtWidgets.QDialog):
 
     def fill_ftrack_url(self):
         url = os.getenv("FTRACK_SERVER")
-        if url == self.ftsite_input.text():
+        checked_url = self.check_url(url)
+        if checked_url == self.ftsite_input.text():
             return
 
-        checked_url = self.check_url(url)
-        self.ftsite_input.setText(checked_url or "")
+        self.ftsite_input.setText(checked_url or "< Not set >")
 
         enabled = bool(checked_url)
 
@@ -147,7 +147,15 @@ class CredentialsDialog(QtWidgets.QDialog):
 
         self.api_input.setEnabled(enabled)
         self.user_input.setEnabled(enabled)
-        self.ftsite_input.setEnabled(enabled)
+
+        if not url:
+            self.btn_advanced.hide()
+            self.btn_simple.hide()
+            self.btn_ftrack_login.hide()
+            self.btn_login.hide()
+            self.note_label.hide()
+            self.api_input.hide()
+            self.user_input.hide()
 
     def set_advanced_mode(self, is_advanced):
         self._in_advance_mode = is_advanced
@@ -293,10 +301,9 @@ class CredentialsDialog(QtWidgets.QDialog):
             url = url.strip("/ ")
 
         if not url:
-            self.set_error((
-                "You need to specify a valid server URL, "
-                "for example https://server-name.ftrackapp.com"
-            ))
+            self.set_error(
+                "Ftrack URL is not defined in settings!"
+            )
             return
 
         if "http" not in url:


### PR DESCRIPTION
## Changes
- ftrack url is filled with schema (`https`) if is not in settings and finished with `.ftrackapp.com` if is not part of url
- ftrack module won't crash if FTRACK_URL is not set
- ftrack login gui shows only ftrack url input and error message if ftrack url is not set