### PR TITLE
Add task name to context pop up.

### DIFF
--- a/pype/hosts/maya/__init__.py
+++ b/pype/hosts/maya/__init__.py
@@ -226,6 +226,9 @@ def on_task_changed(*args):
         lib.set_context_settings()
         lib.update_content_on_context_change()
 
-    lib.show_message("Context was changed",
-                     ("Context was changed to {}".format(
-                        avalon.Session["AVALON_ASSET"])))
+    lib.show_message(
+        "Context was changed",
+        "Context was changed to {}/{}".format(
+            avalon.Session["AVALON_ASSET"], avalon.Session["AVALON_TASK"]
+        )
+    )


### PR DESCRIPTION
A better question might be whether this is actually needed?

This pop up is not present in any other host (as far as I know), and the only thing it does is to stop loading of the workfile and inform the user about what they have done. User cant cancel so it seems like a needless pop up.