### PR TITLE
Maya 2022 and Python 3

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -581,7 +581,7 @@ def get_shader_assignments_from_shapes(shapes, components=True):
 
         # Build a mapping from parent to shapes to include in lookup.
         transforms = {shape.rsplit("|", 1)[0]: shape for shape in shapes}
-        lookup = set(shapes + transforms.keys())
+        lookup = set(shapes) | set(transforms.keys())
 
         component_assignments = defaultdict(list)
         for shading_group in assignments.keys():

--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -437,7 +437,8 @@ def empty_sets(sets, force=False):
             cmds.connectAttr(src, dest)
 
         # Restore original members
-        for origin_set, members in original.iteritems():
+        _iteritems = getattr(original, "iteritems", original.items)
+        for origin_set, members in _iteritems():
             cmds.sets(members, forceElement=origin_set)
 
 
@@ -669,7 +670,8 @@ def displaySmoothness(nodes,
         yield
     finally:
         # Revert state
-        for node, state in originals.iteritems():
+        _iteritems = getattr(originals, "iteritems", originals.items)
+        for node, state in _iteritems():
             if state:
                 cmds.displaySmoothness(node, **state)
 
@@ -712,7 +714,8 @@ def no_display_layers(nodes):
         yield
     finally:
         # Restore original members
-        for layer, members in original.iteritems():
+        _iteritems = getattr(original, "iteritems", original.items)
+        for layer, members in _iteritems():
             cmds.editDisplayLayerMembers(layer, members, noRecurse=True)
 
 

--- a/openpype/hosts/maya/api/setdress.py
+++ b/openpype/hosts/maya/api/setdress.py
@@ -70,7 +70,8 @@ def unlocked(nodes):
         yield
     finally:
         # Reapply original states
-        for uuid, state in states.iteritems():
+        _iteritems = getattr(states, "iteritems", states.items)
+        for uuid, state in _iteritems():
             nodes_from_id = cmds.ls(uuid, long=True)
             if nodes_from_id:
                 node = nodes_from_id[0]

--- a/openpype/hosts/maya/api/setdress.py
+++ b/openpype/hosts/maya/api/setdress.py
@@ -5,6 +5,7 @@ import os
 import contextlib
 import copy
 
+import six
 from maya import cmds
 
 from avalon import api, io
@@ -94,7 +95,7 @@ def load_package(filepath, name, namespace=None):
         # Define a unique namespace for the package
         namespace = os.path.basename(filepath).split(".")[0]
         unique_namespace(namespace)
-    assert isinstance(namespace, basestring)
+    assert isinstance(namespace, six.string_types)
 
     # Load the setdress package data
     with open(filepath, "r") as fp:

--- a/openpype/hosts/maya/plugins/publish/extract_fbx.py
+++ b/openpype/hosts/maya/plugins/publish/extract_fbx.py
@@ -183,7 +183,8 @@ class ExtractFBX(openpype.api.Extractor):
         # Apply the FBX overrides through MEL since the commands
         # only work correctly in MEL according to online
         # available discussions on the topic
-        for option, value in options.iteritems():
+        _iteritems = getattr(options, "iteritems", options.items)
+        for option, value in _iteritems():
             key = option[0].upper() + option[1:]  # uppercase first letter
 
             # Boolean must be passed as lower-case strings

--- a/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
+++ b/openpype/hosts/maya/plugins/publish/submit_maya_muster.py
@@ -383,7 +383,7 @@ class MayaSubmitMuster(pyblish.api.InstancePlugin):
                     "attributes": {
                         "environmental_variables": {
                             "value": ", ".join("{!s}={!r}".format(k, v)
-                                               for (k, v) in env.iteritems()),
+                                               for (k, v) in env.items()),
 
                             "state": True,
                             "subst": False

--- a/openpype/hosts/maya/plugins/publish/validate_instance_subset.py
+++ b/openpype/hosts/maya/plugins/publish/validate_instance_subset.py
@@ -2,6 +2,8 @@ import pyblish.api
 import openpype.api
 import string
 
+import six
+
 # Allow only characters, numbers and underscore
 allowed = set(string.ascii_lowercase +
               string.ascii_uppercase +
@@ -29,7 +31,7 @@ class ValidateSubsetName(pyblish.api.InstancePlugin):
             raise RuntimeError("Instance is missing subset "
                                "name: {0}".format(subset))
 
-        if not isinstance(subset, basestring):
+        if not isinstance(subset, six.string_types):
             raise TypeError("Instance subset name must be string, "
                             "got: {0} ({1})".format(subset, type(subset)))
 

--- a/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_ids_unique.py
@@ -52,7 +52,8 @@ class ValidateNodeIdsUnique(pyblish.api.InstancePlugin):
 
         # Take only the ids with more than one member
         invalid = list()
-        for _ids, members in ids.iteritems():
+        _iteritems = getattr(ids, "iteritems", ids.items)
+        for _ids, members in _iteritems():
             if len(members) > 1:
                 cls.log.error("ID found on multiple nodes: '%s'" % members)
                 invalid.extend(members)

--- a/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
+++ b/openpype/hosts/maya/plugins/publish/validate_node_no_ghosting.py
@@ -32,7 +32,10 @@ class ValidateNodeNoGhosting(pyblish.api.InstancePlugin):
         nodes = cmds.ls(instance, long=True, type=['transform', 'shape'])
         invalid = []
         for node in nodes:
-            for attr, required_value in cls._attributes.iteritems():
+            _iteritems = getattr(
+                cls._attributes, "iteritems", cls._attributes.items
+            )
+            for attr, required_value in _iteritems():
                 if cmds.attributeQuery(attr, node=node, exists=True):
 
                     value = cmds.getAttr('{0}.{1}'.format(node, attr))

--- a/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
+++ b/openpype/hosts/maya/plugins/publish/validate_shape_render_stats.py
@@ -33,7 +33,8 @@ class ValidateShapeRenderStats(pyblish.api.Validator):
         shapes = cmds.ls(instance, long=True, type='surfaceShape')
         invalid = []
         for shape in shapes:
-            for attr, default_value in cls.defaults.iteritems():
+            _iteritems = getattr(cls.defaults, "iteritems", cls.defaults.items)
+            for attr, default_value in _iteritems():
                 if cmds.attributeQuery(attr, node=shape, exists=True):
                     value = cmds.getAttr('{}.{}'.format(shape, attr))
                     if value != default_value:
@@ -52,7 +53,8 @@ class ValidateShapeRenderStats(pyblish.api.Validator):
     @classmethod
     def repair(cls, instance):
         for shape in cls.get_invalid(instance):
-            for attr, default_value in cls.defaults.iteritems():
+            _iteritems = getattr(cls.defaults, "iteritems", cls.defaults.items)
+            for attr, default_value in _iteritems():
 
                 if cmds.attributeQuery(attr, node=shape, exists=True):
                     plug = '{0}.{1}'.format(shape, attr)

--- a/openpype/vendor/python/common/capture.py
+++ b/openpype/vendor/python/common/capture.py
@@ -364,7 +364,8 @@ def apply_view(panel, **options):
 
     # Display options
     display_options = options.get("display_options", {})
-    for key, value in display_options.iteritems():
+    _iteritems = getattr(display_options, "iteritems", display_options.items)
+    for key, value in _iteritems():
         if key in _DisplayOptionsRGB:
             cmds.displayRGBColor(key, *value)
         else:
@@ -372,16 +373,21 @@ def apply_view(panel, **options):
 
     # Camera options
     camera_options = options.get("camera_options", {})
-    for key, value in camera_options.iteritems():
+    _iteritems = getattr(camera_options, "iteritems", camera_options.items)
+    for key, value in _iteritems:
         cmds.setAttr("{0}.{1}".format(camera, key), value)
 
     # Viewport options
     viewport_options = options.get("viewport_options", {})
-    for key, value in viewport_options.iteritems():
+    _iteritems = getattr(viewport_options, "iteritems", viewport_options.items)
+    for key, value in _iteritems():
         cmds.modelEditor(panel, edit=True, **{key: value})
 
     viewport2_options = options.get("viewport2_options", {})
-    for key, value in viewport2_options.iteritems():
+    _iteritems = getattr(
+        viewport2_options, "iteritems", viewport2_options.items
+    )
+    for key, value in _iteritems():
         attr = "hardwareRenderingGlobals.{0}".format(key)
         cmds.setAttr(attr, value)
 
@@ -629,14 +635,16 @@ def _applied_camera_options(options, panel):
                              "for capture: %s" % opt)
             options.pop(opt)
 
-    for opt, value in options.iteritems():
+    _iteritems = getattr(options, "iteritems", options.items)
+    for opt, value in _iteritems():
         cmds.setAttr(camera + "." + opt, value)
 
     try:
         yield
     finally:
         if old_options:
-            for opt, value in old_options.iteritems():
+            _iteritems = getattr(old_options, "iteritems", old_options.items)
+            for opt, value in _iteritems():
                 cmds.setAttr(camera + "." + opt, value)
 
 
@@ -722,14 +730,16 @@ def _applied_viewport2_options(options):
             options.pop(opt)
 
     # Apply settings
-    for opt, value in options.iteritems():
+    _iteritems = getattr(options, "iteritems", options.items)
+    for opt, value in _iteritems():
         cmds.setAttr("hardwareRenderingGlobals." + opt, value)
 
     try:
         yield
     finally:
         # Restore previous settings
-        for opt, value in original.iteritems():
+        _iteritems = getattr(original, "iteritems", original.items)
+        for opt, value in _iteritems():
             cmds.setAttr("hardwareRenderingGlobals." + opt, value)
 
 
@@ -769,7 +779,8 @@ def _maintain_camera(panel, camera):
     try:
         yield
     finally:
-        for camera, renderable in state.iteritems():
+        _iteritems = getattr(state, "iteritems", state.items)
+        for camera, renderable in _iteritems():
             cmds.setAttr(camera + ".rnd", renderable)
 
 


### PR DESCRIPTION
## Changes
- replaced `basestring` with `six.string_types`
- modified how `iteritems` is used to work the same way in Python 2 and 3
    - always tries to check `iteritems` attribute availability on dictiony and use `items` if is not available
    - question is if we should replace all usage with using `items()` in iteration - in Python 2 it creates copy of dictionary instead of iterating over and in Python 3 it does what `iteritems` did in Python 2
- fixed maya capture context managers (hopefully it works as expected)