### PR TITLE
Unreal miss default settings

### DIFF
--- a/openpype/settings/defaults/system_settings/applications.json
+++ b/openpype/settings/defaults/system_settings/applications.json
@@ -1165,6 +1165,7 @@
         },
         "variants": {
             "4-26": {
+                "use_python_2": false,
                 "executables": {
                     "windows": [],
                     "darwin": [],


### PR DESCRIPTION
## Changes
- added `use_python_2` to unreal's defaults