### PR TITLE
FFmpeg gamma argument

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -26,11 +26,11 @@
                                 "ftrackreview"
                             ],
                             "ffmpeg_args": {
-                                "video_filters": [],
-                                "audio_filters": [],
-                                "input": [
-                                    "-gamma 2.2"
+                                "video_filters": [
+                                    "eq=gamma=2.2"
                                 ],
+                                "audio_filters": [],
+                                "input": [],
                                 "output": [
                                     "-pix_fmt yuv420p",
                                     "-crf 18",


### PR DESCRIPTION
## Issue
New ffmpeg do not allow to define `-gamma 2.2` on most of inputs (.png, .jpeg, etc.).

## Suggested solution
Found out that it is video filter configuration of an output instead of input definition. This approach was not tested properly yet. Results with this configuration should be compared to previous results and try to export both video and image sequence.

## Changes
- add gamma as video filter in ffmpeg arguments